### PR TITLE
Support TLS fingerprint pinning for self-signed WSS endpoints

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
@@ -38,6 +38,16 @@ class SettingsRepository(context: Context) {
         get() = prefs.getString(KEY_AUTH_TOKEN, "") ?: ""
         set(value) = prefs.edit().putString(KEY_AUTH_TOKEN, value).apply()
 
+    // TLS Fingerprint (optional, for self-signed certs)
+    var tlsFingerprint: String
+        get() = prefs.getString(KEY_TLS_FINGERPRINT, "") ?: ""
+        set(value) {
+            if (value != tlsFingerprint) {
+                prefs.edit().putString(KEY_TLS_FINGERPRINT, value).apply()
+                isVerified = false
+            }
+        }
+
     // Session ID (auto-generated)
     var sessionId: String
         get() {
@@ -181,6 +191,7 @@ class SettingsRepository(context: Context) {
         private const val PREFS_NAME = "openclaw_secure_prefs"
         private const val KEY_WEBHOOK_URL = "webhook_url"
         private const val KEY_AUTH_TOKEN = "auth_token"
+        private const val KEY_TLS_FINGERPRINT = "tls_fingerprint"
         private const val KEY_SESSION_ID = "session_id"
         private const val KEY_HOTWORD_ENABLED = "hotword_enabled"
         private const val KEY_WAKE_WORD_PRESET = "wake_word_preset"

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
@@ -403,7 +403,8 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
             message = message,
             sessionId = settings.sessionId,
             authToken = settings.authToken.takeIf { it.isNotBlank() },
-            agentId = agentId
+            agentId = agentId,
+            tlsFingerprint = settings.tlsFingerprint.takeIf { it.isNotBlank() }
         )
 
         result.fold(

--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
@@ -173,7 +173,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
             val token = settings.authToken.takeIf { it.isNotBlank() }
 
             Log.d(TAG, "Connecting gateway: $host:$port, tls=$useTls")
-            gatewayClient.connect(host, port, token, useTls = useTls)
+            gatewayClient.connect(host, port, token, useTls = useTls, tlsFingerprint = settings.tlsFingerprint.takeIf { it.isNotBlank() })
         } catch (e: Exception) {
             Log.w(TAG, "Failed to parse webhook URL for WS: ${e.message}")
         }
@@ -270,7 +270,8 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
             message = text,
             sessionId = sessionId,
             authToken = settings.authToken.takeIf { it.isNotBlank() },
-            agentId = getEffectiveAgentId()
+            agentId = getEffectiveAgentId(),
+            tlsFingerprint = settings.tlsFingerprint.takeIf { it.isNotBlank() }
         )
 
         result.fold(

--- a/app/src/main/java/com/openclaw/assistant/utils/SslUtils.kt
+++ b/app/src/main/java/com/openclaw/assistant/utils/SslUtils.kt
@@ -1,0 +1,79 @@
+package com.openclaw.assistant.utils
+
+import android.util.Log
+import okhttp3.OkHttpClient
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+
+/**
+ * Utility for TLS certificate fingerprint pinning.
+ */
+object SslUtils {
+    private const val TAG = "SslUtils"
+
+    /**
+     * Compute SHA-256 fingerprint of a certificate.
+     * Returns lowercase hex string without colons.
+     */
+    fun computeSha256Fingerprint(cert: X509Certificate): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hash = digest.digest(cert.encoded)
+        return hash.joinToString("") { "%02x".format(it) }
+    }
+
+    /**
+     * Normalize fingerprint string (remove colons, lowercase).
+     */
+    fun normalizeFingerprint(fingerprint: String): String {
+        return fingerprint.replace(":", "").lowercase().trim()
+    }
+
+    /**
+     * Create a pinned OkHttpClient based on an existing one.
+     */
+    fun createPinnedClient(baseClient: OkHttpClient, fingerprint: String): OkHttpClient {
+        val trustManager = FingerprintTrustManager(fingerprint)
+        val sslContext = SSLContext.getInstance("TLS")
+        sslContext.init(null, arrayOf(trustManager), SecureRandom())
+
+        return baseClient.newBuilder()
+            .sslSocketFactory(sslContext.socketFactory, trustManager)
+            .hostnameVerifier { _, _ -> true } // Trust the fingerprint regardless of hostname
+            .build()
+    }
+
+    /**
+     * Custom TrustManager that validates the server certificate against a specific SHA-256 fingerprint.
+     */
+    class FingerprintTrustManager(private val expectedFingerprint: String) : X509TrustManager {
+        private val normalizedExpected = normalizeFingerprint(expectedFingerprint)
+
+        override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+            // No-op for client auth
+        }
+
+        override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+            if (chain.isNullOrEmpty()) {
+                throw CertificateException("Empty certificate chain")
+            }
+
+            val serverCert = chain[0]
+            val actualFingerprint = computeSha256Fingerprint(serverCert)
+
+            if (actualFingerprint != normalizedExpected) {
+                Log.e(TAG, "Fingerprint mismatch! Expected: $normalizedExpected, Got: $actualFingerprint")
+                throw CertificateException("Fingerprint mismatch")
+            }
+
+            Log.d(TAG, "Fingerprint matched: $actualFingerprint")
+        }
+
+        override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
+    }
+}

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -99,6 +99,13 @@
     <string name="connected">接続成功！</string>
     <string name="failed">失敗: %s</string>
     <string name="error">エラー: %s</string>
