### PR TITLE
Revert PR #69: Make voice input silence timeout more configurable

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -76,7 +76,7 @@ fun SettingsScreen(
     var resumeLatestSession by remember { mutableStateOf(settings.resumeLatestSession) }
     var wakeWordPreset by remember { mutableStateOf(settings.wakeWordPreset) }
     var customWakeWord by remember { mutableStateOf(settings.customWakeWord) }
-    var speechSilenceTimeout by remember { mutableStateOf(settings.speechSilenceTimeout.toFloat().coerceIn(500f, 10000f)) }
+    var speechSilenceTimeout by remember { mutableStateOf(settings.speechSilenceTimeout.toFloat().coerceIn(5000f, 30000f)) }
     var speechLanguage by remember { mutableStateOf(settings.speechLanguage) }
     var thinkingSoundEnabled by remember { mutableStateOf(settings.thinkingSoundEnabled) }
 
@@ -740,8 +740,8 @@ fun SettingsScreen(
                     Slider(
                         value = speechSilenceTimeout,
                         onValueChange = { speechSilenceTimeout = it },
-                        valueRange = 500f..10000f,
-                        steps = 18,
+                        valueRange = 5000f..30000f,
+                        steps = 4,
                         modifier = Modifier.fillMaxWidth()
                     )
                 }

--- a/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
@@ -121,9 +121,9 @@ class SettingsRepository(context: Context) {
         get() = prefs.getInt(KEY_GATEWAY_PORT, 18789)
         set(value) = prefs.edit().putInt(KEY_GATEWAY_PORT, value).apply()
 
-    // Speech recognition silence timeout in ms (default 2000ms)
+    // Speech recognition silence timeout in ms (default 5000ms)
     var speechSilenceTimeout: Long
-        get() = prefs.getLong(KEY_SPEECH_SILENCE_TIMEOUT, 2000L)
+        get() = prefs.getLong(KEY_SPEECH_SILENCE_TIMEOUT, 5000L)
         set(value) = prefs.edit().putLong(KEY_SPEECH_SILENCE_TIMEOUT, value).apply()
 
     // Speech recognition language (BCP-47 tag, empty = system default)

--- a/app/src/main/java/com/openclaw/assistant/speech/SpeechRecognizerManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/SpeechRecognizerManager.kt
@@ -36,7 +36,7 @@ class SpeechRecognizerManager(private val context: Context) {
      * 音声認識を開始し、結果をFlowで返す
      * language が null の場合はシステムデフォルトを使用する
      */
-    fun startListening(language: String? = null, silenceTimeoutMs: Long = 2000L): Flow<SpeechResult> = callbackFlow {
+    fun startListening(language: String? = null, silenceTimeoutMs: Long = 2500L): Flow<SpeechResult> = callbackFlow {
         // デフォルト言語の決定
         val targetLanguage = language ?: Locale.getDefault().toLanguageTag()
         


### PR DESCRIPTION
This PR reverts #69 (merge commit: e97ee3460487f43899476af54958b19e415de4e8).\n\nReason: requested rollback.\n\nChanges:\n- Reverts the silence-timeout configurability changes introduced by #69.