### PR TITLE
🧹 Remove unused Compose imports in OpenClawSession.kt

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
@@ -31,9 +31,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import android.os.Build
 import androidx.compose.animation.core.*
-import androidx.compose.foundation.Image
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.openclaw.assistant.R
 import com.openclaw.assistant.data.SettingsRepository


### PR DESCRIPTION
**What:** Removed unused imports in `app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt`:
- `androidx.compose.foundation.Image`
- `androidx.compose.ui.graphics.Brush`
- `androidx.compose.ui.res.painterResource`

**Why:** These imports were not used in the file, leading to unnecessary clutter. Removing them improves code health.

**Verification:**
- Verified by reading the file content.
- Verified by running `./gradlew app:lintDebug` which confirmed compilation success (despite unrelated lint errors).
- Confirmed that `androidx.compose.ui.res.stringResource` is still present and used.

**Result:** Cleaner code without unused dependencies in the file.

---
*PR created automatically by Jules for task [16076543871515588450](https://jules.google.com/task/16076543871515588450) started by @yuga-hashimoto*