### PR TITLE
feat: ElevenLabs per-agent voices + HTTPS hardening

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
         android:name="com.openclaw.assistant.OpenClawApplication"
         android:allowBackup="false"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="false"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -82,8 +82,14 @@ fun SettingsScreen(
     var thinkingSoundEnabled by remember { mutableStateOf(settings.thinkingSoundEnabled) }
 
     var showAuthToken by remember { mutableStateOf(false) }
+    var showElevenLabsKey by remember { mutableStateOf(false) }
     var showWakeWordMenu by remember { mutableStateOf(false) }
     var showLanguageMenu by remember { mutableStateOf(false) }
+
+    var elevenLabsApiKey by remember { mutableStateOf(settings.elevenLabsApiKey) }
+    var elevenLabsDefaultVoiceId by remember { mutableStateOf(settings.elevenLabsDefaultVoiceId) }
+    var elevenLabsModelId by remember { mutableStateOf(settings.elevenLabsModelId) }
+    var agentVoiceMappingJson by remember { mutableStateOf(settings.agentVoiceMappingJson.ifBlank { "{\"main\": \"\"}" }) }
     
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -177,6 +183,10 @@ fun SettingsScreen(
                             settings.ttsEnabled = ttsEnabled
                             settings.ttsSpeed = ttsSpeed
                             settings.ttsEngine = ttsEngine
+                            settings.elevenLabsApiKey = elevenLabsApiKey
+                            settings.elevenLabsDefaultVoiceId = elevenLabsDefaultVoiceId
+                            settings.elevenLabsModelId = elevenLabsModelId
+                            settings.agentVoiceMappingJson = agentVoiceMappingJson
                             settings.continuousMode = continuousMode
                             settings.resumeLatestSession = resumeLatestSession
                             settings.wakeWordPreset = wakeWordPreset
@@ -594,6 +604,63 @@ fun SettingsScreen(
 
                     if (ttsEnabled) {
                         HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp), thickness = 0.5.dp)
+
+                        // ElevenLabs Voice Configuration
+                        OutlinedTextField(
+                            value = elevenLabsApiKey,
+                            onValueChange = { elevenLabsApiKey = it },
+                            label = { Text(stringResource(R.string.elevenlabs_api_key_label)) },
+                            placeholder = { Text(stringResource(R.string.elevenlabs_api_key_hint)) },
+                            leadingIcon = { Icon(Icons.Default.Key, contentDescription = null) },
+                            trailingIcon = {
+                                IconButton(onClick = { showElevenLabsKey = !showElevenLabsKey }) {
+                                    Icon(
+                                        if (showElevenLabsKey) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                        contentDescription = null
+                                    )
+                                }
+                            },
+                            visualTransformation = if (showElevenLabsKey) VisualTransformation.None else PasswordVisualTransformation(),
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true
+                        )
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        OutlinedTextField(
+                            value = elevenLabsDefaultVoiceId,
+                            onValueChange = { elevenLabsDefaultVoiceId = it },
+                            label = { Text(stringResource(R.string.elevenlabs_default_voice_id_label)) },
+                            placeholder = { Text(stringResource(R.string.elevenlabs_default_voice_id_hint)) },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true
+                        )
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        OutlinedTextField(
+                            value = elevenLabsModelId,
+                            onValueChange = { elevenLabsModelId = it },
+                            label = { Text(stringResource(R.string.elevenlabs_model_id_label)) },
+                            placeholder = { Text(stringResource(R.string.elevenlabs_model_id_hint)) },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true
+                        )
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        OutlinedTextField(
+                            value = agentVoiceMappingJson,
+                            onValueChange = { agentVoiceMappingJson = it },
+                            label = { Text(stringResource(R.string.agent_voice_mapping_label)) },
+                            placeholder = { Text(stringResource(R.string.agent_voice_mapping_hint)) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(150.dp),
+                            maxLines = 8
+                        )
+
+                        Spacer(modifier = Modifier.height(12.dp))
 
                         // TTS Engine Selection
                         ExposedDropdownMenuBox(

--- a/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
+++ b/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
@@ -18,11 +18,38 @@ import java.util.concurrent.TimeUnit
  */
 class OpenClawClient {
 
-    private val client = OkHttpClient.Builder()
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .readTimeout(120, TimeUnit.SECONDS)
-        .writeTimeout(30, TimeUnit.SECONDS)
-        .build()
+    private fun buildClient(certPinsJson: String?): OkHttpClient {
+        val builder = OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(120, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+
+        val pins = (certPinsJson ?: "").trim()
+        if (pins.isNotBlank()) {
+            try {
+                val obj = org.json.JSONObject(pins)
+                val pinnerBuilder = okhttp3.CertificatePinner.Builder()
+                val hosts = obj.keys()
+                while (hosts.hasNext()) {
+                    val host = hosts.next()
+                    val arr = obj.optJSONArray(host)
+                    if (arr != null) {
+                        for (i in 0 until arr.length()) {
+                            val pin = arr.optString(i)
+                            if (pin.startsWith("sha256/")) {
+                                pinnerBuilder.add(host, pin)
+                            }
+                        }
+                    }
+                }
+                builder.certificatePinner(pinnerBuilder.build())
+            } catch (_: Exception) {
+                // ignore malformed pin config
+            }
+        }
+
+        return builder.build()
+    }
 
     private val gson = Gson()
 
@@ -31,6 +58,7 @@ class OpenClawClient {
      */
     suspend fun sendMessage(
         webhookUrl: String,
+         certPinsJson: String? = null,
         message: String,
         sessionId: String,
         authToken: String? = null,
@@ -39,6 +67,11 @@ class OpenClawClient {
         if (webhookUrl.isBlank()) {
             return@withContext Result.failure(
                 IllegalArgumentException("Webhook URL is not configured")
+            )
+        }
+        if (!webhookUrl.trim().startsWith("https://", ignoreCase = true)) {
+            return@withContext Result.failure(
+                IllegalArgumentException("Webhook URL must use HTTPS for secure communication")
             )
         }
 
@@ -74,6 +107,7 @@ class OpenClawClient {
             }
 
             val request = requestBuilder.build()
+            val client = buildClient(certPinsJson)
 
             client.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
@@ -109,15 +143,23 @@ class OpenClawClient {
      */
     suspend fun testConnection(
         webhookUrl: String,
-        authToken: String?
+        authToken: String?,
+        certPinsJson: String? = null
     ): Result<Boolean> = withContext(Dispatchers.IO) {
         if (webhookUrl.isBlank()) {
             return@withContext Result.failure(
                 IllegalArgumentException("Webhook URL is not configured")
             )
         }
+        if (!webhookUrl.trim().startsWith("https://", ignoreCase = true)) {
+            return@withContext Result.failure(
+                IllegalArgumentException("Webhook URL must use HTTPS for secure communication")
+            )
+        }
 
         try {
+            val client = buildClient(certPinsJson)
+
             // Try a HEAD request first (lightweight)
             var requestBuilder = Request.Builder()
                 .url(webhookUrl)

--- a/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import java.util.UUID
+import org.json.JSONObject
 
 /**
  * Secure settings storage
@@ -110,6 +111,39 @@ class SettingsRepository(context: Context) {
         get() = prefs.getFloat(KEY_TTS_SPEED, 1.2f)
         set(value) = prefs.edit().putFloat(KEY_TTS_SPEED, value).apply()
 
+    // ElevenLabs API key (optional, when present is primary TTS)
+    var elevenLabsApiKey: String
+        get() = prefs.getString(KEY_ELEVENLABS_API_KEY, "") ?: ""
+        set(value) = prefs.edit().putString(KEY_ELEVENLABS_API_KEY, value.trim()).apply()
+
+    // Default ElevenLabs voice ID
+    var elevenLabsDefaultVoiceId: String
+        get() = prefs.getString(KEY_ELEVENLABS_DEFAULT_VOICE_ID, "") ?: ""
+        set(value) = prefs.edit().putString(KEY_ELEVENLABS_DEFAULT_VOICE_ID, value.trim()).apply()
+
+    // ElevenLabs model ID
+    var elevenLabsModelId: String
+        get() = prefs.getString(KEY_ELEVENLABS_MODEL_ID, "eleven_turbo_v2_5") ?: "eleven_turbo_v2_5"
+        set(value) = prefs.edit().putString(KEY_ELEVENLABS_MODEL_ID, value.trim()).apply()
+
+    // Agent -> voice mapping JSON, e.g. {"main":"voiceIdA","coder":"voiceIdB"}
+    var agentVoiceMappingJson: String
+        get() = prefs.getString(KEY_AGENT_VOICE_MAPPING_JSON, "") ?: ""
+        set(value) = prefs.edit().putString(KEY_AGENT_VOICE_MAPPING_JSON, value.trim()).apply()
+
+    fun getElevenLabsVoiceIdForAgent(agentId: String?): String {
+        val id = agentId?.trim().orEmpty()
+        if (id.isNotEmpty()) {
+            try {
+                val obj = JSONObject(agentVoiceMappingJson.ifBlank { "{}" })
+                val mapped = obj.optString(id, "")
+                if (mapped.isNotBlank()) return mapped
+            } catch (_: Exception) {
+            }
+        }
+        return elevenLabsDefaultVoiceId
+    }
+
     // TTS Engine
     var ttsEngine: String
         get() = prefs.getString(KEY_TTS_ENGINE, "") ?: ""
@@ -148,11 +182,12 @@ class SettingsRepository(context: Context) {
 
     /**
      * Get the chat completions URL.
-     * Supports both base URL (http://server) and full path (http://server/v1/chat/completions).
+     * Supports both base URL and full path, but enforces HTTPS-only.
      */
     fun getChatCompletionsUrl(): String {
         val url = webhookUrl.trim().trimEnd('/')
         if (url.isBlank()) return ""
+        if (!url.startsWith("https://")) return ""
         return if (url.contains("/v1/")) url
         else "$url/v1/chat/completions"
     }
@@ -163,9 +198,15 @@ class SettingsRepository(context: Context) {
      */
     fun getBaseUrl(): String {
         val url = webhookUrl.trimEnd('/')
+        if (!url.startsWith("https://")) return ""
         val idx = url.indexOf("/v1/")
         return if (idx > 0) url.substring(0, idx) else url
     }
+
+    // Optional certificate pin map as JSON: {"host":["sha256/..."]}
+    var certPinsJson: String
+        get() = prefs.getString(KEY_CERT_PINS_JSON, "") ?: ""
+        set(value) = prefs.edit().putString(KEY_CERT_PINS_JSON, value.trim()).apply()
 
     // Check if configured
     fun isConfigured(): Boolean {
@@ -196,6 +237,11 @@ class SettingsRepository(context: Context) {
         private const val KEY_RESUME_LATEST_SESSION = "resume_latest_session"
         private const val KEY_TTS_SPEED = "tts_speed"
         private const val KEY_TTS_ENGINE = "tts_engine"
+        private const val KEY_ELEVENLABS_API_KEY = "elevenlabs_api_key"
+        private const val KEY_ELEVENLABS_DEFAULT_VOICE_ID = "elevenlabs_default_voice_id"
+        private const val KEY_ELEVENLABS_MODEL_ID = "elevenlabs_model_id"
+        private const val KEY_AGENT_VOICE_MAPPING_JSON = "agent_voice_mapping_json"
+        private const val KEY_CERT_PINS_JSON = "cert_pins_json"
         private const val KEY_GATEWAY_PORT = "gateway_port"
         private const val KEY_DEFAULT_AGENT_ID = "default_agent_id"
         private const val KEY_SPEECH_SILENCE_TIMEOUT = "speech_silence_timeout"

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
@@ -333,8 +333,8 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
                                 val isTimeout = result.code == SpeechRecognizer.ERROR_SPEECH_TIMEOUT ||
                                               result.code == SpeechRecognizer.ERROR_NO_MATCH
 
-                                if (isTimeout && settings.continuousMode && elapsed < 10000) {
-                                    Log.d(TAG, "Speech timeout within 10s window ($elapsed ms), retrying...")
+                                if (isTimeout && settings.continuousMode) {
+                                    Log.d(TAG, "Speech timeout in continuous mode ($elapsed ms), auto-resume listening...")
                                 } else if (result.code == SpeechRecognizer.ERROR_RECOGNIZER_BUSY) {
                                     speechManager.destroy()
                                     delay(1000)
@@ -356,9 +356,13 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
 
                 if (listenResult == null && !hasActuallySpoken) {
                     Log.w(TAG, "Speech recognition timed out (15s). Device may be locked.")
-                    // Manual timeout - close session without error screen
-                    finish() // Close the session
-                    hasActuallySpoken = true
+                    if (settings.continuousMode) {
+                        Log.d(TAG, "Continuous mode enabled, auto-resuming recognizer")
+                    } else {
+                        // Manual timeout - close session without error screen
+                        finish() // Close the session
+                        hasActuallySpoken = true
+                    }
                 }
                 
                 if (!hasActuallySpoken) {
@@ -369,6 +373,7 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
     }
 
     private var thinkingSoundJob: Job? = null
+    private var lastAgentIdUsed: String? = null
 
     private fun startThinkingSound() {
         thinkingSoundJob?.cancel()
@@ -404,7 +409,8 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
     }
 
     private suspend fun sendViaHttp(message: String) {
-        val agentId = settings.defaultAgentId.takeIf { it.isNotBlank() && it != "main" }
+        val agentId = settings.defaultAgentId.takeIf { it.isNotBlank() }
+        lastAgentIdUsed = agentId
         val result = apiClient.sendMessage(
             webhookUrl = settings.getChatCompletionsUrl(),
             message = message,
@@ -447,7 +453,7 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
         }
 
         if (settings.ttsEnabled) {
-            speakResponse(responseText)
+            speakResponse(responseText, lastAgentIdUsed)
         } else if (settings.continuousMode) {
             delay(500)
             startListening()
@@ -466,14 +472,14 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
         startListening()
     }
 
-    private fun speakResponse(text: String) {
+    private fun speakResponse(text: String, agentId: String? = null) {
         stopThinkingSound()
         currentState.value = AssistantState.SPEAKING
         val cleanText = TTSUtils.stripMarkdownForSpeech(text)
 
         speakingJob = scope.launch {
             try {
-                val success = ttsManager.speak(cleanText)
+                val success = ttsManager.speak(cleanText, agentId)
 
                 // Abandon audio focus after TTS completes
                 abandonAudioFocus()

--- a/app/src/main/java/com/openclaw/assistant/speech/ElevenLabsTTS.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/ElevenLabsTTS.kt
@@ -1,0 +1,103 @@
+package com.openclaw.assistant.speech
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.MediaPlayer
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.io.File
+import java.util.UUID
+import kotlin.coroutines.resume
+
+private const val TAG = "ElevenLabsTTS"
+
+class ElevenLabsTTS(private val context: Context) {
+    private val client = OkHttpClient()
+
+    suspend fun speak(
+        apiKey: String,
+        voiceId: String,
+        text: String,
+        modelId: String = "eleven_turbo_v2_5"
+    ): Boolean = withContext(Dispatchers.IO) {
+        if (apiKey.isBlank() || voiceId.isBlank() || text.isBlank()) return@withContext false
+
+        val url = "https://api.elevenlabs.io/v1/text-to-speech/$voiceId/stream"
+        val bodyJson = JSONObject().apply {
+            put("text", text)
+            put("model_id", modelId)
+            put("voice_settings", JSONObject().apply {
+                put("stability", 0.5)
+                put("similarity_boost", 0.75)
+            })
+        }
+
+        val req = Request.Builder()
+            .url(url)
+            .post(bodyJson.toString().toRequestBody("application/json".toMediaType()))
+            .addHeader("xi-api-key", apiKey)
+            .addHeader("Accept", "audio/mpeg")
+            .build()
+
+        return@withContext try {
+            client.newCall(req).execute().use { resp ->
+                if (!resp.isSuccessful) {
+                    Log.e(TAG, "ElevenLabs HTTP ${resp.code}")
+                    return@use false
+                }
+                val bytes = resp.body?.bytes() ?: return@use false
+                if (bytes.isEmpty()) return@use false
+
+                val tmp = File(context.cacheDir, "elevenlabs-${UUID.randomUUID()}.mp3")
+                tmp.writeBytes(bytes)
+                val played = playFile(tmp)
+                tmp.delete()
+                played
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "ElevenLabs speak failed", e)
+            false
+        }
+    }
+
+    private suspend fun playFile(file: File): Boolean = suspendCancellableCoroutine { cont ->
+        try {
+            val mp = MediaPlayer()
+            mp.setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_ASSISTANCE_ACCESSIBILITY)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build()
+            )
+            mp.setDataSource(file.absolutePath)
+            mp.setOnCompletionListener {
+                it.release()
+                if (cont.isActive) cont.resume(true)
+            }
+            mp.setOnErrorListener { player, _, _ ->
+                player.release()
+                if (cont.isActive) cont.resume(false)
+                true
+            }
+            mp.prepare()
+            mp.start()
+
+            cont.invokeOnCancellation {
+                try {
+                    mp.stop()
+                } catch (_: Exception) {
+                }
+                mp.release()
+            }
+        } catch (e: Exception) {
+            if (cont.isActive) cont.resume(false)
+        }
+    }
+}

--- a/app/src/main/java/com/openclaw/assistant/speech/TTSManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/TTSManager.kt
@@ -29,6 +29,7 @@ class TTSManager(private val context: Context) {
     private var isInitialized = false
     private var pendingSpeak: (() -> Unit)? = null
     private val settings = com.openclaw.assistant.data.SettingsRepository.getInstance(context)
+    private val elevenLabsTTS = ElevenLabsTTS(context)
 
     init {
         initializeWithBruteForce()
@@ -93,7 +94,17 @@ class TTSManager(private val context: Context) {
         initializeWithBruteForce()
     }
 
-    suspend fun speak(text: String): Boolean {
+    suspend fun speak(text: String, agentId: String? = null): Boolean {
+        val apiKey = settings.elevenLabsApiKey
+        val voiceId = settings.getElevenLabsVoiceIdForAgent(agentId)
+        if (apiKey.isNotBlank() && voiceId.isNotBlank()) {
+            val model = settings.elevenLabsModelId.ifBlank { "eleven_turbo_v2_5" }
+            Log.d(TAG, "Using ElevenLabs primary TTS for agent=$agentId")
+            val ok = elevenLabsTTS.speak(apiKey = apiKey, voiceId = voiceId, text = text, modelId = model)
+            if (ok) return true
+            Log.w(TAG, "ElevenLabs TTS failed, falling back to Android TTS")
+        }
+
         // Query the engine's actual max input length instead of assuming 4000
         val maxLen = TTSUtils.getMaxInputLength(tts)
         val chunks = TTSUtils.splitTextForTTS(text, maxLen)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,14 @@
     <string name="read_ai_responses">Read AI responses aloud</string>
     <string name="continuous_conversation">Continuous Conversation</string>
     <string name="auto_start_mic">Auto-start mic after AI speaks</string>
+    <string name="elevenlabs_api_key_label">ElevenLabs API Key</string>
+    <string name="elevenlabs_api_key_hint">sk_...</string>
+    <string name="elevenlabs_default_voice_id_label">Default ElevenLabs Voice ID</string>
+    <string name="elevenlabs_default_voice_id_hint">(optional)</string>
+    <string name="elevenlabs_model_id_label">ElevenLabs Model ID</string>
+    <string name="elevenlabs_model_id_hint">eleven_turbo_v2_5</string>
+    <string name="agent_voice_mapping_label">Per-Agent Voice Mapping (JSON)</string>
+    <string name="agent_voice_mapping_hint">{ \"main\": \"voice-id-1\", \"bitcoin\": \"voice-id-2\" }</string>
     <string name="resume_latest_session">Resume Latest Session</string>
     <string name="resume_latest_session_desc">Continue previous conversation on activation</string>
     <string name="speech_silence_timeout">Silence Timeout</string>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
-            <certificates src="user" />
         </trust-anchors>
     </base-config>
 </network-security-config>


### PR DESCRIPTION
## Summary\n- add ElevenLabs TTS support with per-agent voice mapping\n- wire settings for ElevenLabs API key/default voice/model\n- preserve continuous conversation loop behavior\n- enforce HTTPS-only transport in client/settings\n- disable cleartext traffic in manifest/network config\n\n## Notes\n- Includes secure transport defaults; use HTTPS endpoint in app settings.\n- Build not executed locally on VPS (JDK missing), recommend CI artifact validation.