### PR TITLE
Gateway health indicator and send gating

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -157,6 +157,14 @@
     <!-- Agent -->
     <string name="agent_default">デフォルト</string>
 
+    <!-- Gateway Status -->
+    <string name="gateway_connected">接続済み</string>
+    <string name="gateway_connecting">接続中…</string>
+    <string name="gateway_reconnecting">再接続中…</string>
+    <string name="gateway_disconnected">切断済み</string>
+    <string name="gateway_error">ゲートウェイエラー</string>
+    <string name="retry">再試行</string>
+
     <!-- Pairing -->
     <string name="pairing_required_title">デバイスのペアリングが必要です</string>
     <string name="pairing_required_desc">このデバイスはまだサーバーで承認されていません。サーバーで以下のコマンドを実行して承認してください：</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,14 @@
     <string name="agent_selector">Agent</string>
     <string name="agent_default">Default</string>
 
+    <!-- Gateway Status -->
+    <string name="gateway_connected">Connected</string>
+    <string name="gateway_connecting">Connecting…</string>
+    <string name="gateway_reconnecting">Reconnecting…</string>
+    <string name="gateway_disconnected">Disconnected</string>
+    <string name="gateway_error">Gateway Error</string>
+    <string name="retry">Retry</string>
+
     <!-- Session Foreground Service -->
     <string name="notification_session_channel_name">Voice Session</string>
     <string name="notification_session_title">Conversation in progress</string>


### PR DESCRIPTION
This change adds a gateway health status indicator and gates the send action in the chat composer to achieve parity with the official app's behavior.

Key changes:
- Periodic health polling in ChatViewModel.
- UI indicator (Pill) in ChatScreen header.
- Send action gating based on gateway health.
- Manual retry functionality.
- Localization in EN and JA.

Fixes #89

---
*PR created automatically by Jules for task [14106759381826136755](https://jules.google.com/task/14106759381826136755) started by @yuga-hashimoto*