### PR TITLE
Use configured agentId as model name in API requests

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -384,7 +384,7 @@ fun SettingsScreen(
                                     val testUrl = webhookUrl.trimEnd('/').let { url ->
                                         if (url.contains("/v1/")) url else "$url/v1/chat/completions"
                                     }
-                                    val result = apiClient.testConnection(testUrl, authToken.trim())
+                                    val result = apiClient.testConnection(testUrl, authToken.trim(), defaultAgentId)
                                     result.fold(
                                         onSuccess = {
                                             testResult = TestResult(success = true, message = context.getString(R.string.connected))

--- a/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
+++ b/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
@@ -45,7 +45,7 @@ class OpenClawClient {
         try {
             // OpenAI Chat Completions format for /v1/chat/completions
             val requestBody = JsonObject().apply {
-                addProperty("model", "openclaw")
+                addProperty("model", agentId ?: "openclaw")
                 addProperty("user", sessionId)
                 val messagesArray = JsonArray()
                 val userMessage = JsonObject().apply {
@@ -109,7 +109,8 @@ class OpenClawClient {
      */
     suspend fun testConnection(
         webhookUrl: String,
-        authToken: String?
+        authToken: String?,
+        agentId: String? = null
     ): Result<Boolean> = withContext(Dispatchers.IO) {
         if (webhookUrl.isBlank()) {
             return@withContext Result.failure(
@@ -145,7 +146,7 @@ class OpenClawClient {
 
             // Fallback: POST with minimal OpenAI format
             val requestBody = JsonObject().apply {
-                addProperty("model", "openclaw")
+                addProperty("model", agentId ?: "openclaw")
                 addProperty("user", "connection-test")
                 val messagesArray = JsonArray()
                 val testMessage = JsonObject().apply {


### PR DESCRIPTION
The application was hardcoding the model name as `"openclaw"` in its API requests to the `/v1/chat/completions` endpoint. This caused connection failures (HTTP 404) when using backends like Ollama, even when the user had correctly configured a different model name in the "Default Agent" field.

This PR:
1.  Updates `OpenClawClient.sendMessage` to use the `agentId` parameter for the `model` property in the request body, falling back to `"openclaw"` if null.
2.  Updates `OpenClawClient.testConnection` to accept an optional `agentId` and use it in its fallback POST request.
3.  Modifies `SettingsActivity` to pass the currently entered `defaultAgentId` when the user clicks the "Test Connection" button.

These changes ensure that the user-configured model name is correctly sent to the server, fixing the 404 error for Ollama users.

Fixes #105

---
*PR created automatically by Jules for task [11891912379499833495](https://jules.google.com/task/11891912379499833495) started by @yuga-hashimoto*