### PR TITLE
feat: add first-run setup guide and gateway-to-HTTP auto-config

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -68,6 +68,7 @@ import com.openclaw.assistant.ui.components.ConnectionState
 import com.openclaw.assistant.ui.components.PairingRequiredCard
 import com.openclaw.assistant.ui.components.StatusIndicator
 import com.openclaw.assistant.ui.theme.OpenClawAssistantTheme
+import com.openclaw.assistant.ui.SetupGuideScreen
 
 data class PermissionStatusInfo(
     val permissionName: String,
@@ -151,33 +152,48 @@ class MainActivity : ComponentActivity(), TextToSpeech.OnInitListener {
         runtime.screenRecorder.attachPermissionRequester(permissionRequester)
         
         initializeTTS()
-        checkPermissions()
+        // Removed checkPermissions() from onCreate to allow SetupGuideScreen to handle it
         refreshMissingPermissions()
         refreshAllPermissionsStatus()
 
         setContent {
             OpenClawAssistantTheme {
-                MainScreen(
-                    settings = settings,
-                    diagnostic = voiceDiagnostic,
-                    missingPermissions = missingPermissions,
-                    allPermissionsStatus = allPermissionsStatus,
-                    onOpenSettings = { startActivity(Intent(this, SettingsActivity::class.java)) },
-                    onOpenAssistantSettings = { openAssistantSettings() },
-                    onRefreshDiagnostics = {
-                        initializeTTS() // Re-init on manual refresh
-                        refreshAllPermissionsStatus()
-                    },
-                    onRequestPermissions = { permissions ->
-                        val ungranted = permissions.filter {
-                            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
+                val hasCompletedSetup by remember { mutableStateOf(settings.hasCompletedSetup) }
+                var showSetupGuide by remember { mutableStateOf(!hasCompletedSetup) }
+
+                if (showSetupGuide) {
+                    SetupGuideScreen(
+                        settings = settings,
+                        onComplete = {
+                            showSetupGuide = false
+                            // After setup, we might want to trigger permission refresh or other once
+                            refreshMissingPermissions()
+                            refreshAllPermissionsStatus()
                         }
-                        if (ungranted.isNotEmpty()) {
-                            permissionLauncher.launch(ungranted.toTypedArray())
-                        }
-                    },
-                    onOpenAppSettings = { openAppSettings() }
-                )
+                    )
+                } else {
+                    MainScreen(
+                        settings = settings,
+                        diagnostic = voiceDiagnostic,
+                        missingPermissions = missingPermissions,
+                        allPermissionsStatus = allPermissionsStatus,
+                        onOpenSettings = { startActivity(Intent(this, SettingsActivity::class.java)) },
+                        onOpenAssistantSettings = { openAssistantSettings() },
+                        onRefreshDiagnostics = {
+                            initializeTTS() // Re-init on manual refresh
+                            refreshAllPermissionsStatus()
+                        },
+                        onRequestPermissions = { permissions ->
+                            val ungranted = permissions.filter {
+                                ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
+                            }
+                            if (ungranted.isNotEmpty()) {
+                                permissionLauncher.launch(ungranted.toTypedArray())
+                            }
+                        },
+                        onOpenAppSettings = { openAppSettings() }
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
@@ -141,6 +141,11 @@ class SettingsRepository(context: Context) {
         get() = prefs.getBoolean(KEY_IS_VERIFIED, false)
         set(value) = prefs.edit().putBoolean(KEY_IS_VERIFIED, value).apply()
 
+    // Has completed initial setup guide
+    var hasCompletedSetup: Boolean
+        get() = prefs.getBoolean(KEY_HAS_COMPLETED_SETUP, false)
+        set(value) = prefs.edit().putBoolean(KEY_HAS_COMPLETED_SETUP, value).apply()
+
     // Default Agent ID
     var defaultAgentId: String
         get() = prefs.getString(KEY_DEFAULT_AGENT_ID, "main") ?: "main"
@@ -213,6 +218,7 @@ class SettingsRepository(context: Context) {
         private const val KEY_SPEECH_SILENCE_TIMEOUT = "speech_silence_timeout"
         private const val KEY_THINKING_SOUND_ENABLED = "thinking_sound_enabled"
         private const val KEY_SPEECH_LANGUAGE = "speech_language"
+        private const val KEY_HAS_COMPLETED_SETUP = "has_completed_setup"
 
         // Wake word presets
         const val WAKE_WORD_OPEN_CLAW = "open_claw"

--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
@@ -198,7 +198,14 @@ class GatewaySession(
       val url = "$scheme://${endpoint.host}:${endpoint.port}"
       val httpScheme = if (tls != null) "https" else "http"
       val origin = "$httpScheme://${endpoint.host}:${endpoint.port}"
-      val request = Request.Builder().url(url).header("Origin", origin).build()
+      val request = Request.Builder()
+        .url(url)
+        .header("Origin", origin)
+        .apply {
+          val ua = options.userAgent?.trim()?.takeIf { it.isNotEmpty() }
+          if (ua != null) header("User-Agent", ua)
+        }
+        .build()
       socket = client.newWebSocket(request, Listener())
       try {
         connectDeferred.await()

--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewayTls.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewayTls.kt
@@ -108,17 +108,36 @@ suspend fun probeGatewayTlsFingerprint(
     val context = SSLContext.getInstance("TLS")
     context.init(null, arrayOf(trustAll), SecureRandom())
 
-    // Use createSocket(host, port) to ensure SNI is set automatically by the OS.
+    // Use createSocket() and connect() with timeout to ensure we don't hang on TCP connect.
     var socket: SSLSocket? = null
     try {
-      socket = context.socketFactory.createSocket(trimmedHost, port) as SSLSocket
-      socket.soTimeout = timeoutMs
+      val rawSocket = context.socketFactory.createSocket() as SSLSocket
+      rawSocket.soTimeout = timeoutMs
+      rawSocket.connect(InetSocketAddress(trimmedHost, port), timeoutMs)
+      socket = rawSocket
+
+      // Best-effort SNI for hostnames (avoid crashing on IP literals).
+      try {
+        if (trimmedHost.any { it.isLetter() }) {
+          val params = SSLParameters()
+          params.serverNames = listOf(SNIHostName(trimmedHost))
+          socket.sslParameters = params
+        }
+      } catch (_: Throwable) {
+        // ignore
+      }
       
       socket.startHandshake()
-      val cert = socket.session.peerCertificates.firstOrNull() as? X509Certificate ?: return@withContext null
+      val cert = socket.session.peerCertificates.firstOrNull() as? X509Certificate ?: run {
+          android.util.Log.e("GatewayTls", "Probe failed: Peer certificates empty for $trimmedHost:$port")
+          return@withContext null
+      }
       sha256Hex(cert.encoded)
+    } catch (e: java.net.SocketTimeoutException) {
+      android.util.Log.e("GatewayTls", "Probe timeout ($timeoutMs ms) for $trimmedHost:$port", e)
+      null
     } catch (e: Throwable) {
-      android.util.Log.e("GatewayTls", "Probe failed for $trimmedHost:$port", e)
+      android.util.Log.e("GatewayTls", "Probe failed with exception for $trimmedHost:$port", e)
       null
     } finally {
       try {

--- a/app/src/main/java/com/openclaw/assistant/node/ConnectionManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/ConnectionManager.kt
@@ -25,6 +25,7 @@ class ConnectionManager(
   private val smsAvailable: () -> Boolean,
   private val hasRecordAudioPermission: () -> Boolean,
   private val manualTls: () -> Boolean,
+  private val deviceId: () -> String?,
 ) {
   companion object {
     internal fun resolveTlsParamsForEndpoint(
@@ -147,7 +148,7 @@ class ConnectionManager(
   fun buildClientInfo(clientId: String, clientMode: String): GatewayClientInfo {
     return GatewayClientInfo(
       id = clientId,
-      displayName = prefs.displayName.value,
+      displayName = deviceId() ?: prefs.displayName.value,
       version = resolvedVersionName(),
       platform = "android",
       mode = clientMode,

--- a/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
@@ -131,6 +131,7 @@ class NodeRuntime(context: Context) {
     smsAvailable = { sms.canSendSms() },
     hasRecordAudioPermission = { hasRecordAudioPermission() },
     manualTls = { manualTls.value },
+    deviceId = { deviceId },
   )
 
   private val invokeDispatcher: InvokeDispatcher = InvokeDispatcher(
@@ -588,12 +589,15 @@ class NodeRuntime(context: Context) {
     val tls = connectionManager.resolveTlsParams(endpoint)
     if (tls?.required == true && tls.expectedFingerprint.isNullOrBlank()) {
       // First-time TLS: capture fingerprint, ask user to verify out-of-band, then store and connect.
-      _statusText.value = appContext.getString(R.string.state_verify_fingerprint)
       scope.launch {
+        _statusText.value = appContext.getString(R.string.state_verify_fingerprint)
+        android.util.Log.d("NodeRuntime", "Starting TLS probe for ${endpoint.host}:${endpoint.port}")
         val fp = probeGatewayTlsFingerprint(endpoint.host, endpoint.port) ?: run {
+          android.util.Log.e("NodeRuntime", "TLS probe failed")
           _statusText.value = appContext.getString(R.string.state_failed_fingerprint)
           return@launch
         }
+        android.util.Log.d("NodeRuntime", "TLS probe success, setting pending trust")
         _pendingGatewayTrust.value = GatewayTrustPrompt(endpoint = endpoint, fingerprintSha256 = fp)
       }
       return

--- a/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
@@ -1,0 +1,809 @@
+package com.openclaw.assistant.ui
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
+import com.openclaw.assistant.OpenClawApplication
+import com.openclaw.assistant.R
+import com.openclaw.assistant.api.OpenClawClient
+import com.openclaw.assistant.data.SettingsRepository
+import com.openclaw.assistant.ui.components.ConnectionState
+import com.openclaw.assistant.ui.components.StatusIndicator
+import com.openclaw.assistant.ui.GatewayTrustDialog
+import com.openclaw.assistant.utils.GatewayConfigUtils
+import kotlinx.coroutines.launch
+
+private enum class SetupStep(val index: Int) {
+    Welcome(1),
+    Connection(2),
+    Permissions(3),
+    FinalCheck(4)
+}
+
+private enum class ConnectionMode {
+    SetupCode,
+    Manual
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SetupGuideScreen(
+    settings: SettingsRepository,
+    onComplete: () -> Unit
+) {
+    val context = LocalContext.current
+    val runtime = remember(context.applicationContext) {
+        (context.applicationContext as OpenClawApplication).nodeRuntime
+    }
+
+    var currentStep by rememberSaveable { mutableStateOf(SetupStep.Welcome) }
+
+    // UI State for Connection step
+    var connectionMode by rememberSaveable { mutableStateOf(ConnectionMode.SetupCode) }
+    var setupCode by rememberSaveable { mutableStateOf("") }
+    var manualHost by rememberSaveable { mutableStateOf(runtime.manualHost.value) }
+    var manualPort by rememberSaveable { mutableStateOf(runtime.manualPort.value.toString()) }
+    var manualTls by rememberSaveable { mutableStateOf(runtime.manualTls.value) }
+    var authToken by rememberSaveable { mutableStateOf(settings.authToken) }
+    var manualPassword by rememberSaveable { mutableStateOf(runtime.getGatewayPassword() ?: "") }
+
+    val totalSteps = SetupStep.entries.size
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Column {
+                        Text(
+                            text = stringResource(R.string.setup_guide_first_run),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        Text(
+                            text = stringResource(R.string.setup_guide_step_format, currentStep.index, totalSteps),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
+                },
+                navigationIcon = {
+                    if (currentStep.index > 1) {
+                        IconButton(onClick = {
+                            val prevIndex = currentStep.index - 1
+                            currentStep = SetupStep.entries.first { it.index == prevIndex }
+                        }) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
+                        }
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        val pendingGatewayTrust by runtime.pendingGatewayTrust.collectAsState()
+        if (pendingGatewayTrust != null) {
+            GatewayTrustDialog(
+                prompt = pendingGatewayTrust!!,
+                onAccept = { runtime.acceptGatewayTrustPrompt() },
+                onDecline = { runtime.declineGatewayTrustPrompt() }
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+
+            when (currentStep) {
+                SetupStep.Welcome -> WelcomeStep(
+                    onNext = { currentStep = SetupStep.Connection }
+                )
+                SetupStep.Connection -> ConnectionStep(
+                    mode = connectionMode,
+                    setupCode = setupCode,
+                    manualHost = manualHost,
+                    manualPort = manualPort,
+                    manualTls = manualTls,
+                    authToken = authToken,
+                    manualPassword = manualPassword,
+                    onModeChange = { connectionMode = it },
+                    onSetupCodeChange = { setupCode = it },
+                    onManualHostChange = { manualHost = it },
+                    onManualPortChange = { manualPort = it },
+                    onManualTlsChange = { manualTls = it },
+                    onAuthTokenChange = { authToken = it },
+                    onManualPasswordChange = { manualPassword = it },
+                    onNext = {
+                        // Apply settings
+                        if (connectionMode == ConnectionMode.SetupCode) {
+                            val decoded = GatewayConfigUtils.decodeGatewaySetupCode(setupCode)
+                            if (decoded != null) {
+                                val parsed = GatewayConfigUtils.parseGatewayEndpoint(decoded.url)
+                                if (parsed != null) {
+                                    runtime.setManualHost(parsed.host)
+                                    runtime.setManualPort(parsed.port)
+                                    runtime.setManualTls(parsed.tls)
+                                    // Save to gateway-specific storage (prefs), not HTTP settings
+                                    if (decoded.token != null) {
+                                        runtime.prefs.saveGatewayToken(decoded.token)
+                                    }
+                                    if (decoded.password != null) {
+                                        runtime.setGatewayPassword(decoded.password)
+                                    }
+                                    // Auto-generate HTTP URL and token from gateway endpoint
+                                    GatewayConfigUtils.composeGatewayManualUrl(parsed.host, parsed.port.toString(), parsed.tls)
+                                        ?.let { settings.httpUrl = it }
+                                    decoded.token?.let { settings.authToken = it }
+                                        ?: decoded.password?.let { settings.authToken = it }
+                                }
+                            }
+                        } else {
+                            runtime.setManualHost(manualHost)
+                            runtime.setManualPort(manualPort.toIntOrNull() ?: 18789)
+                            runtime.setManualTls(manualTls)
+                            // Save to gateway-specific storage (prefs), not HTTP settings
+                            runtime.prefs.saveGatewayToken(authToken.trim())
+                            runtime.setGatewayPassword(manualPassword.trim())
+                            // Auto-generate HTTP URL from gateway endpoint
+                            GatewayConfigUtils.composeGatewayManualUrl(manualHost, manualPort, manualTls)
+                                ?.let { settings.httpUrl = it }
+                            // Set HTTP auth token from manual input
+                            if (authToken.isNotBlank()) settings.authToken = authToken.trim()
+                            else if (manualPassword.isNotBlank()) settings.authToken = manualPassword.trim()
+                        }
+                        runtime.setManualEnabled(true)
+                        settings.connectionType = SettingsRepository.CONNECTION_TYPE_GATEWAY
+                        currentStep = SetupStep.Permissions
+                    }
+                )
+                SetupStep.Permissions -> PermissionsStep(
+                    onNext = { currentStep = SetupStep.FinalCheck }
+                )
+                SetupStep.FinalCheck -> FinalCheckStep(
+                    settings = settings,
+                    onFinish = {
+                        settings.hasCompletedSetup = true
+                        onComplete()
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WelcomeStep(onNext: () -> Unit) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Icon(
+            imageVector = Icons.Default.Launch,
+            contentDescription = null,
+            modifier = Modifier.size(80.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = stringResource(R.string.setup_guide_title),
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            lineHeight = 40.sp
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+
+        BulletPoint(stringResource(R.string.setup_guide_welcome_bullet_1))
+        BulletPoint(stringResource(R.string.setup_guide_welcome_bullet_2))
+        BulletPoint(stringResource(R.string.setup_guide_welcome_bullet_3))
+        BulletPoint(stringResource(R.string.setup_guide_welcome_bullet_4))
+
+        Spacer(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(
+            onClick = onNext,
+            modifier = Modifier.fillMaxWidth().height(56.dp),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Text(stringResource(R.string.setup_guide_next), fontSize = 18.sp)
+        }
+    }
+}
+
+@Composable
+private fun BulletPoint(text: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        Icon(
+            Icons.Default.Check,
+            contentDescription = null,
+            modifier = Modifier.size(24.dp).padding(top = 2.dp),
+            tint = MaterialTheme.colorScheme.secondary
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(text = text, style = MaterialTheme.typography.bodyLarge)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ConnectionStep(
+    mode: ConnectionMode,
+    setupCode: String,
+    manualHost: String,
+    manualPort: String,
+    manualTls: Boolean,
+    authToken: String,
+    manualPassword: String,
+    onModeChange: (ConnectionMode) -> Unit,
+    onSetupCodeChange: (String) -> Unit,
+    onManualHostChange: (String) -> Unit,
+    onManualPortChange: (String) -> Unit,
+    onManualTlsChange: (Boolean) -> Unit,
+    onAuthTokenChange: (String) -> Unit,
+    onManualPasswordChange: (String) -> Unit,
+    onNext: () -> Unit
+) {
+    Column {
+        Text(
+            text = stringResource(R.string.setup_guide_connection_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Mode Selector
+        TabRow(
+            selectedTabIndex = if (mode == ConnectionMode.SetupCode) 0 else 1,
+            containerColor = Color.Transparent,
+            divider = {}
+        ) {
+            Tab(
+                selected = mode == ConnectionMode.SetupCode,
+                onClick = { onModeChange(ConnectionMode.SetupCode) },
+                text = { Text(stringResource(R.string.setup_guide_mode_setup_code)) }
+            )
+            Tab(
+                selected = mode == ConnectionMode.Manual,
+                onClick = { onModeChange(ConnectionMode.Manual) },
+                text = { Text(stringResource(R.string.setup_guide_mode_manual)) }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        if (mode == ConnectionMode.SetupCode) {
+            Text(
+                text = stringResource(R.string.setup_guide_connection_guide_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = stringResource(R.string.setup_guide_connection_guide_cmd_1),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+                    .background(Color.Black, RoundedCornerShape(8.dp))
+                    .padding(12.dp)
+            ) {
+                Text(
+                    text = "openclaw qr --setup-code-only",
+                    color = Color.Green,
+                    fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                    fontSize = 12.sp
+                )
+            }
+            Text(
+                text = stringResource(R.string.setup_guide_connection_guide_json_desc),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            OutlinedTextField(
+                value = setupCode,
+                onValueChange = onSetupCodeChange,
+                label = { Text(stringResource(R.string.setup_guide_setup_code_label)) },
+                placeholder = { Text(stringResource(R.string.setup_guide_setup_code_hint)) },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp)
+            )
+
+            val isCodeValid = GatewayConfigUtils.decodeGatewaySetupCode(setupCode) != null
+            if (setupCode.isNotBlank() && !isCodeValid) {
+                Text(
+                    text = stringResource(R.string.setup_guide_invalid_code),
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(start = 16.dp, top = 4.dp)
+                )
+            }
+        } else {
+            // Manual Mode fields
+            OutlinedTextField(
+                value = manualHost,
+                onValueChange = onManualHostChange,
+                label = { Text(stringResource(R.string.setup_guide_manual_host)) },
+                placeholder = { Text("192.168.1.100") },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri)
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            OutlinedTextField(
+                value = manualPort,
+                onValueChange = onManualPortChange,
+                label = { Text(stringResource(R.string.setup_guide_manual_port)) },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.setup_guide_manual_tls), fontWeight = FontWeight.Bold)
+                    Text(stringResource(R.string.setup_guide_manual_tls_desc), style = MaterialTheme.typography.bodySmall)
+                }
+                Switch(checked = manualTls, onCheckedChange = onManualTlsChange)
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            OutlinedTextField(
+                value = authToken,
+                onValueChange = onAuthTokenChange,
+                label = { Text(stringResource(R.string.setup_guide_manual_token)) },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                visualTransformation = PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            OutlinedTextField(
+                value = manualPassword,
+                onValueChange = onManualPasswordChange,
+                label = { Text(stringResource(R.string.setup_guide_manual_password)) },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                visualTransformation = PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        val canContinue = if (mode == ConnectionMode.SetupCode) {
+            GatewayConfigUtils.decodeGatewaySetupCode(setupCode) != null
+        } else {
+            manualHost.isNotBlank() && manualPort.toIntOrNull() != null
+        }
+
+        Button(
+            onClick = onNext,
+            enabled = canContinue,
+            modifier = Modifier.fillMaxWidth().height(56.dp),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Text(stringResource(R.string.setup_guide_next), fontSize = 18.sp)
+        }
+    }
+}
+
+@Composable
+private fun PermissionsStep(onNext: () -> Unit) {
+    val context = LocalContext.current
+    val permissions = remember {
+        mutableListOf(
+            Manifest.permission.RECORD_AUDIO,
+            Manifest.permission.CAMERA,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.SEND_SMS
+        ).apply {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                add(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }
+    }
+
+    var permissionsStatus by remember {
+        mutableStateOf(permissions.associateWith {
+            ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+        })
+    }
+
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { results ->
+        permissionsStatus = results.mapValues { it.value }
+    }
+
+    Column {
+        Text(
+            text = stringResource(R.string.setup_guide_permissions_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.setup_guide_permissions_desc),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        PermissionItem(
+            icon = Icons.Default.Mic,
+            name = stringResource(R.string.permission_record_audio),
+            desc = stringResource(R.string.permission_record_audio_desc),
+            isGranted = permissionsStatus[Manifest.permission.RECORD_AUDIO] == true
+        )
+        PermissionItem(
+            icon = Icons.Default.PhotoCamera,
+            name = stringResource(R.string.capability_camera),
+            desc = stringResource(R.string.permission_camera_desc),
+            isGranted = permissionsStatus[Manifest.permission.CAMERA] == true
+        )
+        PermissionItem(
+            icon = Icons.Default.LocationOn,
+            name = stringResource(R.string.capability_location),
+            desc = stringResource(R.string.permission_location_desc),
+            isGranted = permissionsStatus[Manifest.permission.ACCESS_FINE_LOCATION] == true || permissionsStatus[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            PermissionItem(
+                icon = Icons.Default.Notifications,
+                name = stringResource(R.string.permission_notifications),
+                desc = stringResource(R.string.permission_post_notifications_desc),
+                isGranted = permissionsStatus[Manifest.permission.POST_NOTIFICATIONS] == true
+            )
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(
+            onClick = { launcher.launch(permissions.toTypedArray()) },
+            modifier = Modifier.fillMaxWidth().height(56.dp),
+            shape = RoundedCornerShape(16.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+        ) {
+            Text(stringResource(R.string.grant_permission), fontSize = 18.sp)
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        TextButton(
+            onClick = onNext,
+            modifier = Modifier.fillMaxWidth().height(56.dp)
+        ) {
+            Text(stringResource(R.string.setup_guide_next), fontSize = 18.sp)
+        }
+    }
+}
+
+@Composable
+private fun PermissionItem(
+    icon: ImageVector,
+    name: String,
+    desc: String,
+    isGranted: Boolean
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .background(
+                    if (isGranted) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceVariant,
+                    CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = if (isGranted) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = name, fontWeight = FontWeight.Bold)
+            Text(text = desc, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        if (isGranted) {
+            Icon(Icons.Default.CheckCircle, contentDescription = null, tint = Color.Green)
+        }
+    }
+}
+
+@Composable
+private fun FinalCheckStep(
+    settings: SettingsRepository,
+    onFinish: () -> Unit
+) {
+    val context = LocalContext.current
+    val runtime = remember(context.applicationContext) {
+        (context.applicationContext as OpenClawApplication).nodeRuntime
+    }
+    val isConnected by runtime.isConnected.collectAsState()
+    val statusText by runtime.statusText.collectAsState()
+    val serverName by runtime.serverName.collectAsState()
+    val remoteAddress by runtime.remoteAddress.collectAsState()
+    val manualHost by runtime.manualHost.collectAsState()
+    val manualPort by runtime.manualPort.collectAsState()
+    val manualTls by runtime.manualTls.collectAsState()
+    val isPairingRequired by runtime.isPairingRequired.collectAsState()
+
+    val scope = rememberCoroutineScope()
+    val apiClient = remember { OpenClawClient() }
+    var attemptedConnect by remember { mutableStateOf(false) }
+    var pairingDetected by remember { mutableStateOf(false) }
+    var isFinishing by remember { mutableStateOf(false) }
+
+    val finishWithHttpTest: () -> Unit = {
+        scope.launch {
+            isFinishing = true
+            if (settings.httpUrl.isNotBlank()) {
+                val testUrl = settings.getChatCompletionsUrl()
+                val result = apiClient.testConnection(testUrl, settings.authToken)
+                if (result.isSuccess) {
+                    settings.isVerified = true
+                } else {
+                    // HTTP test failed: skip HTTP config
+                    settings.httpUrl = ""
+                    settings.authToken = ""
+                    settings.isVerified = false
+                }
+            }
+            isFinishing = false
+            onFinish()
+        }
+    }
+
+    LaunchedEffect(isPairingRequired) {
+        if (isPairingRequired) pairingDetected = true
+    }
+
+    val gatewayUrl = remember(manualHost, manualPort, manualTls) {
+        "${if (manualTls) "https" else "http"}://$manualHost:$manualPort"
+    }
+    val hasToken = remember { runtime.prefs.loadGatewayToken()?.isNotBlank() == true }
+    val hasPassword = remember { runtime.getGatewayPassword()?.isNotBlank() == true }
+    val authLabel = when {
+        hasToken && hasPassword -> stringResource(R.string.setup_guide_auth_token_password)
+        hasToken -> stringResource(R.string.setup_guide_auth_token)
+        hasPassword -> stringResource(R.string.setup_guide_auth_password)
+        else -> stringResource(R.string.setup_guide_auth_none)
+    }
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = stringResource(R.string.setup_guide_final_check_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.setup_guide_final_check_desc),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Gateway URL + auth summary
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp))
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = stringResource(R.string.setup_guide_gateway_label),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.width(72.dp)
+                )
+                Text(
+                    text = gatewayUrl,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = stringResource(R.string.setup_guide_auth_label),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.width(72.dp)
+                )
+                Text(
+                    text = authLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        if (!attemptedConnect) {
+            Text(
+                text = stringResource(R.string.setup_guide_test_connection_desc),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        } else {
+            StatusIndicator(
+                state = if (isConnected) ConnectionState.Connected else ConnectionState.Disconnected,
+                label = statusText,
+                modifier = Modifier.padding(16.dp)
+            )
+
+            if (isConnected && (serverName != null || remoteAddress != null)) {
+                Text(
+                    text = stringResource(R.string.setup_guide_connected_to, serverName ?: remoteAddress ?: ""),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+
+            if (!isConnected && pairingDetected) {
+                Spacer(modifier = Modifier.height(8.dp))
+                PairingGuideBlock(deviceId = runtime.deviceId)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        if (isConnected) {
+            Button(
+                onClick = finishWithHttpTest,
+                enabled = !isFinishing,
+                modifier = Modifier.fillMaxWidth().height(56.dp),
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                if (isFinishing) {
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp), color = MaterialTheme.colorScheme.onPrimary, strokeWidth = 2.dp)
+                } else {
+                    Text(stringResource(R.string.setup_guide_finish), fontSize = 18.sp)
+                }
+            }
+        } else {
+            Button(
+                onClick = {
+                    attemptedConnect = true
+                    pairingDetected = false
+                    runtime.connectManual()
+                },
+                modifier = Modifier.fillMaxWidth().height(56.dp),
+                shape = RoundedCornerShape(16.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+            ) {
+                Text(stringResource(R.string.test_connection_button), fontSize = 18.sp)
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            TextButton(
+                onClick = finishWithHttpTest,
+                enabled = !isFinishing,
+                modifier = Modifier.fillMaxWidth().height(48.dp)
+            ) {
+                if (isFinishing) {
+                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                } else {
+                    Text(stringResource(R.string.setup_guide_finish), fontSize = 16.sp)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PairingGuideBlock(deviceId: String?) {
+    val approveCmd = if (deviceId != null) {
+        "openclaw devices approve $deviceId"
+    } else {
+        "openclaw devices approve <RequestId>"
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp))
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.setup_guide_pairing_required),
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = stringResource(R.string.setup_guide_pairing_run_on_host),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        CommandBlock("openclaw devices list")
+        CommandBlock(approveCmd)
+        Text(
+            text = stringResource(R.string.setup_guide_pairing_retest_desc),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun CommandBlock(command: String) {
+    val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.Black, RoundedCornerShape(6.dp))
+            .combinedClickable(
+                onClick = {},
+                onLongClick = {
+                    clipboardManager.setText(AnnotatedString(command))
+                    android.widget.Toast.makeText(context, context.getString(R.string.setup_guide_copied), android.widget.Toast.LENGTH_SHORT).show()
+                }
+            )
+            .padding(10.dp)
+    ) {
+        Text(
+            text = command,
+            color = Color.Green,
+            fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+            fontSize = 12.sp
+        )
+    }
+}

--- a/app/src/main/java/com/openclaw/assistant/utils/GatewayConfigUtils.kt
+++ b/app/src/main/java/com/openclaw/assistant/utils/GatewayConfigUtils.kt
@@ -1,0 +1,81 @@
+package com.openclaw.assistant.utils
+
+import android.util.Base64
+import androidx.core.net.toUri
+import java.util.Locale
+import org.json.JSONObject
+
+data class GatewayEndpointConfig(
+    val host: String,
+    val port: Int,
+    val tls: Boolean,
+    val displayUrl: String
+)
+
+data class GatewaySetupCode(
+    val url: String,
+    val token: String?,
+    val password: String?
+)
+
+object GatewayConfigUtils {
+
+    fun parseGatewayEndpoint(rawInput: String): GatewayEndpointConfig? {
+        val raw = rawInput.trim()
+        if (raw.isEmpty()) return null
+
+        val normalized = if (raw.contains("://")) raw else "https://$raw"
+        val uri = normalized.toUri()
+        val host = uri.host?.trim().orEmpty()
+        if (host.isEmpty()) return null
+
+        val scheme = uri.scheme?.trim()?.lowercase(Locale.US).orEmpty()
+        val tls = when (scheme) {
+            "ws", "http" -> false
+            "wss", "https" -> true
+            else -> true
+        }
+        val defaultPort = when (scheme) {
+            "wss", "https" -> 443
+            "ws", "http" -> 80
+            else -> 443
+        }
+        val port = uri.port.takeIf { it in 1..65535 } ?: defaultPort
+        val displayUrl = "${if (tls) "https" else "http"}://$host:$port"
+
+        return GatewayEndpointConfig(host = host, port = port, tls = tls, displayUrl = displayUrl)
+    }
+
+    fun decodeGatewaySetupCode(rawInput: String): GatewaySetupCode? {
+        val trimmed = rawInput.trim()
+        if (trimmed.isEmpty()) return null
+
+        val padded = trimmed
+            .replace('-', '+')
+            .replace('_', '/')
+            .let { normalized ->
+                val remainder = normalized.length % 4
+                if (remainder == 0) normalized else normalized + "=".repeat(4 - remainder)
+            }
+
+        return try {
+            val decoded = String(Base64.decode(padded, Base64.DEFAULT), Charsets.UTF_8)
+            val obj = JSONObject(decoded)
+            val url = obj.optString("url").trim()
+            if (url.isEmpty()) return null
+            val token = obj.optString("token").trim().ifEmpty { null }
+            val password = obj.optString("password").trim().ifEmpty { null }
+            GatewaySetupCode(url = url, token = token, password = password)
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    fun composeGatewayManualUrl(hostInput: String, portInput: String, tls: Boolean): String? {
+        val host = hostInput.trim()
+        val port = portInput.trim().toIntOrNull() ?: return null
+        if (host.isEmpty() || port !in 1..65535) return null
+        val scheme = if (tls) "https" else "http"
+        return "$scheme://$host:$port"
+    }
+}

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -375,4 +375,58 @@
     <string name="update_available">新しいバージョン (%s) が利用可能です</string>
     <string name="up_to_date">最新バージョンです</string>
     <string name="update_action">更新</string>
+
+    <!-- セットアップガイド -->
+    <string name="setup_guide_first_run">初回起動</string>
+    <string name="setup_guide_title">OpenClaw Assistant\nセットアップガイド</string>
+    <string name="setup_guide_step_format">ステップ %1$d / %2$d</string>
+    <string name="setup_guide_welcome_title">できること</string>
+    <string name="setup_guide_welcome_bullet_1">モバイルからGatewayの操作やAIとのチャットが可能です。</string>
+    <string name="setup_guide_welcome_bullet_2">セットアップコードで簡単に接続でき、CLIコマンドでペアリングも可能です。</string>
+    <string name="setup_guide_welcome_bullet_3">必要な権限や機能だけを自由に有効化できます。</string>
+    <string name="setup_guide_welcome_bullet_4">アプリを使い始める前に、実際の接続テストを行えます。</string>
+    <string name="setup_guide_connection_title">Gateway接続設定</string>
+    <string name="setup_guide_connection_guide_title">セットアップコードとURLの取得</string>
+    <string name="setup_guide_connection_guide_cmd_1">Gatewayホストで以下のコマンドを実行してください：</string>
+    <string name="setup_guide_connection_guide_json_desc">`--json` を指定すると `setupCode` と `gatewayUrl` が表示されます。</string>
+    <string name="setup_guide_connection_discovery_desc">自動URL検出は未実装です。エミュレータは `10.0.2.2` を、実機はLAN内またはTailscaleのホスト名を使用してください。</string>
+    <string name="setup_guide_mode_setup_code">セットアップコード</string>
+    <string name="setup_guide_mode_manual">手動入力</string>
+    <string name="setup_guide_setup_code_label">セットアップコード</string>
+    <string name="setup_guide_setup_code_hint">`openclaw qr --setup-code-only` で取得したコードを貼り付けてください</string>
+    <string name="setup_guide_manual_host">ホスト</string>
+    <string name="setup_guide_manual_port">ポート</string>
+    <string name="setup_guide_manual_tls">TLSを使用</string>
+    <string name="setup_guide_manual_tls_desc">セキュアなWebSocket (`wss`) に切り替えます。</string>
+    <string name="setup_guide_manual_token">トークン (任意)</string>
+    <string name="setup_guide_manual_password">パスワード (任意)</string>
+    <string name="setup_guide_permissions_title">権限の設定</string>
+    <string name="setup_guide_permissions_desc">OpenClawの機能を利用するために必要な権限を許可します。</string>
+    <string name="setup_guide_final_check_title">最終確認</string>
+    <string name="setup_guide_final_check_desc">接続と設定内容を確認します。</string>
+    <string name="setup_guide_finish">完了</string>
+    <string name="setup_guide_next">次へ</string>
+    <string name="setup_guide_invalid_code">セットアップコードが無効です。</string>
+    <string name="setup_guide_invalid_url">GatewayのURLが無効です。</string>
+
+    <!-- Setup Code Apply & HTTP Sync -->
+    <string name="http_use_gateway_url">GatewayのURLを使用</string>
+    <string name="setup_code_applied">設定を適用しました！</string>
+    <string name="setup_code_invalid_code">セットアップコードが無効または不完全です。</string>
+
+    <!-- Additional Setup Guide Strings (JA) -->
+    <string name="permission_camera_desc">AIがカメラ映像を確認するために必要です</string>
+    <string name="permission_location_desc">AIがあなたの現在地を把握するために必要です</string>
+    <string name="setup_guide_auth_token_password">トークン + パスワード</string>
+    <string name="setup_guide_auth_token">トークン</string>
+    <string name="setup_guide_auth_password">パスワード</string>
+    <string name="setup_guide_auth_none">なし</string>
+    <string name="setup_guide_gateway_label">Gateway</string>
+    <string name="setup_guide_auth_label">認証</string>
+    <string name="setup_guide_test_connection_desc">接続テストを押して、Gatewayへの到達性を確認してください。</string>
+    <string name="setup_guide_connected_to">%s に接続しました</string>
+    <string name="setup_guide_pairing_required">ペアリングが必要です</string>
+    <string name="setup_guide_pairing_run_on_host">Gatewayホストで以下を実行してください：</string>
+    <string name="setup_guide_pairing_retest_desc">完了後、再度接続テストをタップしてください。</string>
+    <string name="setup_guide_copied">コピーしました</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -372,4 +372,58 @@
     <string name="update_available">New version (%s) available</string>
     <string name="up_to_date">App is up to date</string>
     <string name="update_action">Update</string>
+
+    <!-- Setup Guide -->
+    <string name="setup_guide_first_run">FIRST RUN</string>
+    <string name="setup_guide_title">OpenClaw Assistant\nMobile Setup</string>
+    <string name="setup_guide_step_format">Step %1$d of %2$d</string>
+    <string name="setup_guide_welcome_title">What You Get</string>
+    <string name="setup_guide_welcome_bullet_1">Control the gateway and operator chat from one mobile surface.</string>
+    <string name="setup_guide_welcome_bullet_2">Connect with setup code and recover pairing with CLI commands.</string>
+    <string name="setup_guide_welcome_bullet_3">Enable only the permissions and capabilities you want.</string>
+    <string name="setup_guide_welcome_bullet_4">Finish with a real connection check before entering the app.</string>
+    <string name="setup_guide_connection_title">Gateway Connection</string>
+    <string name="setup_guide_connection_guide_title">Get setup code + gateway URL</string>
+    <string name="setup_guide_connection_guide_cmd_1">Run these on the gateway host:</string>
+    <string name="setup_guide_connection_guide_json_desc">`--json` prints `setupCode` and `gatewayUrl`.</string>
+    <string name="setup_guide_connection_discovery_desc">Auto URL discovery is not wired yet. Android emulator uses `10.0.2.2`; real devices need LAN/Tailscale host.</string>
+    <string name="setup_guide_mode_setup_code">Setup Code</string>
+    <string name="setup_guide_mode_manual">Manual</string>
+    <string name="setup_guide_setup_code_label">SETUP CODE</string>
+    <string name="setup_guide_setup_code_hint">Paste code from `openclaw qr --setup-code-only`</string>
+    <string name="setup_guide_manual_host">HOST</string>
+    <string name="setup_guide_manual_port">PORT</string>
+    <string name="setup_guide_manual_tls">Use TLS</string>
+    <string name="setup_guide_manual_tls_desc">Switch to secure websocket (`wss`).</string>
+    <string name="setup_guide_manual_token">TOKEN (OPTIONAL)</string>
+    <string name="setup_guide_manual_password">PASSWORD (OPTIONAL)</string>
+    <string name="setup_guide_permissions_title">Permissions</string>
+    <string name="setup_guide_permissions_desc">Grant permissions to enable OpenClaw features.</string>
+    <string name="setup_guide_final_check_title">Final Check</string>
+    <string name="setup_guide_final_check_desc">Verify connection and settings.</string>
+    <string name="setup_guide_finish">Finish</string>
+    <string name="setup_guide_next">Next</string>
+    <string name="setup_guide_invalid_code">Invalid setup code.</string>
+    <string name="setup_guide_invalid_url">Invalid gateway URL.</string>
+
+    <!-- Setup Code Apply & HTTP Sync -->
+    <string name="http_use_gateway_url">Use Gateway URL</string>
+    <string name="setup_code_applied">Settings applied!</string>
+    <string name="setup_code_invalid_code">Invalid or incomplete setup code.</string>
+
+    <!-- Additional Setup Guide Strings -->
+    <string name="permission_camera_desc">Required for the AI to see your camera stream</string>
+    <string name="permission_location_desc">Required for the AI to know your location</string>
+    <string name="setup_guide_auth_token_password">Token + Password</string>
+    <string name="setup_guide_auth_token">Token</string>
+    <string name="setup_guide_auth_password">Password</string>
+    <string name="setup_guide_auth_none">None</string>
+    <string name="setup_guide_gateway_label">Gateway</string>
+    <string name="setup_guide_auth_label">Auth</string>
+    <string name="setup_guide_test_connection_desc">Press Test Connection to verify gateway reachability.</string>
+    <string name="setup_guide_connected_to">Connected to %s</string>
+    <string name="setup_guide_pairing_required">Pairing Required</string>
+    <string name="setup_guide_pairing_run_on_host">Run these on the gateway host:</string>
+    <string name="setup_guide_pairing_retest_desc">Then tap Test Connection again.</string>
+    <string name="setup_guide_copied">Copied</string>
 </resources>


### PR DESCRIPTION
## Summary

- **First-run setup wizard** (`SetupGuideScreen`): 4-step guide (Welcome → Connection → Permissions → Final Check) shown on first app launch instead of the main screen. Supports setup-code and manual connection modes.
- **Gateway → HTTP auto-config**: Applying a setup code or completing the setup guide now auto-populates the HTTP server URL and auth token from the gateway endpoint, so users don't have to configure HTTP manually.
- **HTTP test on finish**: `finishWithHttpTest` runs an HTTP connection test when completing the setup guide. If the test fails, HTTP settings are cleared (skipped) rather than saved as unverified.
- **Fix chat type availability after setup**: Added `runtime.setManualEnabled(true)` in `ConnectionStep.onNext` so `isGatewayConfigured` is correctly `true` after the wizard — both Gateway and HTTP chat creation are available in `SessionListActivity`.
- **Settings screen improvements**: "Apply" button for setup-code field (replaces per-keystroke auto-apply); "Use Gateway URL" button in the HTTP tab.
- **`GatewayConfigUtils`**: New utility file with helpers for decoding setup codes, parsing gateway endpoints, and composing HTTP URLs.
- **TLS / WebSocket fixes**: Better TLS fingerprint probe (connect-with-timeout, best-effort SNI), User-Agent header support in `GatewaySession`, `deviceId` lambda wired into `ConnectionManager`.

## Test plan

- [ ] Fresh install: setup guide appears; entering a valid setup code and tapping Next fills Gateway fields and HTTP URL
- [ ] Setup guide: Final Check with successful HTTP test → both Gateway and HTTP chat options appear in new-chat FAB
- [ ] Setup guide: Final Check with failing HTTP test → only Gateway chat option appears; HTTP settings are blank
- [ ] Settings screen: Setup Code tab → type code → tap Apply → fields populated, success message shown
- [ ] Settings screen: HTTP tab → "Use Gateway URL" button fills server URL from current gateway config
- [ ] Second launch: setup guide is skipped, main screen shown directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)