### PR TITLE
fix(chat): strip gateway metadata in ChatActivity

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import com.openclaw.assistant.OpenClawApplication
 import com.openclaw.assistant.api.OpenClawClient
 import com.openclaw.assistant.data.SettingsRepository
+import com.openclaw.assistant.chat.ChatMarkdownPreprocessor
 import com.openclaw.assistant.gateway.AgentInfo
 import com.openclaw.assistant.speech.SpeechRecognizerManager
 import com.openclaw.assistant.speech.SpeechResult
@@ -857,10 +858,11 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun com.openclaw.assistant.chat.ChatMessage.toUiChatMessage(): ChatMessage {
         val mergedText = content.joinToString("\n") { it.text ?: "" }.trim().ifBlank { "(no text)" }
+        val preprocessed = ChatMarkdownPreprocessor.preprocess(mergedText)
         val isUserMessage = role.equals("user", ignoreCase = true)
         return ChatMessage(
             id = id,
-            text = mergedText,
+            text = preprocessed,
             isUser = isUserMessage,
             timestamp = timestampMs ?: System.currentTimeMillis()
         )


### PR DESCRIPTION
## Summary

- Fixed an issue where `MessageBubble` in `ChatActivity` was using `MarkdownText` without passing it through `ChatMarkdownPreprocessor`.
- Added the preprocessor to `toUiChatMessage()` to remove metadata blocks injected by the gateway (e.g., `Conversation info (untrusted metadata):`) at the data transformation layer.

## Root Cause

Based on gateway logs, `sessions.patch` was failing with `missing scope: operator.admin`, causing the conversation label to remain as the device name. This resulted in metadata like `"conversation_label": "Flip7"` being injected.

The `ChatMarkdownPreprocessor` was originally only connected to the overlay UI (`ChatSheetContent` → `ChatMarkdown`) and was not applied in `ChatActivity`, causing the metadata to be displayed as is.

## Test plan

- [ ] Create a new Gateway chat while connected to the gateway.
- [ ] Verify that the `Conversation info (untrusted metadata):` block is no longer displayed.
- [ ] Confirm that normal message sending and receiving function correctly.

Fixes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)