### PR TITLE
Feat: Allow cleartext traffic (HTTP)

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config>
+    <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
             <certificates src="user" />


### PR DESCRIPTION
This PR enables cleartext traffic (HTTP) support. This allows users to connect to OpenClaw instances running on local networks, VPNs, or via Tailscale without requiring HTTPS setup.

Fixes #21