### PR TITLE
Add inline buttons for executive approval requests

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -179,4 +179,11 @@
     <string name="support_section">サポート</string>
     <string name="report_issue">問題を報告</string>
     <string name="report_issue_desc">バグの報告や機能のリクエストはこちらから（GitHub）</string>
+
+    <!-- Approval Buttons -->
+    <string name="action_approve">承認</string>
+    <string name="action_deny">拒否</string>
+    <string name="action_allow_once">1回許可</string>
+    <string name="action_allow_always">常に許可</string>
+    <string name="action_allow">許可</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,4 +211,11 @@
     <string name="support_section">Support</string>
     <string name="report_issue">Report Issue</string>
     <string name="report_issue_desc">Found a bug or have a feature request? Let us know on GitHub.</string>
+
+    <!-- Approval Buttons -->
+    <string name="action_approve">Approve</string>
+    <string name="action_deny">Deny</string>
+    <string name="action_allow_once">Allow Once</string>
+    <string name="action_allow_always">Allow Always</string>
+    <string name="action_allow">Allow</string>
 </resources>


### PR DESCRIPTION
Added inline interactive buttons for executive approval requests (e.g., /approve, /deny, /allow-once) in both the chat interface and the voice assistant overlay. These buttons appear automatically when the assistant's message contains the corresponding commands, allowing users to take action without manual entry.

Fixes #77

---
*PR created automatically by Jules for task [10842502583431036643](https://jules.google.com/task/10842502583431036643) started by @yuga-hashimoto*