### PR TITLE
Make voice input silence timeout configurable with a better range

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -71,7 +71,7 @@ fun SettingsScreen(
     var continuousMode by remember { mutableStateOf(settings.continuousMode) }
     var wakeWordPreset by remember { mutableStateOf(settings.wakeWordPreset) }
     var customWakeWord by remember { mutableStateOf(settings.customWakeWord) }
-    var speechSilenceTimeout by remember { mutableStateOf(settings.speechSilenceTimeout.toFloat().coerceIn(5000f, 30000f)) }
+    var speechSilenceTimeout by remember { mutableStateOf(settings.speechSilenceTimeout.toFloat().coerceIn(500f, 10000f)) }
     var speechLanguage by remember { mutableStateOf(settings.speechLanguage) }
     var thinkingSoundEnabled by remember { mutableStateOf(settings.thinkingSoundEnabled) }
 
@@ -731,8 +731,8 @@ fun SettingsScreen(
                     Slider(
                         value = speechSilenceTimeout,
                         onValueChange = { speechSilenceTimeout = it },
-                        valueRange = 5000f..30000f,
-                        steps = 4,
+                        valueRange = 500f..10000f,
+                        steps = 18,
                         modifier = Modifier.fillMaxWidth()
                     )
                 }

--- a/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
@@ -116,9 +116,9 @@ class SettingsRepository(context: Context) {
         get() = prefs.getInt(KEY_GATEWAY_PORT, 18789)
         set(value) = prefs.edit().putInt(KEY_GATEWAY_PORT, value).apply()
 
-    // Speech recognition silence timeout in ms (default 5000ms)
+    // Speech recognition silence timeout in ms (default 2000ms)
     var speechSilenceTimeout: Long
-        get() = prefs.getLong(KEY_SPEECH_SILENCE_TIMEOUT, 5000L)
+        get() = prefs.getLong(KEY_SPEECH_SILENCE_TIMEOUT, 2000L)
         set(value) = prefs.edit().putLong(KEY_SPEECH_SILENCE_TIMEOUT, value).apply()
 
     // Speech recognition language (BCP-47 tag, empty = system default)


### PR DESCRIPTION
The voice input silence timeout was previously fixed to a minimum of 5 seconds, which could feel unresponsive to users. This PR updates the settings to allow a range from 500ms to 10s, with 500ms increments, and sets a more sensible default of 2s.

Changes:
1.  **SettingsRepository.kt**: Changed default `speechSilenceTimeout` from 5000L to 2000L.
2.  **SettingsActivity.kt**:
    -   Changed initial state `coerceIn` range to `500f..10000f`.
    -   Updated `Slider` with `valueRange = 500f..10000f` and `steps = 18` (500ms increments).
3.  Verified that `speechSilenceTimeout` is correctly used in `SpeechRecognizerManager.kt` via `RecognizerIntent` extras.

Fixes #68

---
*PR created automatically by Jules for task [4565143221579176376](https://jules.google.com/task/4565143221579176376) started by @yuga-hashimoto*