### PR TITLE
Add Canvas support (navigate/eval/snapshot/A2UI)

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewayProtocol.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewayProtocol.kt
@@ -27,6 +27,7 @@ data class AgentEventPayload(
 
 data class AgentStreamData(
     val text: String?,
+    val arguments: String?,   // Usually the same as text when phase=start for tools
     val phase: String?,       // "start", "result"
     val name: String?,
     val toolCallId: String?

--- a/app/src/main/java/com/openclaw/assistant/ui/components/CanvasWebView.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/CanvasWebView.kt
@@ -1,0 +1,105 @@
+package com.openclaw.assistant.ui.components
+
+import android.annotation.SuppressLint
+import android.graphics.Bitmap
+import android.util.Base64
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.openclaw.assistant.ui.chat.CanvasUiState
+import java.io.ByteArrayOutputStream
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+fun CanvasWebView(
+    state: CanvasUiState,
+    onSnapshotCaptured: (String, String) -> Unit,
+    onEvalCompleted: () -> Unit,
+    onA2uiProcessed: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var webViewInstance by remember { mutableStateOf<WebView?>(null) }
+
+    // Handle URL navigation
+    LaunchedEffect(state.url, state.lastNavigationTime) {
+        if (state.url.isNotEmpty()) {
+            webViewInstance?.loadUrl(state.url)
+        }
+    }
+
+    // Handle JS evaluation
+    LaunchedEffect(state.pendingEval) {
+        state.pendingEval?.let { code ->
+            webViewInstance?.evaluateJavascript(code) {
+                onEvalCompleted()
+            }
+        }
+    }
+
+    // Handle A2UI Push
+    LaunchedEffect(state.pendingA2uiPush) {
+        state.pendingA2uiPush?.let { data ->
+            // Assume the canvas listener is window.onA2UIPushed
+            val script = "if (window.onA2UIPushed) { window.onA2UIPushed($data); } else { window.postMessage({type: 'a2ui.push', data: $data}, '*'); }"
+            webViewInstance?.evaluateJavascript(script) {
+                onA2uiProcessed()
+            }
+        }
+    }
+
+    // Handle A2UI Reset
+    LaunchedEffect(state.pendingA2uiReset) {
+        if (state.pendingA2uiReset) {
+            val script = "if (window.onA2UIReset) { window.onA2UIReset(); } else { window.postMessage({type: 'a2ui.reset'}, '*'); }"
+            webViewInstance?.evaluateJavascript(script) {
+                onA2uiProcessed()
+            }
+        }
+    }
+
+    // Handle Snapshot
+    LaunchedEffect(state.pendingSnapshotId) {
+        state.pendingSnapshotId?.let { toolCallId ->
+            webViewInstance?.let { webView ->
+                webView.postDelayed({
+                    val bitmap = Bitmap.createBitmap(webView.width, webView.height, Bitmap.Config.ARGB_8888)
+                    val canvas = android.graphics.Canvas(bitmap)
+                    webView.draw(canvas)
+
+                    val outputStream = ByteArrayOutputStream()
+                    bitmap.compress(Bitmap.CompressFormat.JPEG, 80, outputStream)
+                    val base64 = Base64.encodeToString(outputStream.toByteArray(), Base64.NO_WRAP)
+
+                    onSnapshotCaptured(toolCallId, base64)
+                }, 100) // Small delay to ensure rendering is complete
+            }
+        }
+    }
+
+    AndroidView(
+        modifier = modifier,
+        factory = { context ->
+            WebView(context).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+                webViewClient = WebViewClient()
+                settings.javaScriptEnabled = true
+                settings.domStorageEnabled = true
+                settings.databaseEnabled = true
+                webViewInstance = this
+
+                if (state.url.isNotEmpty()) {
+                    loadUrl(state.url)
+                }
+            }
+        },
+        update = {
+            // Usually we handle updates via LaunchedEffect, but can use this too
+        }
+    )
+}


### PR DESCRIPTION
This PR implements the missing Canvas functionality in the OpenClaw Assistant Android app, achieving parity with the official OpenClaw application.

### Key Changes:
1. **Canvas Rendering**: Introduced a new `CanvasWebView` Jetpack Compose component that wraps an Android `WebView` to render dynamic content.
2. **Canvas Tools**:
   - `canvas.navigate`: Supports navigating to arbitrary URLs or the default Gateway Canvas host.
   - `canvas.eval`: Allows the AI agent to execute JavaScript within the Canvas environment.
   - `canvas.snapshot`: Enables capturing the current Canvas state as a Base64-encoded image.
   - `canvas.a2ui.push`/`reset`: Supports the Agent-to-UI protocol for pushing data to the Canvas.
3. **Gateway Enhancements**:
   - Updated `GatewayClient` to accumulate streaming text deltas, ensuring a smooth UI experience.
   - Added support for sending tool results back to the agent via WebSocket RPC.
   - Fixed a race condition where streaming text was cleared before collectors could process the terminal state.
4. **UI Integration**:
   - Integrated a toggleable Canvas overlay into the `ChatActivity`.
   - Added Canvas support to the `OpenClawSession` (voice assistant overlay).
   - Switched the app to prioritize WebSocket-based communication when a gateway is connected, enabling real-time tool execution.
5. **Stability Fixes**:
   - Ensured `OpenClawSession` properly manages coroutine scopes to prevent duplicate event collectors upon session reactivation.
   - Handled nullability and missing imports to ensure a clean build.

### Verification:
- Unit tests passed.
- Lint analysis completed with no new errors.
- Code reviewed and iterated upon to fix regressions and race conditions.

Fixes #112

---
*PR created automatically by Jules for task [8177064534465265001](https://jules.google.com/task/8177064534465265001) started by @yuga-hashimoto*