### PR TITLE
Make voice input silence timeout configurable with a better range

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -71,7 +71,7 @@ fun SettingsScreen(
     var continuousMode by remember { mutableStateOf(settings.continuousMode) }
     var wakeWordPreset by remember { mutableStateOf(settings.wakeWordPreset) }
     var customWakeWord by remember { mutableStateOf(settings.customWakeWord) }
-    var speechSilenceTimeout by remember { mutableStateOf(settings.speechSilenceTimeout.toFloat().coerceIn(5000f, 30000f)) }
+    var speechSilenceTimeout by remember { mutableStateOf(settings.speechSilenceTimeout.toFloat().coerceIn(500f, 10000f)) }
     var speechLanguage by remember { mutableStateOf(settings.speechLanguage) }
     var thinkingSoundEnabled by remember { mutableStateOf(settings.thinkingSoundEnabled) }
 
@@ -731,8 +731,8 @@ fun SettingsScreen(
                     Slider(
                         value = speechSilenceTimeout,
                         onValueChange = { speechSilenceTimeout = it },
-                        valueRange = 5000f..30000f,
-                        steps = 4,
+                        valueRange = 500f..10000f,
+                        steps = 18,
                         modifier = Modifier.fillMaxWidth()
                     )
                 }

--- a/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
@@ -116,9 +116,9 @@ class SettingsRepository(context: Context) {
         get() = prefs.getInt(KEY_GATEWAY_PORT, 18789)
         set(value) = prefs.edit().putInt(KEY_GATEWAY_PORT, value).apply()
 
-    // Speech recognition silence timeout in ms (default 5000ms)
+    // Speech recognition silence timeout in ms (default 2000ms)
     var speechSilenceTimeout: Long
-        get() = prefs.getLong(KEY_SPEECH_SILENCE_TIMEOUT, 5000L)
+        get() = prefs.getLong(KEY_SPEECH_SILENCE_TIMEOUT, 2000L)
         set(value) = prefs.edit().putLong(KEY_SPEECH_SILENCE_TIMEOUT, value).apply()
 
     // Speech recognition language (BCP-47 tag, empty = system default)

--- a/app/src/main/java/com/openclaw/assistant/speech/SpeechRecognizerManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/SpeechRecognizerManager.kt
@@ -36,7 +36,7 @@ class SpeechRecognizerManager(private val context: Context) {
      * 音声認識を開始し、結果をFlowで返す
      * language が null の場合はシステムデフォルトを使用する
      */
-    fun startListening(language: String? = null, silenceTimeoutMs: Long = 2500L): Flow<SpeechResult> = callbackFlow {
+    fun startListening(language: String? = null, silenceTimeoutMs: Long = 2000L): Flow<SpeechResult> = callbackFlow {
         // デフォルト言語の決定
         val targetLanguage = language ?: Locale.getDefault().toLanguageTag()
         


### PR DESCRIPTION
The voice input silence timeout (the time from when the user stops speaking to when the assistant stops listening) was previously restricted to a range of 5s to 30s, which is too long for most conversational use cases. 

This change:
1. Updates the default timeout to a more standard 2s (2000ms).
2. Expands the settings range to 0.5s - 10s.
3. Improves the settings slider granularity to 0.5s increments.
4. Synchronizes default values across the repository and the speech manager.

Fixes #68

---
*PR created automatically by Jules for task [17050956691411525903](https://jules.google.com/task/17050956691411525903) started by @yuga-hashimoto*