### PR TITLE
fix: update Compose BOM to 2024.09.03 and suppress Vosk audio buffer noise

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -160,7 +160,7 @@ dependencies {
     implementation("androidx.webkit:webkit:1.10.0")
 
     // Compose
-    implementation(platform("androidx.compose:compose-bom:2024.06.00"))
+    implementation(platform("androidx.compose:compose-bom:2024.09.03"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
@@ -221,7 +221,7 @@ dependencies {
     testImplementation("org.robolectric:robolectric:4.16")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2024.06.00"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.09.03"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -128,6 +128,14 @@ class HotwordService : Service(), VoskRecognitionListener {
                     getSharedPreferences("hotword_prefs", Context.MODE_PRIVATE)
                         .edit().putBoolean("vosk_unsupported", true).apply()
                     // Don't resume - device doesn't support Vosk
+                } else if (throwable is RuntimeException && throwable.message == "error reading audio buffer") {
+                    // Transient mic unavailability - handled by recovery logic, no need to report
+                    speechService = null
+                    android.os.Handler(android.os.Looper.getMainLooper()).post {
+                        if (!isSessionActive) {
+                            resumeHotwordDetection()
+                        }
+                    }
                 } else {
                     FirebaseCrashlytics.getInstance().recordException(throwable)
                     speechService = null


### PR DESCRIPTION
## Summary

2.0.2で検出されたCrashlyticsの4件のイシューに対応します。

### Issue 1: Vosk audio buffer error (NON-FATAL) — 30件/週
- `RuntimeException: error reading audio buffer` はマイク一時的非利用可能時の既知エラー
- 既存の回復ロジック（`resumeHotwordDetection()`）が動作しているため、Crashlyticsへの報告が純粋なノイズになっていた
- **対応**: uncaught exception handlerでこのエラーのみCrashlytics報告をスキップ

### Issue 2: HOVER_EXIT IllegalStateException (FATAL) — 6件/週
### Issue 4: CursorAnchorInfo NullPointerException (FATAL) — 1件/週
- いずれもCompose内部のバグ（`AndroidComposeView`、`CursorAnchorInfoController`）
- **対応**: Compose BOM を `2024.06.00` → `2024.09.03`（Compose UI 1.7.3）に更新（修正含む）

### Issue 3: fontWeightAdjustment NoSuchFieldError (FATAL) — 1件/週
- Android 11（API 30）端末で発生しているが、minSdk=31のため正規インストール環境では再現不可
- サイドロードされたAPKからの報告と考えられるため、コード修正なし

## Test plan

- [ ] ビルドが通ることを確認（CI）
- [ ] Compose UIが正常に動作することを確認
- [ ] ウェイクワード検出が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)