### PR TITLE
feat: update default configuration for continuous mode and permissions

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SecurePrefs.kt
+++ b/app/src/main/java/com/openclaw/assistant/SecurePrefs.kt
@@ -42,7 +42,7 @@ class SecurePrefs(context: Context) {
     MutableStateFlow(loadOrMigrateDisplayName(context = context))
   val displayName: StateFlow<String> = _displayName
 
-  private val _cameraEnabled = MutableStateFlow(prefs.getBoolean("camera.enabled", true))
+  private val _cameraEnabled = MutableStateFlow(prefs.getBoolean("camera.enabled", false))
   val cameraEnabled: StateFlow<Boolean> = _cameraEnabled
 
   private val _locationMode =
@@ -50,10 +50,10 @@ class SecurePrefs(context: Context) {
   val locationMode: StateFlow<LocationMode> = _locationMode
 
   private val _locationPreciseEnabled =
-    MutableStateFlow(prefs.getBoolean("location.preciseEnabled", true))
+    MutableStateFlow(prefs.getBoolean("location.preciseEnabled", false))
   val locationPreciseEnabled: StateFlow<Boolean> = _locationPreciseEnabled
 
-  private val _preventSleep = MutableStateFlow(prefs.getBoolean("screen.preventSleep", true))
+  private val _preventSleep = MutableStateFlow(prefs.getBoolean("screen.preventSleep", false))
   val preventSleep: StateFlow<Boolean> = _preventSleep
 
   private val _manualEnabled =

--- a/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
@@ -97,7 +97,7 @@ class SettingsRepository(context: Context) {
 
     // Continuous mode
     var continuousMode: Boolean
-        get() = prefs.getBoolean(KEY_CONTINUOUS_MODE, false)
+        get() = prefs.getBoolean(KEY_CONTINUOUS_MODE, true)
         set(value) = prefs.edit().putBoolean(KEY_CONTINUOUS_MODE, value).apply()
 
     // Resume Latest Session


### PR DESCRIPTION
## Overview
This PR updates the default configuration values to improve user experience and ensure privacy.

## Changes
- **Continuous Conversation**: Set the default value of `continuousMode` to `true` (ON) in `SettingsRepository`. This allows users to engage in looping voice conversations by default.
- **Privacy & Permissions**: Reset the default values to `false` (OFF) for the following features in `SecurePrefs`:
  - Camera access
  - Precise location tracking
  - Screen sleep prevention (prevent sleep)

These updates ensure that voice features are ready to use out-of-the-box while hardware permissions remain disabled until explicitly authorized by the user.