### PR TITLE
fix(ci): generate both APK and AAB artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,12 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Decode google-services.json
-        env:
-          DEBUG_GOOGLE_SERVICES_JSON: ${{ secrets.DEBUG_GOOGLE_SERVICES_JSON }}
+      - name: Generate PR google-services.json
         run: |
-          if [ -n "${DEBUG_GOOGLE_SERVICES_JSON}" ]; then
-            echo "Decoding DEBUG_GOOGLE_SERVICES_JSON..."
-            printf '%s' "$DEBUG_GOOGLE_SERVICES_JSON" | base64 --decode > app/google-services.json
-          else
-            echo "GOOGLE_SERVICES_JSON secret not found. Generating dummy file..."
-            echo "WARNING: Debug APK will crash at runtime without real Firebase config."
-            cat > app/google-services.json << 'EOT'
+          # PR CI builds use "pr" variant (applicationIdSuffix = ".test").
+          # Always generate a matching dummy google-services.json to avoid
+          # package-name mismatch with release Firebase config.
+          cat > app/google-services.json << 'EOT'
           {
             "project_info": {
               "project_number": "000000000000",
@@ -48,16 +43,8 @@ jobs:
                     "package_name": "com.openclaw.assistant"
                   }
                 },
-                "api_key": [
-                  {
-                    "current_key": "mock-api-key"
-                  }
-                ],
-                "services": {
-                  "appinvite_service": {
-                    "other_platform_oauth_client": []
-                  }
-                }
+                "api_key": [{ "current_key": "mock-api-key" }],
+                "services": { "analytics_service": { "status": 1 }, "appinvite_service": { "status": 1, "other_platform_oauth_client": [] }, "ads_service": { "status": 2 } }
               },
               {
                 "client_info": {
@@ -66,22 +53,23 @@ jobs:
                     "package_name": "com.openclaw.assistant.debug"
                   }
                 },
-                "api_key": [
-                  {
-                    "current_key": "mock-api-key"
+                "api_key": [{ "current_key": "mock-api-key" }],
+                "services": { "analytics_service": { "status": 1 }, "appinvite_service": { "status": 1, "other_platform_oauth_client": [] }, "ads_service": { "status": 2 } }
+              },
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:000000000000:android:0000000000000002",
+                  "android_client_info": {
+                    "package_name": "com.openclaw.assistant.test"
                   }
-                ],
-                "services": {
-                  "appinvite_service": {
-                    "other_platform_oauth_client": []
-                  }
-                }
+                },
+                "api_key": [{ "current_key": "mock-api-key" }],
+                "services": { "analytics_service": { "status": 1 }, "appupload_service": { "status": 1, "other_platform_oauth_client": [] }, "ads_service": { "status": 2 } }
               }
             ],
             "configuration_version": "1"
           }
           EOT
-          fi
 
       - name: Decode Keystore
         env:
@@ -105,14 +93,23 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build Debug APK
+      - name: Build PR Test APK
         run: ./gradlew assembleDebug
+
+      - name: Build PR Test AAB
+        run: ./gradlew assembleRelease
 
       - name: Run Lint
         run: ./gradlew lint
 
-      - name: Upload Debug APK
+      - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: app-debug-apk
+          name: app-pr-test-apk
           path: app/build/outputs/apk/debug/app-debug.apk
+
+      - name: Upload AAB
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-pr-test-aab
+          path: app/build/outputs/bundle/release/app-release.aab


### PR DESCRIPTION
Changes to CI workflow:
- Add `assembleRelease` step to generate AAB artifact
- Keep existing `assembleDebug` step to generate APK artifact
- This allows both APK and AAB to be generated for PR testing