### PR TITLE
Implement Live Streaming Assistant Text Bubble

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -255,10 +255,30 @@ fun ChatScreen(
         items
     }
 
-    // Scroll to bottom when new messages arrive
-    LaunchedEffect(groupedItems.size) {
-        if (groupedItems.isNotEmpty()) {
-            listState.animateScrollToItem(groupedItems.size - 1)
+    // Auto-scroll for new messages or major state changes
+    LaunchedEffect(groupedItems.size, uiState.isThinking, uiState.isSpeaking) {
+        val targetIndex = groupedItems.size +
+            (if (uiState.streamingAssistantText != null) 1 else 0) +
+            (if (uiState.isThinking) 1 else 0) +
+            (if (uiState.isSpeaking) 1 else 0)
+
+        if (targetIndex > 0) {
+            listState.animateScrollToItem(targetIndex - 1)
+        }
+    }
+
+    // Performance-optimized scroll for streaming updates: only scroll if already at bottom, and don't animate
+    LaunchedEffect(uiState.streamingAssistantText) {
+        if (uiState.streamingAssistantText != null) {
+            val layoutInfo = listState.layoutInfo
+            val visibleItems = layoutInfo.visibleItemsInfo
+            if (visibleItems.isNotEmpty()) {
+                val lastVisibleItem = visibleItems.last()
+                // If the user is near the bottom, keep them at the bottom
+                if (lastVisibleItem.index >= layoutInfo.totalItemsCount - 2) {
+                    listState.scrollToItem(layoutInfo.totalItemsCount - 1)
+                }
+            }
         }
     }
 
@@ -430,6 +450,19 @@ fun ChatScreen(
                             is ChatListItem.MessageItem -> {
                                 MessageBubble(message = item.message)
                             }
+                        }
+                    }
+
+                    if (uiState.streamingAssistantText != null) {
+                        item(key = "streaming_bubble") {
+                            MessageBubble(
+                                message = ChatMessage(
+                                    id = "streaming_assistant_msg",
+                                    text = uiState.streamingAssistantText,
+                                    isUser = false,
+                                    timestamp = uiState.streamingAssistantTimestamp
+                                )
+                            )
                         }
                     }
                     

--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewayClient.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewayClient.kt
@@ -512,6 +512,12 @@ class GatewayClient(context: android.content.Context) {
                 errorMessage = payload.get("errorMessage")?.asString
             )
             Log.d(TAG, "Chat event: state=${event.state}, runId=${event.runId}")
+
+            // Clear streaming text on terminal states
+            if (event.state == "final" || event.state == "error" || event.state == "aborted") {
+                _streamingText.value = null
+            }
+
             _chatEvents.tryEmit(event)
         } catch (e: Exception) {
             Log.w(TAG, "Failed to parse chat event: ${e.message}, json=${payloadJson.take(200)}")
@@ -539,9 +545,13 @@ class GatewayClient(context: android.content.Context) {
             Log.d(TAG, "Agent event: stream=${event.stream}, textLen=${streamData?.text?.length ?: 0}, phase=${streamData?.phase}")
             _agentEvents.tryEmit(event)
 
-            // Update streaming text for "assistant" stream
-            if (event.stream == "assistant" && !streamData?.text.isNullOrEmpty()) {
-                _streamingText.value = streamData?.text
+            // Update streaming text for "assistant" stream (accumulate deltas)
+            if (event.stream == "assistant") {
+                if (streamData?.phase == "start") {
+                    _streamingText.value = ""
+                } else if (!streamData?.text.isNullOrEmpty()) {
+                    _streamingText.value = (_streamingText.value ?: "") + streamData?.text
+                }
             }
         } catch (e: Exception) {
             Log.w(TAG, "Failed to parse agent event: ${e.message}")


### PR DESCRIPTION
This pull request implements live streaming assistant text rendering in the chat interface, achieving parity with the official app experience.

Key changes:
1. **GatewayClient**: Updated `handleAgentEvent` to append text deltas for the `assistant` stream and initialize on the `start` phase. Added logic to clear the streaming text when a chat run reaches a terminal state (`final`, `error`, `aborted`).
2. **ChatViewModel**: Introduced `streamingAssistantText` and `streamingAssistantTimestamp` to `ChatUiState`. The ViewModel now observes the gateway's streaming state and automatically transitions the UI from "Thinking" to "Streaming" as soon as the first chunk of text arrives.
3. **ChatActivity**: 
   - Renders a real-time `MessageBubble` for the streaming content.
   - Implemented an intelligent auto-scroll mechanism: major state changes trigger an animated scroll, while incremental streaming updates use a performance-optimized `scrollToItem` only if the user is already near the bottom. This ensures the UI remains responsive and doesn't force-scroll if the user is reviewing chat history.
   - Used stable keys and timestamps to minimize unnecessary recompositions during rapid streaming updates.

These changes provide a much more responsive and modern chat experience, allowing users to see the assistant's response as it is being generated.

Fixes #90

---
*PR created automatically by Jules for task [13311878750304239231](https://jules.google.com/task/13311878750304239231) started by @yuga-hashimoto*