### PR TITLE
🔒 Fix sensitive exception logging in OpenClawSession

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import com.openclaw.assistant.BuildConfig
 import com.openclaw.assistant.R
 import com.openclaw.assistant.data.SettingsRepository
 import com.openclaw.assistant.api.OpenClawClient
@@ -368,7 +369,11 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
                     }
                 },
                 onFailure = { error ->
-                    Log.e(TAG, "API error", error)
+                    if (BuildConfig.DEBUG) {
+                        Log.e(TAG, "API error", error)
+                    } else {
+                        Log.e(TAG, "API error: ${error.javaClass.simpleName}")
+                    }
                     currentState.value = AssistantState.ERROR
                     errorMessage.value = error.message ?: context.getString(R.string.error_network)
                 }


### PR DESCRIPTION
**What:**
Modified `app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt` to sanitize API error logging.

**Risk:**
Previously, `Log.e(TAG, "API error", error)` would log the full exception message and stack trace. If the exception originated from a network library (like OkHttp), the message could contain sensitive information such as the full request URL (potentially including tokens) or response body. This information would then be written to the device logs, accessible to anyone with physical access or apps with log reading permissions (on older Android versions) or through bug reports.

**Solution:**
Implemented a check for `BuildConfig.DEBUG`.
- In debug builds, full exception details are logged for development purposes.
- In release builds, only the exception class name is logged (e.g., "API error: IOException"), preventing sensitive data leakage while still indicating the type of error.

---
*PR created automatically by Jules for task [4682131750075013801](https://jules.google.com/task/4682131750075013801) started by @yuga-hashimoto*