### PR TITLE
Support full Gateway WebSocket URL (path-aware)

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -302,24 +302,15 @@ fun MainScreen(
     // Auto-connect WS on launch for agent list and pairing detection
     LaunchedEffect(Unit) {
         if (settings.isConfigured()) {
-             val baseUrl = settings.getBaseUrl()
-             if (baseUrl.isNotBlank()) {
-                 try {
-                     val url = java.net.URL(baseUrl)
-                     val host = url.host
-                     val useTls = url.protocol == "https"
-                     val port = if (useTls) {
-                         if (url.port > 0) url.port else 443
-                     } else {
-                         if (settings.gatewayPort > 0) settings.gatewayPort else
-                             if (url.port > 0) url.port else 18789
-                     }
-                     val token = settings.authToken.takeIf { it.isNotBlank() }
-                     gatewayClient.connect(host, port, token, useTls = useTls)
-                 } catch (e: Exception) {
-                     // Ignore parse errors here
-                 }
-             }
+            try {
+                val wsUrl = settings.getEffectiveGatewayUrl()
+                if (wsUrl.isNotBlank()) {
+                    val token = settings.authToken.takeIf { it.isNotBlank() }
+                    gatewayClient.connect(wsUrl, token)
+                }
+            } catch (e: Exception) {
+                // Ignore errors here
+            }
         }
     }
 

--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
@@ -154,28 +154,16 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun connectGatewayIfNeeded() {
-        val baseUrl = settings.getBaseUrl()
-        if (baseUrl.isBlank()) return
-
         try {
-            val url = java.net.URL(baseUrl)
-            val host = url.host
-            val useTls = url.protocol == "https"
+            val wsUrl = settings.getEffectiveGatewayUrl()
+            if (wsUrl.isBlank()) return
 
-            // For tunneled connections (HTTPS, e.g. ngrok), use the URL's port (443 default).
-            // For direct LAN connections (HTTP), use gatewayPort setting or URL port.
-            val port = if (useTls) {
-                if (url.port > 0) url.port else 443
-            } else {
-                if (settings.gatewayPort > 0) settings.gatewayPort else
-                    if (url.port > 0) url.port else 18789
-            }
             val token = settings.authToken.takeIf { it.isNotBlank() }
 
-            Log.d(TAG, "Connecting gateway: $host:$port, tls=$useTls")
-            gatewayClient.connect(host, port, token, useTls = useTls)
+            Log.d(TAG, "Connecting gateway: $wsUrl")
+            gatewayClient.connect(wsUrl, token)
         } catch (e: Exception) {
-            Log.w(TAG, "Failed to parse webhook URL for WS: ${e.message}")
+            Log.w(TAG, "Failed to connect to gateway: ${e.message}")
         }
     }
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -11,6 +11,9 @@
     <string name="settings_title">設定</string>
     <string name="webhook_url_label">サーバーURL</string>
     <string name="webhook_url_hint">https://your-server</string>
+    <string name="gateway_websocket_url_label">ゲートウェイWebSocket URL（任意）</string>
+    <string name="gateway_websocket_url_hint">wss://your-server/ws</string>
+    <string name="gateway_websocket_url_desc">自動生成されたURLを上書きします。リバースプロキシ等でパスが必要な場合に使用します。</string>
     <string name="auth_token_label">認証トークン（任意）</string>
     <string name="auth_token_hint">任意</string>
     <string name="session_id_label">セッションID</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,9 @@
     <string name="settings_title">Settings</string>
     <string name="webhook_url_label">Server URL</string>
     <string name="webhook_url_hint">https://your-server</string>
+    <string name="gateway_websocket_url_label">Gateway WebSocket URL (optional)</string>
+    <string name="gateway_websocket_url_hint">wss://your-server/ws</string>
+    <string name="gateway_websocket_url_desc">Overrides derived URL. Supports full path for reverse proxies.</string>
     <string name="auth_token_label">Auth Token (optional)</string>
     <string name="auth_token_hint">Optional</string>
     <string name="session_id_label">Session ID</string>


### PR DESCRIPTION
This PR adds support for full WebSocket URLs in the Gateway connection. Previously, the app only supported host and port, dropping any path information. Now, users can specify a full URL like `wss://example.com/ws/gateway`, which is correctly handled by the updated `GatewayClient`. The app still maintains backward compatibility by automatically deriving a WebSocket URL from the base Webhook URL if the explicit WebSocket URL is not provided.

Fixes #82

---
*PR created automatically by Jules for task [4428516321245431321](https://jules.google.com/task/4428516321245431321) started by @yuga-hashimoto*