### PR TITLE
Fix Ollama model 'openclaw' not found error

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -384,7 +384,8 @@ fun SettingsScreen(
                                     val testUrl = webhookUrl.trimEnd('/').let { url ->
                                         if (url.contains("/v1/")) url else "$url/v1/chat/completions"
                                     }
-                                    val result = apiClient.testConnection(testUrl, authToken.trim())
+                                    val modelToTest = if (defaultAgentId.isNotBlank() && defaultAgentId != "main") defaultAgentId else null
+                                    val result = apiClient.testConnection(testUrl, authToken.trim(), modelToTest)
                                     result.fold(
                                         onSuccess = {
                                             testResult = TestResult(success = true, message = context.getString(R.string.connected))

--- a/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
+++ b/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
@@ -45,7 +45,7 @@ class OpenClawClient {
         try {
             // OpenAI Chat Completions format for /v1/chat/completions
             val requestBody = JsonObject().apply {
-                addProperty("model", "openclaw")
+                addProperty("model", agentId ?: "openclaw")
                 addProperty("user", sessionId)
                 val messagesArray = JsonArray()
                 val userMessage = JsonObject().apply {
@@ -109,7 +109,8 @@ class OpenClawClient {
      */
     suspend fun testConnection(
         webhookUrl: String,
-        authToken: String?
+        authToken: String?,
+        modelName: String? = null
     ): Result<Boolean> = withContext(Dispatchers.IO) {
         if (webhookUrl.isBlank()) {
             return@withContext Result.failure(
@@ -145,7 +146,7 @@ class OpenClawClient {
 
             // Fallback: POST with minimal OpenAI format
             val requestBody = JsonObject().apply {
-                addProperty("model", "openclaw")
+                addProperty("model", modelName ?: "openclaw")
                 addProperty("user", "connection-test")
                 val messagesArray = JsonArray()
                 val testMessage = JsonObject().apply {


### PR DESCRIPTION
Fixes issue where Ollama connection fails with "model 'openclaw' not found" because the app was hardcoding the model name. Now uses the selected Agent ID as the model name in the API request body.

---
*PR created automatically by Jules for task [17102334638932039159](https://jules.google.com/task/17102334638932039159) started by @yuga-hashimoto*