### PR TITLE
Add inline buttons for executive approval requests

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -428,7 +428,10 @@ fun ChatScreen(
                                 DateHeader(item.dateText)
                             }
                             is ChatListItem.MessageItem -> {
-                                MessageBubble(message = item.message)
+                                MessageBubble(
+                                    message = item.message,
+                                    onAction = { onSendMessage(it) }
+                                )
                             }
                         }
                     }
@@ -472,7 +475,7 @@ fun DateHeader(dateText: String) {
 }
 
 @Composable
-fun MessageBubble(message: ChatMessage) {
+fun MessageBubble(message: ChatMessage, onAction: (String) -> Unit) {
     val isUser = message.isUser
     val alignment = if (isUser) Alignment.CenterEnd else Alignment.CenterStart
     val containerColor = if (isUser) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface
@@ -513,6 +516,52 @@ fun MessageBubble(message: ChatMessage) {
                                 markdown = message.text,
                                 color = contentColor
                             )
+
+                            // Check for approval commands
+                            val approvalRegex = remember(message.text) {
+                                Regex("""/(approve|allow-once|allow-always|deny)\b(?:\s+([a-zA-Z0-9]+)\b)?""")
+                            }
+                            val matches = remember(message.text) {
+                                approvalRegex.findAll(message.text).toList()
+                            }
+
+                            if (matches.isNotEmpty()) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    matches.forEach { match ->
+                                        val command = match.value
+                                        val type = match.groupValues[1]
+                                        val label = when (type) {
+                                            "approve" -> stringResource(R.string.action_approve)
+                                            "allow-once" -> stringResource(R.string.action_allow_once)
+                                            "allow-always" -> stringResource(R.string.action_allow_always)
+                                            "deny" -> stringResource(R.string.action_deny)
+                                            else -> type.replaceFirstChar { it.uppercase() }
+                                        }
+
+                                        if (type == "deny") {
+                                            OutlinedButton(
+                                                onClick = { onAction(command) },
+                                                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+                                                modifier = Modifier.height(32.dp)
+                                            ) {
+                                                Text(label, fontSize = 12.sp)
+                                            }
+                                        } else {
+                                            Button(
+                                                onClick = { onAction(command) },
+                                                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+                                                modifier = Modifier.height(32.dp)
+                                            ) {
+                                                Text(label, fontSize = 12.sp)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -167,4 +167,10 @@
     <string name="support_section">サポート</string>
     <string name="report_issue">問題を報告</string>
     <string name="report_issue_desc">バグの報告や機能のリクエストはこちらから（GitHub）</string>
+
+    <!-- Approval Actions -->
+    <string name="action_approve">承認</string>
+    <string name="action_deny">拒否</string>
+    <string name="action_allow_once">1回許可</string>
+    <string name="action_allow_always">常に許可</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,4 +199,10 @@
     <string name="support_section">Support</string>
     <string name="report_issue">Report Issue</string>
     <string name="report_issue_desc">Found a bug or have a feature request? Let us know on GitHub.</string>
+
+    <!-- Approval Actions -->
+    <string name="action_approve">Approve</string>
+    <string name="action_deny">Deny</string>
+    <string name="action_allow_once">Allow Once</string>
+    <string name="action_allow_always">Allow Always</string>
 </resources>


### PR DESCRIPTION
This change adds support for inline action buttons in the chat interface when the assistant requests an executive approval. 

Instead of manually copying and pasting commands like `/approve <hash>`, users can now simply tap a button within the chat bubble.

Key changes:
- `MessageBubble` now scans its content for patterns like `/approve`, `/deny`, `/allow-once`, and `/allow-always`.
- If matches are found, corresponding buttons are displayed below the message text.
- Tapping a button sends the exact command back to the assistant.
- Added string resources for "Approve", "Deny", "Allow Once", and "Allow Always" in both English and Japanese.
- The "Deny" button uses an Outlined style for visual distinction.

Fixes #77

---
*PR created automatically by Jules for task [17488641412119851001](https://jules.google.com/task/17488641412119851001) started by @yuga-hashimoto*