### PR TITLE
⚡ Bolt: Optimize Vosk Model Loading in HotwordService

### DIFF
--- a/app/src/test/java/com/openclaw/assistant/service/HotwordServiceTest.kt
+++ b/app/src/test/java/com/openclaw/assistant/service/HotwordServiceTest.kt
@@ -1,0 +1,76 @@
+package com.openclaw.assistant.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HotwordServiceTest {
+
+    @Test
+    fun shouldCopyModel_returnsFalse_whenVersionsMatchAndDirValid() {
+        val currentVersion = 10
+        val savedVersion = 10
+        val targetDirExists = true
+        val targetDirNotEmpty = true
+
+        val result = HotwordService.shouldCopyModel(
+            currentVersion,
+            savedVersion,
+            targetDirExists,
+            targetDirNotEmpty
+        )
+
+        assertFalse("Should NOT copy when versions match and dir is valid", result)
+    }
+
+    @Test
+    fun shouldCopyModel_returnsTrue_whenVersionsMismatch() {
+        val currentVersion = 11
+        val savedVersion = 10
+        val targetDirExists = true
+        val targetDirNotEmpty = true
+
+        val result = HotwordService.shouldCopyModel(
+            currentVersion,
+            savedVersion,
+            targetDirExists,
+            targetDirNotEmpty
+        )
+
+        assertTrue("Should copy when versions mismatch", result)
+    }
+
+    @Test
+    fun shouldCopyModel_returnsTrue_whenDirMissing() {
+        val currentVersion = 10
+        val savedVersion = 10
+        val targetDirExists = false
+        val targetDirNotEmpty = false // irrelevant if exists is false, but usually empty
+
+        val result = HotwordService.shouldCopyModel(
+            currentVersion,
+            savedVersion,
+            targetDirExists,
+            targetDirNotEmpty
+        )
+
+        assertTrue("Should copy when target dir is missing", result)
+    }
+
+    @Test
+    fun shouldCopyModel_returnsTrue_whenDirEmpty() {
+        val currentVersion = 10
+        val savedVersion = 10
+        val targetDirExists = true
+        val targetDirNotEmpty = false
+
+        val result = HotwordService.shouldCopyModel(
+            currentVersion,
+            savedVersion,
+            targetDirExists,
+            targetDirNotEmpty
+        )
+
+        assertTrue("Should copy when target dir is empty", result)
+    }
+}


### PR DESCRIPTION
💡 What:
Implemented a version-based cache check in `HotwordService.kt` to avoid redundant copying of the Vosk speech recognition model (50MB+) on every service startup.

🎯 Why:
The original implementation unconditionally copied the model from assets to internal storage every time the service started. This caused significant I/O overhead, delayed the hotword detection readiness, and consumed unnecessary CPU/Battery.

📊 Impact:
- Reduces service startup time by eliminating ~50MB file copy on subsequent launches.
- Reduces disk I/O significantly.

🔬 Measurement:
- Verified logic with new unit tests in `HotwordServiceTest.kt` covering version match/mismatch scenarios.
- `shouldCopyModel` returns false only when versions match and the directory is populated.

---
*PR created automatically by Jules for task [10437859347076448811](https://jules.google.com/task/10437859347076448811) started by @yuga-hashimoto*