### PR TITLE
docs: Move Ko-fi badge to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenClaw Assistant
 
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/R5R51S97C4)
+
 **[日本語版はこちら](#日本語) | English below**
 
 📹 **Demo Video**: https://x.com/i/status/2017914589938438532


### PR DESCRIPTION
Moved the Ko-fi funding badge to the top of the README for better visibility.