### PR TITLE
Add pending tool calls tracking and UI parity

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -55,6 +55,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.openclaw.assistant.speech.TTSUtils
 import com.openclaw.assistant.ui.chat.ChatMessage
+import com.openclaw.assistant.ui.chat.PendingToolCall
 import com.openclaw.assistant.ui.components.MarkdownText
 import com.openclaw.assistant.ui.chat.ChatUiState
 import com.openclaw.assistant.ui.chat.ChatViewModel
@@ -433,7 +434,11 @@ fun ChatScreen(
                         }
                     }
                     
-                    if (uiState.isThinking) {
+                    if (uiState.pendingToolCalls.isNotEmpty()) {
+                        item {
+                            RunningToolsIndicator()
+                        }
+                    } else if (uiState.isThinking) {
                         item {
                             ThinkingIndicator()
                         }
@@ -522,6 +527,35 @@ fun MessageBubble(message: ChatMessage) {
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(top = 4.dp, start = 8.dp, end = 8.dp)
+            )
+        }
+    }
+}
+
+@Composable
+fun RunningToolsIndicator() {
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(vertical = 8.dp)
+                .background(MaterialTheme.colorScheme.surface, CircleShape)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                strokeWidth = 2.dp,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                stringResource(R.string.running_tools),
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = androidx.compose.ui.text.font.FontWeight.Medium
             )
         }
     }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -29,6 +29,7 @@
     <string name="stop_description">停止</string>
     <string name="listening">聞いています…</string>
     <string name="thinking">考え中…</string>
+    <string name="running_tools">ツールを実行中…</string>
     <string name="speaking">読み上げ中…</string>
     <string name="ready">準備完了</string>
     <string name="error_no_webhook">Webhook URLを設定してください</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="stop_description">Stop</string>
     <string name="listening">Listening…</string>
     <string name="thinking">Thinking…</string>
+    <string name="running_tools">Running tools…</string>
     <string name="speaking">Speaking…</string>
     <string name="ready">Ready</string>
     <string name="error_no_webhook">Please configure Webhook URL</string>


### PR DESCRIPTION
This change implements real-time pending tool call tracking and display in the chat UI, bringing the app to parity with the official OpenClaw Android implementation.

Key changes:
1. **ViewModel Tracking**: `ChatViewModel` now subscribes to `GatewayClient.agentEvents`. It maintains a map of active tool calls, adding them on "start" phase and removing them on "result" phase. It also clears the map when a chat run finishes.
2. **UI Component**: A new `RunningToolsIndicator` Composable was added to `ChatActivity`. This indicator appears in the chat timeline whenever there are pending tool calls, showing a spinner and "Running tools…" text.
3. **Localization**: Added the `running_tools` string to both `values/strings.xml` and `values-ja/strings.xml`.
4. **Build Fix**: Added a dummy `google-services.json` in the `app/` directory. This is required by the project's Google Services and Firebase Crashlytics integration to allow successful Gradle builds and tests in the sandbox environment.

Fixes #88

---
*PR created automatically by Jules for task [2763667611736931123](https://jules.google.com/task/2763667611736931123) started by @yuga-hashimoto*