### PR TITLE
Fix Japanese TTS Download and UI Cleanup

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -94,8 +94,8 @@
     <string name="wake_word_custom">カスタム…</string>
     <string name="tts_engine_label">音声合成エンジン</string>
     <string name="tts_engine_system">システム標準 (Google等)</string>
-    <string name="tts_engine_embedded">OpenClaw 内蔵 (レスキューモード)</string>
+    <string name="tts_engine_embedded">OpenClaw 内蔵</string>
     <string name="model_not_installed">音声モデルが未インストールです</string>
     <string name="download_model">モデルをダウンロード (%s)</string>
-    <string name="embedded_tts_not_available">内蔵TTSは英語と中国語のみ対応。日本語はシステムTTSを使用します。</string>
+    <string name="embedded_tts_not_available">内蔵TTSは日本語、英語、中国語のみ対応しています。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,8 +94,8 @@
     <string name="wake_word_custom">Custom…</string>
     <string name="tts_engine_label">TTS Engine</string>
     <string name="tts_engine_system">System Default (Google, etc.)</string>
-    <string name="tts_engine_embedded">OpenClaw Built-in (Rescue mode)</string>
+    <string name="tts_engine_embedded">OpenClaw Built-in</string>
     <string name="model_not_installed">Voice model not installed</string>
     <string name="download_model">Download Model (%s)</string>
-    <string name="embedded_tts_not_available">Built-in TTS only supports English and Chinese. Your language uses System TTS.</string>
+    <string name="embedded_tts_not_available">Built-in TTS only supports Japanese, English, and Chinese.</string>
 </resources>


### PR DESCRIPTION
This PR fixes the Japanese model download issue and cleans up the UI strings.

### Changes
- **Reliable Download:** Switched the Japanese model source to Hugging Face to bypass missing GitHub archive files.
- **UI Refinement:** Removed the term '(Rescue mode)' from the TTS engine selection.
- **Support Update:** Updated internal strings to accurately list Japanese as a supported language for the embedded engine.