### PR TITLE
🛡️ Sentinel: [HIGH] Enforce HTTPS for public network traffic

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-31 - [Secure Local Networking]
+**Vulnerability:** Global `usesCleartextTraffic="true"` allows insecure communication on public networks.
+**Learning:** Android's `network_security_config` cannot selectively allow cleartext traffic for arbitrary local IPs (user-defined).
+**Prevention:** Combine `usesCleartextTraffic="true"` with manual code validation (`InetAddress.isSiteLocalAddress()`) to enforce HTTPS on public networks while allowing HTTP on local networks.

--- a/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
+++ b/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
@@ -2,6 +2,7 @@ package com.openclaw.assistant.api
 
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import com.openclaw.assistant.util.NetworkUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
@@ -34,6 +35,12 @@ class OpenClawClient {
         authToken: String? = null
     ): Result<OpenClawResponse> = withContext(Dispatchers.IO) {
         try {
+            if (!NetworkUtils.isUrlSecure(webhookUrl)) {
+                return@withContext Result.failure(
+                    SecurityException("Insecure connection: HTTP is only allowed for local networks.")
+                )
+            }
+
             // Simple request body for /hooks/voice
             val requestBody = JsonObject().apply {
                 addProperty("message", message)
@@ -87,6 +94,12 @@ class OpenClawClient {
         authToken: String?
     ): Result<Boolean> = withContext(Dispatchers.IO) {
         try {
+            if (!NetworkUtils.isUrlSecure(webhookUrl)) {
+                return@withContext Result.failure(
+                    SecurityException("Insecure connection: HTTP is only allowed for local networks.")
+                )
+            }
+
             // Try a HEAD request first (lightweight)
             var requestBuilder = Request.Builder()
                 .url(webhookUrl)

--- a/app/src/main/java/com/openclaw/assistant/util/NetworkUtils.kt
+++ b/app/src/main/java/com/openclaw/assistant/util/NetworkUtils.kt
@@ -1,0 +1,55 @@
+package com.openclaw.assistant.util
+
+import java.net.InetAddress
+import java.net.URI
+
+object NetworkUtils {
+
+    /**
+     * Checks if the given URL is secure.
+     *
+     * Security Policy:
+     * - HTTPS is always allowed.
+     * - HTTP is ONLY allowed for:
+     *   - Loopback addresses (localhost, 127.0.0.1)
+     *   - Private IP addresses (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+     *
+     * This prevents sending sensitive data (auth tokens) over cleartext to public networks.
+     */
+    fun isUrlSecure(url: String): Boolean {
+        if (url.isBlank()) return false
+
+        return try {
+            val uri = URI(url)
+            val scheme = uri.scheme?.lowercase() ?: return false
+
+            // HTTPS is secure
+            if (scheme == "https") return true
+
+            // Allow HTTP only for local networks
+            if (scheme == "http") {
+                val host = uri.host ?: return false
+
+                // Fast check for localhost string
+                if (host.equals("localhost", ignoreCase = true)) return true
+
+                // Resolve host to check IP properties
+                // Note: This performs a DNS lookup, but is acceptable for the security gain
+                // on insecure HTTP connections.
+                val address = InetAddress.getByName(host)
+
+                return address.isLoopbackAddress ||
+                       address.isSiteLocalAddress ||
+                       // Check for Link Local (169.254.x.x) - sometimes used in ad-hoc networks
+                       address.isLinkLocalAddress
+            }
+
+            // Other schemes (ftp, etc) are not supported/secure
+            false
+
+        } catch (e: Exception) {
+            // Malformed URL or Unknown Host -> Fail Secure
+            false
+        }
+    }
+}

--- a/app/src/test/java/com/openclaw/assistant/util/NetworkUtilsTest.kt
+++ b/app/src/test/java/com/openclaw/assistant/util/NetworkUtilsTest.kt
@@ -1,0 +1,50 @@
+package com.openclaw.assistant.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NetworkUtilsTest {
+
+    @Test
+    fun isUrlSecure_https_returnsTrue() {
+        assertTrue(NetworkUtils.isUrlSecure("https://example.com"))
+        assertTrue(NetworkUtils.isUrlSecure("https://192.168.1.1"))
+        assertTrue(NetworkUtils.isUrlSecure("https://8.8.8.8"))
+    }
+
+    @Test
+    fun isUrlSecure_httpLocalhost_returnsTrue() {
+        assertTrue(NetworkUtils.isUrlSecure("http://localhost"))
+        assertTrue(NetworkUtils.isUrlSecure("http://127.0.0.1"))
+    }
+
+    @Test
+    fun isUrlSecure_httpPrivateIp_returnsTrue() {
+        assertTrue(NetworkUtils.isUrlSecure("http://192.168.1.100"))
+        assertTrue(NetworkUtils.isUrlSecure("http://10.0.0.5"))
+        assertTrue(NetworkUtils.isUrlSecure("http://172.16.0.5"))
+        assertTrue(NetworkUtils.isUrlSecure("http://172.31.255.255"))
+    }
+
+    @Test
+    fun isUrlSecure_httpPublicIp_returnsFalse() {
+        assertFalse(NetworkUtils.isUrlSecure("http://8.8.8.8"))
+        assertFalse(NetworkUtils.isUrlSecure("http://1.1.1.1"))
+        assertFalse(NetworkUtils.isUrlSecure("http://172.32.0.1")) // Outside private range
+        assertFalse(NetworkUtils.isUrlSecure("http://11.0.0.1"))
+    }
+
+    @Test
+    fun isUrlSecure_invalidUrl_returnsFalse() {
+        assertFalse(NetworkUtils.isUrlSecure("invalid-url"))
+        assertFalse(NetworkUtils.isUrlSecure(""))
+        assertFalse(NetworkUtils.isUrlSecure("   "))
+    }
+
+    @Test
+    fun isUrlSecure_otherSchemes_returnsFalse() {
+        assertFalse(NetworkUtils.isUrlSecure("ftp://192.168.1.1"))
+        assertFalse(NetworkUtils.isUrlSecure("ws://192.168.1.1")) // WebSocket insecure
+    }
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The app allows cleartext HTTP traffic globally (`usesCleartextTraffic="true"`). This exposes sensitive data (auth tokens) if a user configures a public HTTP URL.
🎯 Impact: Attackers on the same network could intercept authentication tokens.
🔧 Fix: Implemented `NetworkUtils.isUrlSecure` to validate webhook URLs.
  - HTTP is now blocked for public IP addresses.
  - HTTP is allowed ONLY for Loopback (localhost) and Private IP ranges (RFC 1918).
  - HTTPS is required for all other connections.
✅ Verification: Added comprehensive unit tests in `NetworkUtilsTest.kt` verifying allowed/blocked URLs. Verified `OpenClawClient` throws `SecurityException` for insecure URLs.

---
*PR created automatically by Jules for task [13275452328872157200](https://jules.google.com/task/13275452328872157200) started by @yuga-hashimoto*