### PR TITLE
🛡️ Sentinel: Enforce HTTPS for public network connections

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - HTTPS Enforcement Gap
+**Vulnerability:** Application allowed global cleartext traffic (`usesCleartextTraffic="true"`) without enforcing HTTPS for public network connections, risking data exposure.
+**Learning:** `usesCleartextTraffic` is necessary for local development (e.g., `localhost`, `10.0.2.2`) but requires strict application-level checks to prevent insecure public connections.
+**Prevention:** Use `NetworkUtils.isUrlSecure` to validate user-provided URLs before initiating requests, ensuring HTTPS for public addresses while allowing HTTP only for local/private IPs.

--- a/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
+++ b/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
@@ -2,6 +2,7 @@ package com.openclaw.assistant.api
 
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import com.openclaw.assistant.util.NetworkUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
@@ -34,6 +35,12 @@ class OpenClawClient {
         authToken: String? = null
     ): Result<OpenClawResponse> = withContext(Dispatchers.IO) {
         try {
+            if (!NetworkUtils.isUrlSecure(webhookUrl)) {
+                return@withContext Result.failure(
+                    SecurityException("Insecure connection not allowed. Use HTTPS or a local IP.")
+                )
+            }
+
             // Simple request body for /hooks/voice
             val requestBody = JsonObject().apply {
                 addProperty("message", message)
@@ -87,6 +94,12 @@ class OpenClawClient {
         authToken: String?
     ): Result<Boolean> = withContext(Dispatchers.IO) {
         try {
+            if (!NetworkUtils.isUrlSecure(webhookUrl)) {
+                return@withContext Result.failure(
+                    SecurityException("Insecure connection not allowed. Use HTTPS or a local IP.")
+                )
+            }
+
             // Try a HEAD request first (lightweight)
             var requestBuilder = Request.Builder()
                 .url(webhookUrl)

--- a/app/src/main/java/com/openclaw/assistant/util/NetworkUtils.kt
+++ b/app/src/main/java/com/openclaw/assistant/util/NetworkUtils.kt
@@ -1,0 +1,53 @@
+package com.openclaw.assistant.util
+
+import java.net.URI
+
+object NetworkUtils {
+    /**
+     * Checks if the URL is secure (HTTPS) or a local/private address.
+     * Enforces HTTPS for public networks.
+     */
+    fun isUrlSecure(url: String): Boolean {
+        return try {
+            val uri = URI(url)
+            val scheme = uri.scheme?.lowercase() ?: return false
+
+            if (scheme == "https") {
+                return true
+            }
+
+            if (scheme == "http") {
+                val host = uri.host ?: return false
+
+                // Localhost
+                if (host.equals("localhost", ignoreCase = true)) return true
+
+                // Check if it's an IP address
+                if (host.matches(Regex("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"))) {
+                    val parts = host.split(".")
+                    if (parts.size != 4) return false
+
+                    val b1 = parts[0].toIntOrNull() ?: return false
+                    val b2 = parts[1].toIntOrNull() ?: return false
+                    // b3 and b4 don't need checking for range here as we just check prefix
+
+                    // 127.x.x.x (Loopback)
+                    if (b1 == 127) return true
+
+                    // 10.x.x.x (Private Class A)
+                    if (b1 == 10) return true
+
+                    // 192.168.x.x (Private Class C)
+                    if (b1 == 192 && b2 == 168) return true
+
+                    // 172.16.x.x - 172.31.x.x (Private Class B)
+                    if (b1 == 172 && b2 in 16..31) return true
+                }
+            }
+
+            false
+        } catch (e: Exception) {
+            false
+        }
+    }
+}

--- a/app/src/test/java/com/openclaw/assistant/util/NetworkUtilsTest.kt
+++ b/app/src/test/java/com/openclaw/assistant/util/NetworkUtilsTest.kt
@@ -1,0 +1,70 @@
+package com.openclaw.assistant.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NetworkUtilsTest {
+
+    @Test
+    fun isUrlSecure_https_returnsTrue() {
+        assertTrue(NetworkUtils.isUrlSecure("https://example.com"))
+        assertTrue(NetworkUtils.isUrlSecure("https://1.1.1.1"))
+    }
+
+    @Test
+    fun isUrlSecure_httpPublic_returnsFalse() {
+        assertFalse(NetworkUtils.isUrlSecure("http://example.com"))
+        assertFalse(NetworkUtils.isUrlSecure("http://8.8.8.8"))
+    }
+
+    @Test
+    fun isUrlSecure_localhost_returnsTrue() {
+        assertTrue(NetworkUtils.isUrlSecure("http://localhost"))
+        assertTrue(NetworkUtils.isUrlSecure("http://localhost:8080"))
+    }
+
+    @Test
+    fun isUrlSecure_loopbackIp_returnsTrue() {
+        assertTrue(NetworkUtils.isUrlSecure("http://127.0.0.1"))
+        assertTrue(NetworkUtils.isUrlSecure("http://127.0.0.1:3000"))
+    }
+
+    @Test
+    fun isUrlSecure_emulatorIp_returnsTrue() {
+        assertTrue(NetworkUtils.isUrlSecure("http://10.0.2.2"))
+        assertTrue(NetworkUtils.isUrlSecure("http://10.0.2.2:5000"))
+    }
+
+    @Test
+    fun isUrlSecure_privateIpClassA_returnsTrue() {
+        assertTrue(NetworkUtils.isUrlSecure("http://10.0.0.1"))
+        assertTrue(NetworkUtils.isUrlSecure("http://10.255.255.255"))
+    }
+
+    @Test
+    fun isUrlSecure_privateIpClassB_returnsTrue() {
+        assertTrue(NetworkUtils.isUrlSecure("http://172.16.0.1"))
+        assertTrue(NetworkUtils.isUrlSecure("http://172.31.255.255"))
+    }
+
+    @Test
+    fun isUrlSecure_privateIpClassB_outOfRange_returnsFalse() {
+        assertFalse(NetworkUtils.isUrlSecure("http://172.15.0.1")) // Public
+        assertFalse(NetworkUtils.isUrlSecure("http://172.32.0.1")) // Public
+    }
+
+    @Test
+    fun isUrlSecure_privateIpClassC_returnsTrue() {
+        assertTrue(NetworkUtils.isUrlSecure("http://192.168.0.1"))
+        assertTrue(NetworkUtils.isUrlSecure("http://192.168.1.1"))
+        assertTrue(NetworkUtils.isUrlSecure("http://192.168.255.255"))
+    }
+
+    @Test
+    fun isUrlSecure_invalidUrl_returnsFalse() {
+        assertFalse(NetworkUtils.isUrlSecure("not a url"))
+        assertFalse(NetworkUtils.isUrlSecure("ftp://example.com"))
+        assertFalse(NetworkUtils.isUrlSecure(""))
+    }
+}


### PR DESCRIPTION
This PR introduces a security enhancement to enforce HTTPS for all public network connections. The application was previously configured to allow cleartext traffic globally via `usesCleartextTraffic="true"` to support local development. However, this configuration exposed users to potential data interception if they configured an HTTP URL for a public server.

Changes:
1.  **NetworkUtils:** Created a utility class `NetworkUtils` with `isUrlSecure` method. This method returns `true` for HTTPS URLs and HTTP URLs that point to local or private IP addresses (e.g., localhost, 10.0.2.2, 192.168.x.x). It returns `false` for public HTTP URLs.
2.  **OpenClawClient:** Updated `sendMessage` and `testConnection` methods in `OpenClawClient` to call `NetworkUtils.isUrlSecure` before making any network request. If the check fails, a `SecurityException` is thrown, preventing the insecure connection.
3.  **Tests:** Added `NetworkUtilsTest` with unit tests covering various scenarios including valid HTTPS, invalid HTTP public, valid HTTP local/private, and malformed URLs.
4.  **Documentation:** Added an entry to `.jules/sentinel.md` documenting the vulnerability and the fix.

This change ensures that sensitive data (like auth tokens and voice messages) is transmitted securely over public networks while maintaining the ability to connect to local servers for development and testing.

---
*PR created automatically by Jules for task [10237807309249265752](https://jules.google.com/task/10237807309249265752) started by @yuga-hashimoto*