### PR TITLE
fix: use BuildConfig for accurate app version in issue reports

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/utils/SystemInfoProvider.kt
+++ b/app/src/main/java/com/openclaw/assistant/utils/SystemInfoProvider.kt
@@ -2,6 +2,7 @@ package com.openclaw.assistant.utils
 
 import android.content.Context
 import android.os.Build
+import com.openclaw.assistant.BuildConfig
 import com.openclaw.assistant.data.SettingsRepository
 
 object SystemInfoProvider {
@@ -35,12 +36,18 @@ object SystemInfoProvider {
 
     private fun getAppVersion(context: Context): String {
         return try {
-            val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-            @Suppress("DEPRECATION")
-            val versionCode = packageInfo.versionCode
-            "${packageInfo.versionName} ($versionCode)"
+            // Use BuildConfig for accurate version info from build.gradle
+            "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
         } catch (e: Exception) {
-            "Unknown"
+            // Fallback to PackageManager if BuildConfig fails
+            try {
+                val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+                @Suppress("DEPRECATION")
+                val versionCode = packageInfo.versionCode
+                "${packageInfo.versionName} ($versionCode)"
+            } catch (e2: Exception) {
+                "Unknown"
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem
When users report issues via the "問題を報告" button, the app version shows incorrect values like `test (1)` instead of the actual version (e.g., `2.0.2`).

## Root Cause
`getAppVersion()` was using `PackageManager` to get version info, which returns incorrect values in debug builds or when the manifest isn't properly configured.

## Solution
Use `BuildConfig.VERSION_NAME` and `BuildConfig.VERSION_CODE` instead, which are set correctly during the build process from `build.gradle`.

## Changes
- Import `com.openclaw.assistant.BuildConfig`
- Use `BuildConfig.VERSION_NAME` and `BuildConfig.VERSION_CODE` as primary source
- Keep PackageManager as fallback for edge cases
- Add nested try-catch for better error handling

## Testing
- [ ] Build release APK and verify version shows correctly
- [ ] Test issue report button shows correct version

Fixes #<issue_number>