### PR TITLE
Wear OS Support - OpenClaw as Default Assistant

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -156,6 +156,11 @@ dependencies {
     // Vosk
     implementation("com.alphacephei:vosk-android:0.3.75")
 
+    // Wear OS
+    implementation("androidx.wear:wear:1.3.0")
+    implementation("androidx.wear.compose:compose-material:1.3.1")
+    implementation("androidx.wear.compose:compose-foundation:1.3.1")
+
     // Tink (Crypto)
     implementation("com.google.crypto.tink:tink-android:1.10.0")
 

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -10,4 +10,6 @@
     <issue id="ObsoleteSdkInt" severity="warning" />
     <!-- Firebase dependencies bring activity/fragment lint checks -->
     <issue id="InvalidFragmentVersionForActivityResult" severity="warning" />
+    <!-- Allow android:required="false" for watch feature to support single APK -->
+    <issue id="InvalidWearFeatureAttribute" severity="warning" />
 </lint>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
     <!-- Start service on boot -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <!-- Wear OS compatibility -->
+    <uses-feature android:name="android.hardware.type.watch" android:required="false" />
+
     <!-- Required to detect TTS engines and speech recognizer languages (Android 11+) -->
     <queries>
         <intent>
@@ -46,6 +49,8 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.OpenClawAssistant"
         tools:targetApi="34">
+
+        <meta-data android:name="com.google.android.wearable.standalone" android:value="true" />
 
         <!-- Main Activity -->
         <activity
@@ -81,6 +86,8 @@
             <intent-filter>
                 <action android:name="android.service.voice.VoiceInteractionService" />
                 <action android:name="android.intent.action.ASSIST" />
+                <action android:name="android.intent.action.VOICE_COMMAND" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </service>
 


### PR DESCRIPTION
This PR adds support for Wear OS, allowing OpenClaw to be used as a default assistant on smartwatches.

Key changes:
1. **Manifest Updates**: Added `android.intent.action.VOICE_COMMAND` and `android.intent.category.DEFAULT` to the assistant service so it shows up in Wear OS selection. Added `android.hardware.type.watch` feature (optional) and standalone metadata.
2. **Wear OS UI**: Implemented `WatchAssistantUI` in `OpenClawSession.kt` using `androidx.wear.compose` components. This UI provides a simplified flow with a centered mic status, user query, and response text, which is ideal for small circular screens.
3. **Runtime Detection**: Added a check for `PackageManager.FEATURE_WATCH` in `OpenClawSession` to switch between mobile and watch UI.
4. **Dependencies**: Added `androidx.wear` and `androidx.wear.compose` dependencies.
5. **Linting**: Suppressed `InvalidWearFeatureAttribute` to allow a single APK for both mobile and watch.

The implementation ensures that long-pressing the home button (or side button on Wear OS) triggers a voice session that processes speech and returns both voice and text on the watch.

Fixes #58

---
*PR created automatically by Jules for task [5849162001129696377](https://jules.google.com/task/5849162001129696377) started by @yuga-hashimoto*