### PR TITLE
Improve mic permission handling and release config

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -69,7 +69,7 @@ jobs:
           files: |
             app/build/outputs/apk/release/OpenClawAssistant-${{ github.ref_name }}.apk
             app/build/outputs/bundle/release/OpenClawAssistant-${{ github.ref_name }}.aab
-          draft: true
+          draft: false
           prerelease: false
 
       - name: Upload Artifacts (Non-tag push)

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -111,6 +111,11 @@
     <string name="connection_status_disconnected">未接続</string>
     <string name="connection_status_reconnecting">再接続中…</string>
 
+    <!-- Permission handling -->
+    <string name="mic_permission_denied_permanently">マイクの権限が永久に拒否されています。ウェイクワード検知を使用するには、アプリの設定から権限を有効にしてください。</string>
+    <string name="open_settings">設定を開く</string>
+    <string name="cancel">キャンセル</string>
+
     <!-- Chat UI -->
     <string name="conversations_title">会話</string>
     <string name="new_chat">新規チャット</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,6 +135,11 @@
     <string name="connection_status_disconnected">Disconnected</string>
     <string name="connection_status_reconnecting">Reconnecting…</string>
 
+    <!-- Permission handling -->
+    <string name="mic_permission_denied_permanently">Microphone permission has been permanently denied. Please enable it in app settings to use wake word detection.</string>
+    <string name="open_settings">Open Settings</string>
+    <string name="cancel">Cancel</string>
+
     <!-- Chat UI -->
     <string name="conversations_title">Conversations</string>
     <string name="new_chat">New Chat</string>


### PR DESCRIPTION
## Summary

- Migrate mic permission handling to `ActivityResultContracts` (replacing deprecated `requestPermissions`) and show a settings dialog when permission is permanently denied
- Fix hotword toggle to properly await permission result before starting the service
- Explicitly select a real speech recognition service in `SpeechRecognizerManager`, skipping the app's own stub `RecognitionService`
- Change release workflow from `draft: true` to `draft: false` so releases are published directly on tag push

## Test plan

- [ ] Launch the app without mic permission and verify the permission request appears
- [ ] Deny permission with "Don't ask again" and verify the settings dialog is shown
- [ ] Toggle hotword ON, confirm permission is requested and the service starts after granting
- [ ] Verify speech recognition uses an external service (e.g. Google) instead of the app's own stub
- [ ] Push a tag and verify the release is published directly (not as a draft)

🤖 Generated with [Claude Code](https://claude.com/claude-code)