### PR TITLE
fix: jules workflow fails on push events

### DIFF
--- a/.github/workflows/jules-from-issue-label.yml
+++ b/.github/workflows/jules-from-issue-label.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   create-jules-session:
-    if: github.event.label.name == 'jules' && github.event.issue.state == 'open'
+    # Skip if not triggered by issues event (e.g., workflow validation on push)
+    if: github.event_name == 'issues' && github.event.label.name == 'jules' && github.event.issue.state == 'open'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,7 +33,7 @@ jobs:
           TITLE="Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}"
           PROMPT="Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
 
-  ${ISSUE_BODY:-}"
+${ISSUE_BODY:-}"
           jq -n --arg title "$TITLE" --arg prompt "$PROMPT" --arg source "sources/github/${REPO_FULL}" '{"title":$title,"prompt":$prompt,"automationMode":"AUTO_CREATE_PR","sourceContext":{"source":$source,"githubRepoContext":{"startingBranch":"main"}}}' > /tmp/jules_payload.json
           SUCCESS=0
           KEY_USED=""


### PR DESCRIPTION
## Problem

The `jules-from-issue-label.yml` workflow was failing when triggered by `push` events. This happens when GitHub validates workflow files or when the workflow file is modified in a commit.

Error: `This run likely failed because of a workflow file issue.`

## Root Cause

The workflow is designed to only handle `issues` events (specifically when an issue is labeled with `'jules'`), but it was being triggered during `push` events as well. When this happens, `github.event.issue` is undefined, causing the job to fail.

## Fix

Added an explicit `github.event_name == 'issues'` check to the job condition, ensuring the job only runs for issues events.

### Changes
- Added `github.event_name == 'issues'` to the `if` condition
- This prevents the workflow from running (and failing) on push events

## Verification

After this fix, the workflow will:
- ✅ Run when an issue is labeled with `'jules'`
- ✅ Skip when triggered by push events (workflow validation)

---
Fixes CI failures on main branch