### PR TITLE
fix(chat): optimize chat load time

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/chat/ChatController.kt
+++ b/app/src/main/java/com/openclaw/assistant/chat/ChatController.kt
@@ -1,8 +1,10 @@
 package com.openclaw.assistant.chat
 
+import android.util.Log
 import com.openclaw.assistant.gateway.GatewaySession
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -81,7 +83,7 @@ class ChatController(
     if (_sessionKey.value == key && bootstrapJob?.isActive == true) return
     _sessionKey.value = key
     bootstrapJob?.cancel()
-    bootstrapJob = scope.launch { bootstrap(forceHealth = true) }
+    bootstrapJob = scope.launch { bootstrap(forceHealth = true, clearMessages = false) }
   }
 
   fun applyMainSessionKey(mainSessionKey: String) {
@@ -91,12 +93,12 @@ class ChatController(
     if (_sessionKey.value != "main") return
     _sessionKey.value = trimmed
     bootstrapJob?.cancel()
-    bootstrapJob = scope.launch { bootstrap(forceHealth = true) }
+    bootstrapJob = scope.launch { bootstrap(forceHealth = true, clearMessages = true) }
   }
 
   fun refresh() {
     bootstrapJob?.cancel()
-    bootstrapJob = scope.launch { bootstrap(forceHealth = true) }
+    bootstrapJob = scope.launch { bootstrap(forceHealth = true, clearMessages = false) }
   }
 
   fun refreshSessions(limit: Int? = null) {
@@ -115,7 +117,7 @@ class ChatController(
     if (key == _sessionKey.value) return
     _sessionKey.value = key
     bootstrapJob?.cancel()
-    bootstrapJob = scope.launch { bootstrap(forceHealth = true) }
+    bootstrapJob = scope.launch { bootstrap(forceHealth = true, clearMessages = true) }
   }
 
   fun sendMessage(
@@ -195,8 +197,10 @@ class ChatController(
               )
             }
           }
+        Log.d("ChatDbg", "chat.send start idempotencyKey=$runId sessionKey=$sessionKey")
         val res = session.request("chat.send", params.toString(), timeoutMs = 35_000)
         val actualRunId = parseRunId(res) ?: runId
+        Log.d("ChatDbg", "chat.send response: actualRunId=$actualRunId (same=${actualRunId == runId}) res=$res")
         if (actualRunId != runId) {
           clearPendingRun(runId)
           armPendingRunTimeout(actualRunId)
@@ -206,6 +210,8 @@ class ChatController(
           }
         }
       } catch (err: Throwable) {
+        if (err is CancellationException) throw err
+        Log.e("ChatDbg", "chat.send error: ${err.message}")
         clearPendingRun(runId)
         _errorText.value = err.message
       }
@@ -258,14 +264,16 @@ class ChatController(
     }
   }
 
-  private suspend fun bootstrap(forceHealth: Boolean) {
+  private suspend fun bootstrap(forceHealth: Boolean, clearMessages: Boolean = false) {
     _errorText.value = null
     clearPendingRuns()
     pendingToolCallsById.clear()
     publishPendingToolCalls()
     _streamingAssistantText.value = null
     _sessionId.value = null
-    _messages.value = emptyList() // clear stale messages while loading
+    if (clearMessages) {
+      _messages.value = emptyList() // clear stale messages while loading
+    }
 
     val key = _sessionKey.value
     try {
@@ -289,6 +297,7 @@ class ChatController(
       pollHealthIfNeeded(force = forceHealth)
       fetchSessions(limit = 50)
     } catch (err: Throwable) {
+      if (err is CancellationException) throw err
       _errorText.value = err.message
     }
   }
@@ -324,10 +333,14 @@ class ChatController(
   private fun handleChatEvent(payloadJson: String) {
     val payload = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: return
     val sessionKey = payload["sessionKey"].asStringOrNull()?.trim()
-    if (!sessionKey.isNullOrEmpty() && sessionKey != _sessionKey.value) return
+    if (!sessionKey.isNullOrEmpty() && sessionKey != _sessionKey.value) {
+      Log.d("ChatDbg", "handleChatEvent: sessionKey mismatch event=$sessionKey current=${_sessionKey.value}, skipping")
+      return
+    }
 
     val runId = payload["runId"].asStringOrNull()
     val state = payload["state"].asStringOrNull()
+    Log.d("ChatDbg", "handleChatEvent: state=$state runId=$runId sessionKey=$sessionKey pendingRuns=${synchronized(pendingRuns){pendingRuns.toList()}}")
     if (runId != null) {
       val isPending =
         synchronized(pendingRuns) {
@@ -359,6 +372,8 @@ class ChatController(
             val historyJson =
               session.request("chat.history", """{"sessionKey":"${_sessionKey.value}"}""")
             val history = parseHistory(historyJson, sessionKey = _sessionKey.value)
+            val lastMsg = history.messages.lastOrNull()
+            Log.d("ChatDbg", "handleChatEvent: history reloaded msgCount=${history.messages.size} state=$state lastRole=${lastMsg?.role} lastText=${lastMsg?.content?.firstOrNull()?.text?.take(50)}")
             _messages.value = history.messages
             _sessionId.value = history.sessionId
             history.thinkingLevel?.trim()?.takeIf { it.isNotEmpty() }?.let { _thinkingLevel.value = it }


### PR DESCRIPTION
## Description
Optimized Gateway Chat load time by eliminating unnecessary full list clearings on screen refresh or session resume.

When reopening a session, the previous chat history is temporarily displayed so that the screen doesn't go blank while the app fetches the latest history from the server.

### Changes
* Added a `clearMessages` flag to `bootstrap` method in `ChatController.kt`.
* Set `clearMessages=false` for instances where the chat screen is loaded into an existing active session.
* Maintained `clearMessages=true` to clear out messages appropriately when switching out of a session so that chat histories don't mix.