+    <string name="tls_fingerprint_label">TLSフィンガープリント (SHA-256)</string>
+    <string name="tls_fingerprint_hint">任意（自己署名証明書用）</string>
+    <string name="tls_fingerprint_help">形式: aa:bb:cc… または aabbcc…</string>
+    <string name="paste_from_clipboard">クリップボードから貼り付け</string>
+    <string name="error_tls_failed">TLSハンドシェイクに失敗しました</string>
+    <string name="error_tls_cert_mismatch">証明書のフィンガープリントが一致しません</string>
+    <string name="error_tls_self_signed_hint">自己署名証明書が検出されました。設定からTLSフィンガープリントを設定してください。</string>
     
     <!-- Wake Word Presets -->
     <string name="wake_word_openclaw">OpenClaw</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,6 +123,13 @@
     <string name="connected">Connected!</string>
     <string name="failed">Failed: %s</string>
     <string name="error">Error: %s</string>
+    <string name="tls_fingerprint_label">TLS Fingerprint (SHA-256)</string>
+    <string name="tls_fingerprint_hint">Optional (for self-signed certs)</string>
+    <string name="tls_fingerprint_help">Format: aa:bb:cc… or aabbcc…</string>
+    <string name="paste_from_clipboard">Paste from clipboard</string>
+    <string name="error_tls_failed">TLS handshake failed</string>
+    <string name="error_tls_cert_mismatch">Certificate fingerprint mismatch</string>
+    <string name="error_tls_self_signed_hint">Self-signed certificate detected. Try setting the TLS Fingerprint in Settings.</string>
     
     <!-- Wake Word Presets -->
     <string name="wake_word_openclaw">OpenClaw</string>


### PR DESCRIPTION
This change adds first-class support for self-signed TLS certificates in the Android app. Users can now provide a SHA-256 fingerprint in the connection settings. When provided, the app will strictly verify the server certificate against this fingerprint, allowing secure connections to home servers, tailnets, or other deployments with self-signed certs without requiring a public CA.

Key changes:
- Created a utility class `SslUtils` that implements a custom `X509TrustManager` for fingerprint verification.
- Updated `SettingsRepository` to securely persist the fingerprint.
- Enhanced the Connection section in `SettingsActivity` with a new field and "Paste from clipboard" functionality.
- Modified `OpenClawClient` (REST) and `GatewayClient` (WebSocket) to dynamically create a pinned `OkHttpClient` when a fingerprint is configured.
- Added specific error messages for TLS handshake failures and fingerprint mismatches to improve user troubleshooting.

Fixes #79

---
*PR created automatically by Jules for task [7273809230227871026](https://jules.google.com/task/7273809230227871026) started by @yuga-hashimoto*