### PR TITLE
fix: add R8 keep rules for BouncyCastle to prevent BKS KeyStore error

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -40,3 +40,9 @@
 -dontwarn org.slf4j.impl.**
 -dontwarn org.xbill.DNS.spi.**
 -keep class org.xbill.DNS.** { *; }
+
+# BouncyCastle — required for BKS KeyStore provider registration.
+# Without these rules, R8 strips the security provider registration code,
+# causing java.security.KeyStoreException: BKS not found at runtime.
+-keep class org.bouncycastle.** { *; }
+-dontwarn org.bouncycastle.**


### PR DESCRIPTION
## Summary
- `org.bouncycastle:bcprov-jdk18on:1.83` の ProGuard `-keep` ルールが欠如していたため、R8 がセキュリティプロバイダー登録コードを削除していた
- リリースビルドで Gateway 接続時に `java.security.KeyStoreException: BKS not found` が発生
- `proguard-rules.pro` に `-keep class org.bouncycastle.** { *; }` を追加して修正

## Test plan
- [ ] リリースビルド（またはminifyEnabled=true）でGateway接続が正常に動作することを確認
- [ ] TLS設定なし・フィンガープリントピニングあり・TOFUモードそれぞれで接続できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)