### PR TITLE
Add Notification Tools Support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -213,6 +213,7 @@ dependencies {
 
     // Testing
     testImplementation("junit:junit:4.13.2")
+    testImplementation("io.mockk:mockk:1.13.9")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.10.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     testImplementation("io.kotest:kotest-runner-junit5-jvm:5.8.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -177,6 +177,17 @@
             android:name=".receiver.InstallResultReceiver"
             android:exported="false" />
 
+        <!-- Notification Listener Service -->
+        <service
+            android:name="com.openclaw.assistant.service.OpenClawNotificationListenerService"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/openclaw/assistant/node/ConnectionManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/ConnectionManager.kt
@@ -11,6 +11,7 @@ import com.openclaw.assistant.protocol.OpenClawCanvasA2UICommand
 import com.openclaw.assistant.protocol.OpenClawCanvasCommand
 import com.openclaw.assistant.protocol.OpenClawCameraCommand
 import com.openclaw.assistant.protocol.OpenClawLocationCommand
+import com.openclaw.assistant.protocol.OpenClawNotificationCommand
 import com.openclaw.assistant.protocol.OpenClawScreenCommand
 import com.openclaw.assistant.protocol.OpenClawSmsCommand
 import com.openclaw.assistant.protocol.OpenClawCapability
@@ -23,6 +24,7 @@ class ConnectionManager(
   private val locationMode: () -> LocationMode,
   private val voiceWakeMode: () -> VoiceWakeMode,
   private val smsAvailable: () -> Boolean,
+  private val notificationsAvailable: () -> Boolean,
   private val hasRecordAudioPermission: () -> Boolean,
   private val manualTls: () -> Boolean,
   private val deviceId: () -> String?,
@@ -101,6 +103,10 @@ class ConnectionManager(
       if (smsAvailable()) {
         add(OpenClawSmsCommand.Send.rawValue)
       }
+      if (notificationsAvailable()) {
+        add(OpenClawNotificationCommand.List.rawValue)
+        add(OpenClawNotificationCommand.Action.rawValue)
+      }
       if (BuildConfig.DEBUG) {
         add("debug.logs")
         add("debug.ed25519")
@@ -119,6 +125,9 @@ class ConnectionManager(
       }
       if (locationMode() != LocationMode.Off) {
         add(OpenClawCapability.Location.rawValue)
+      }
+      if (notificationsAvailable()) {
+        add(OpenClawCapability.Notifications.rawValue)
       }
     }
 

--- a/app/src/main/java/com/openclaw/assistant/node/InvokeDispatcher.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/InvokeDispatcher.kt
@@ -5,6 +5,7 @@ import com.openclaw.assistant.protocol.OpenClawCanvasA2UICommand
 import com.openclaw.assistant.protocol.OpenClawCanvasCommand
 import com.openclaw.assistant.protocol.OpenClawCameraCommand
 import com.openclaw.assistant.protocol.OpenClawLocationCommand
+import com.openclaw.assistant.protocol.OpenClawNotificationCommand
 import com.openclaw.assistant.protocol.OpenClawScreenCommand
 import com.openclaw.assistant.protocol.OpenClawSmsCommand
 
@@ -14,6 +15,7 @@ class InvokeDispatcher(
   private val locationHandler: LocationHandler,
   private val screenHandler: ScreenHandler,
   private val smsHandler: SmsHandler,
+  private val notificationHandler: NotificationHandler,
   private val a2uiHandler: A2UIHandler,
   private val debugHandler: DebugHandler,
   private val appUpdateHandler: AppUpdateHandler,
@@ -158,6 +160,10 @@ class InvokeDispatcher(
 
       // SMS command
       OpenClawSmsCommand.Send.rawValue -> smsHandler.handleSmsSend(paramsJson)
+
+      // Notifications commands
+      OpenClawNotificationCommand.List.rawValue -> notificationHandler.handleList()
+      OpenClawNotificationCommand.Action.rawValue -> notificationHandler.handleAction(paramsJson)
 
       // Debug commands
       "debug.ed25519" -> debugHandler.handleEd25519()

--- a/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
@@ -58,6 +58,7 @@ class NodeRuntime(context: Context) {
   val location = LocationCaptureManager(appContext)
   val screenRecorder = ScreenRecordManager(appContext)
   val sms = SmsManager(appContext)
+  val notifications = NotificationManager(appContext)
   private val json = Json { ignoreUnknownKeys = true }
 
   private val externalAudioCaptureActive = MutableStateFlow(false)
@@ -116,6 +117,10 @@ class NodeRuntime(context: Context) {
     sms = sms,
   )
 
+  private val notificationHandler: NotificationHandler = NotificationHandler(
+    notificationManager = notifications,
+  )
+
   private val a2uiHandler: A2UIHandler = A2UIHandler(
     canvas = canvas,
     json = json,
@@ -129,6 +134,7 @@ class NodeRuntime(context: Context) {
     locationMode = { locationMode.value },
     voiceWakeMode = { voiceWakeMode.value },
     smsAvailable = { sms.canSendSms() },
+    notificationsAvailable = { notifications.isAccessGranted() },
     hasRecordAudioPermission = { hasRecordAudioPermission() },
     manualTls = { manualTls.value },
     deviceId = { deviceId },
@@ -140,6 +146,7 @@ class NodeRuntime(context: Context) {
     locationHandler = locationHandler,
     screenHandler = screenHandler,
     smsHandler = smsHandlerImpl,
+    notificationHandler = notificationHandler,
     a2uiHandler = a2uiHandler,
     debugHandler = debugHandler,
     appUpdateHandler = appUpdateHandler,

--- a/app/src/main/java/com/openclaw/assistant/node/NotificationHandler.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/NotificationHandler.kt
@@ -1,0 +1,31 @@
+package com.openclaw.assistant.node
+
+import com.openclaw.assistant.gateway.GatewaySession
+
+class NotificationHandler(
+    private val notificationManager: NotificationManager
+) {
+    fun handleList(): GatewaySession.InvokeResult {
+        val result = notificationManager.listNotifications()
+        return if (result.ok) {
+            GatewaySession.InvokeResult.ok(result.payloadJson)
+        } else {
+            GatewaySession.InvokeResult.error(
+                code = result.error ?: "NOTIFICATION_LIST_FAILED",
+                message = result.payloadJson
+            )
+        }
+    }
+
+    suspend fun handleAction(paramsJson: String?): GatewaySession.InvokeResult {
+        val result = notificationManager.performAction(paramsJson)
+        return if (result.ok) {
+            GatewaySession.InvokeResult.ok(result.payloadJson)
+        } else {
+            GatewaySession.InvokeResult.error(
+                code = result.error ?: "NOTIFICATION_ACTION_FAILED",
+                message = result.payloadJson
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/openclaw/assistant/node/NotificationManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/NotificationManager.kt
@@ -1,0 +1,196 @@
+package com.openclaw.assistant.node
+
+import android.app.Notification
+import android.app.RemoteInput
+import android.content.Context
+import android.os.Bundle
+import com.openclaw.assistant.service.OpenClawNotificationListenerService
+import kotlinx.serialization.json.*
+
+class NotificationManager(private val context: Context) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    data class NotificationResult(
+        val ok: Boolean,
+        val error: String? = null,
+        val payloadJson: String,
+    )
+
+    fun isAccessGranted(): Boolean {
+        return OpenClawNotificationListenerService.getConnectedInstance() != null
+    }
+
+    fun listNotifications(): NotificationResult {
+        val service = OpenClawNotificationListenerService.getConnectedInstance()
+            ?: return NotificationResult(
+                ok = false,
+                error = "NOTIFICATION_ACCESS_DENIED",
+                payloadJson = """{"error":"NOTIFICATION_ACCESS_DENIED: enable notification access for OpenClaw in Android Settings"}"""
+            )
+
+        val notifications = try {
+            service.activeNotifications ?: emptyArray()
+        } catch (e: Exception) {
+            return NotificationResult(
+                ok = false,
+                error = "NOTIFICATION_LIST_FAILED",
+                payloadJson = """{"error":"NOTIFICATION_LIST_FAILED: ${e.message}"}"""
+            )
+        }
+
+        val list = notifications.map { sbn ->
+            val n = sbn.notification
+            val extras = n.extras
+            buildJsonObject {
+                put("key", sbn.key)
+                put("package", sbn.packageName)
+                put("title", extras.getCharSequence(Notification.EXTRA_TITLE)?.toString() ?: "")
+                put("text", extras.getCharSequence(Notification.EXTRA_TEXT)?.toString() ?: "")
+                put("subText", extras.getCharSequence(Notification.EXTRA_SUB_TEXT)?.toString() ?: "")
+                put("postTime", sbn.postTime)
+                put("isClearable", sbn.isClearable)
+                put("isOngoing", sbn.isOngoing)
+
+                val actions = n.actions?.mapIndexed { index, action ->
+                    buildJsonObject {
+                        put("id", index)
+                        put("title", action.title?.toString() ?: "")
+                        put("hasRemoteInput", action.remoteInputs?.isNotEmpty() == true)
+                    }
+                } ?: emptyList()
+                put("actions", JsonArray(actions))
+            }
+        }
+
+        return NotificationResult(
+            ok = true,
+            payloadJson = buildJsonObject {
+                put("notifications", JsonArray(list))
+            }.toString()
+        )
+    }
+
+    suspend fun performAction(paramsJson: String?): NotificationResult {
+        val service = OpenClawNotificationListenerService.getConnectedInstance()
+            ?: return NotificationResult(
+                ok = false,
+                error = "NOTIFICATION_ACCESS_DENIED",
+                payloadJson = """{"error":"NOTIFICATION_ACCESS_DENIED: enable notification access for OpenClaw in Android Settings"}"""
+            )
+
+        val params = try {
+            paramsJson?.let { json.parseToJsonElement(it).jsonObject }
+        } catch (e: Exception) {
+            null
+        } ?: return NotificationResult(
+            ok = false,
+            error = "INVALID_REQUEST",
+            payloadJson = """{"error":"INVALID_REQUEST: valid JSON params required"}"""
+        )
+
+        val key = params["key"]?.jsonPrimitive?.content
+            ?: return NotificationResult(
+                ok = false,
+                error = "INVALID_REQUEST",
+                payloadJson = """{"error":"INVALID_REQUEST: 'key' required"}"""
+            )
+
+        val action = params["action"]?.jsonPrimitive?.content
+            ?: return NotificationResult(
+                ok = false,
+                error = "INVALID_REQUEST",
+                payloadJson = """{"error":"INVALID_REQUEST: 'action' required"}"""
+            )
+
+        val sbn = try {
+            service.activeNotifications?.find { it.key == key }
+        } catch (e: Exception) {
+            null
+        } ?: return NotificationResult(
+            ok = false,
+            error = "NOTIFICATION_NOT_FOUND",
+            payloadJson = """{"error":"NOTIFICATION_NOT_FOUND: notification with key $key not found"}"""
+        )
+
+        return when (action) {
+            "dismiss" -> {
+                if (sbn.isClearable) {
+                    service.cancelNotification(sbn.key)
+                    NotificationResult(ok = true, payloadJson = """{"ok":true}""")
+                } else {
+                    NotificationResult(
+                        ok = false,
+                        error = "NOTIFICATION_NOT_CLEARABLE",
+                        payloadJson = """{"error":"NOTIFICATION_NOT_CLEARABLE"}"""
+                    )
+                }
+            }
+            "open" -> {
+                try {
+                    sbn.notification.contentIntent?.send()
+                    NotificationResult(ok = true, payloadJson = """{"ok":true}""")
+                } catch (e: Exception) {
+                    NotificationResult(
+                        ok = false,
+                        error = "ACTION_FAILED",
+                        payloadJson = """{"error":"${e.message}"}"""
+                    )
+                }
+            }
+            "reply" -> {
+                val text = params["text"]?.jsonPrimitive?.content
+                    ?: return NotificationResult(
+                        ok = false,
+                        error = "INVALID_REQUEST",
+                        payloadJson = """{"error":"INVALID_REQUEST: 'text' required for reply"}"""
+                    )
+
+                val replyAction = sbn.notification.actions?.find { it.remoteInputs?.isNotEmpty() == true }
+                    ?: return NotificationResult(
+                        ok = false,
+                        error = "REPLY_NOT_SUPPORTED",
+                        payloadJson = """{"error":"REPLY_NOT_SUPPORTED: notification does not support remote input reply"}"""
+                    )
+
+                try {
+                    val remoteInput = replyAction.remoteInputs[0]
+                    val intent = android.content.Intent()
+                    val bundle = Bundle()
+                    bundle.putCharSequence(remoteInput.resultKey, text)
+                    RemoteInput.addResultsToIntent(replyAction.remoteInputs, intent, bundle)
+                    replyAction.actionIntent.send(context, 0, intent)
+                    NotificationResult(ok = true, payloadJson = """{"ok":true}""")
+                } catch (e: Exception) {
+                    NotificationResult(
+                        ok = false,
+                        error = "ACTION_FAILED",
+                        payloadJson = """{"error":"${e.message}"}"""
+                    )
+                }
+            }
+            else -> {
+                // Check if it's a numeric action ID
+                val actionId = action.toIntOrNull()
+                if (actionId != null && sbn.notification.actions != null && actionId >= 0 && actionId < sbn.notification.actions.size) {
+                    val customAction = sbn.notification.actions[actionId]
+                    try {
+                        customAction.actionIntent.send()
+                        NotificationResult(ok = true, payloadJson = """{"ok":true}""")
+                    } catch (e: Exception) {
+                        NotificationResult(
+                            ok = false,
+                            error = "ACTION_FAILED",
+                            payloadJson = """{"error":"${e.message}"}"""
+                        )
+                    }
+                } else {
+                    NotificationResult(
+                        ok = false,
+                        error = "INVALID_ACTION",
+                        payloadJson = """{"error":"INVALID_ACTION: $action"}"""
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/openclaw/assistant/protocol/OpenClawProtocolConstants.kt
+++ b/app/src/main/java/com/openclaw/assistant/protocol/OpenClawProtocolConstants.kt
@@ -7,6 +7,17 @@ enum class OpenClawCapability(val rawValue: String) {
     Sms("sms"),
     VoiceWake("voiceWake"),
     Location("location"),
+    Notifications("notifications"),
+}
+
+enum class OpenClawNotificationCommand(val rawValue: String) {
+    List("notifications.list"),
+    Action("notifications.action"),
+    ;
+
+    companion object {
+        const val NamespacePrefix: String = "notifications."
+    }
 }
 
 enum class OpenClawCanvasCommand(val rawValue: String) {

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawNotificationListenerService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawNotificationListenerService.kt
@@ -1,0 +1,33 @@
+package com.openclaw.assistant.service
+
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Service to listen for and interact with system notifications.
+ * Must be enabled by the user in Android Settings.
+ */
+class OpenClawNotificationListenerService : NotificationListenerService() {
+
+    override fun onListenerConnected() {
+        super.onListenerConnected()
+        instance.set(this)
+    }
+
+    override fun onListenerDisconnected() {
+        super.onListenerDisconnected()
+        instance.set(null)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        instance.set(null)
+    }
+
+    companion object {
+        private val instance = AtomicReference<OpenClawNotificationListenerService?>()
+
+        fun getConnectedInstance(): OpenClawNotificationListenerService? = instance.get()
+    }
+}

--- a/app/src/test/java/com/openclaw/assistant/node/NotificationManagerTest.kt
+++ b/app/src/test/java/com/openclaw/assistant/node/NotificationManagerTest.kt
@@ -1,0 +1,46 @@
+package com.openclaw.assistant.node
+
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class NotificationManagerTest {
+
+    private lateinit var notificationManager: NotificationManager
+
+    @Before
+    fun setup() {
+        // We use a real instance but it won't have the service connected in test environment
+        notificationManager = NotificationManager(FakeContext())
+    }
+
+    @Test
+    fun `isAccessGranted returns false when service is not connected`() {
+        assertFalse(notificationManager.isAccessGranted())
+    }
+
+    @Test
+    fun `listNotifications returns error when access is denied`() {
+        val result = notificationManager.listNotifications()
+
+        assertFalse(result.ok)
+        assertEquals("NOTIFICATION_ACCESS_DENIED", result.error)
+        assertTrue(result.payloadJson.contains("NOTIFICATION_ACCESS_DENIED"))
+    }
+
+    @Test
+    fun `performAction returns error when access is denied`() = kotlinx.coroutines.test.runTest {
+        val result = notificationManager.performAction("""{"key":"test","action":"dismiss"}""")
+
+        assertFalse(result.ok)
+        assertEquals("NOTIFICATION_ACCESS_DENIED", result.error)
+        assertTrue(result.payloadJson.contains("NOTIFICATION_ACCESS_DENIED"))
+    }
+
+    private class FakeContext : android.content.ContextWrapper(null) {
+        override fun getPackageName(): String = "com.openclaw.assistant"
+    }
+}


### PR DESCRIPTION
This change implements parity for notification tools in the Android application. It introduces a `NotificationListenerService` that allows the assistant to list active notifications and perform actions such as dismissing, opening, or replying to them. The functionality is exposed via the `notifications.list` and `notifications.action` commands and is only advertised as a capability if the user has granted the necessary notification access permission.

Fixes #167

---
*PR created automatically by Jules for task [11155076285905737219](https://jules.google.com/task/11155076285905737219) started by @yuga-hashimoto*