### PR TITLE
feat: automatic auth mode detection (token/password fallback)

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
@@ -62,6 +62,9 @@ class GatewaySession(
   private val onInvoke: (suspend (InvokeRequest) -> InvokeResult)? = null,
   private val onTlsFingerprint: ((stableId: String, fingerprint: String) -> Unit)? = null,
 ) {
+  companion object {
+    private const val TAG = "GatewaySession"
+  }
   data class InvokeRequest(
     val id: String,
     val nodeId: String,
@@ -301,17 +304,65 @@ class GatewaySession(
       val identityId = identity.deviceId ?: throw IllegalStateException("missing device identity id")
       val storedToken = deviceAuthStore.loadToken(identityId, options.role)
       val trimmedToken = token?.trim().orEmpty()
+      val trimmedPassword = password?.trim().orEmpty()
       val authToken = if (storedToken.isNullOrBlank()) trimmedToken else storedToken
       val canFallbackToShared = !storedToken.isNullOrBlank() && trimmedToken.isNotBlank()
-      val payload = buildConnectParams(identity, connectNonce, authToken, password?.trim())
-      val res = request("connect", payload, timeoutMs = 8_000)
-      if (!res.ok) {
-        val msg = res.error?.message ?: "connect failed"
+      
+      // Try automatic auth mode detection: token first, then password
+      val credential = trimmedToken.ifEmpty { trimmedPassword }
+      
+      if (credential.isNotEmpty()) {
+        // Try token auth first
+        val tokenPayload = buildConnectParams(identity, connectNonce, authToken, null)
+        val tokenRes = request("connect", tokenPayload, timeoutMs = 8_000)
+        
+        if (tokenRes.ok) {
+          handleConnectSuccess(tokenRes, canFallbackToShared, identityId)
+          return
+        }
+        
+        // Token auth failed, try password auth if password is provided
+        if (trimmedPassword.isNotEmpty()) {
+          Log.d(TAG, "Token auth failed, trying password auth...")
+          val passwordPayload = buildConnectParams(identity, connectNonce, "", trimmedPassword)
+          val passwordRes = request("connect", passwordPayload, timeoutMs = 8_000)
+          
+          if (passwordRes.ok) {
+            handleConnectSuccess(passwordRes, canFallbackToShared, identityId)
+            return
+          }
+          
+          // Both failed
+          val msg = passwordRes.error?.message ?: "connect failed"
+          if (canFallbackToShared) {
+            deviceAuthStore.clearToken(identityId, options.role)
+          }
+          throw IllegalStateException(msg)
+        }
+        
+        // Token failed and no password provided
+        val msg = tokenRes.error?.message ?: "connect failed"
         if (canFallbackToShared) {
           deviceAuthStore.clearToken(identityId, options.role)
         }
         throw IllegalStateException(msg)
+      } else {
+        // No credential provided, try connect without auth
+        val payload = buildConnectParams(identity, connectNonce, "", null)
+        val res = request("connect", payload, timeoutMs = 8_000)
+        if (!res.ok) {
+          val msg = res.error?.message ?: "connect failed"
+          throw IllegalStateException(msg)
+        }
+        handleConnectSuccess(res, false, identityId)
       }
+    }
+    
+    private suspend fun handleConnectSuccess(
+      res: RpcResponse, 
+      canFallbackToShared: Boolean, 
+      identityId: String
+    ) {
       val payloadJson = res.payloadJson ?: throw IllegalStateException("connect failed: missing payload")
       val obj = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: throw IllegalStateException("connect failed")
       val serverObj = obj["server"].asObjectOrNull()


### PR DESCRIPTION
## Summary

This PR adds automatic authentication mode detection to GatewaySession, allowing seamless fallback from token auth to password auth.

## Changes

- Modified `sendConnect()` to implement automatic auth mode detection:
  1. First tries token authentication
  2. Falls back to password authentication if token fails (and password is provided)
- Added `handleConnectSuccess()` helper method to avoid code duplication
- Maintains backward compatibility with existing token-based and password-based setups

## Use Case

Enables the Android app to connect to gateways using either:
- Token-based authentication (existing behavior)
- Password-based authentication (e.g., Tailscale Funnel)
- Automatic fallback without UI changes

## Testing

- [ ] Test with token-based gateway
- [ ] Test with password-based gateway (Tailscale Funnel)
- [ ] Test with no authentication (local development)