### PR TITLE
Parity: Implement device introspection commands

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/ConnectionManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/ConnectionManager.kt
@@ -10,6 +10,7 @@ import com.openclaw.assistant.gateway.GatewayTlsParams
 import com.openclaw.assistant.protocol.OpenClawCanvasA2UICommand
 import com.openclaw.assistant.protocol.OpenClawCanvasCommand
 import com.openclaw.assistant.protocol.OpenClawCameraCommand
+import com.openclaw.assistant.protocol.OpenClawDeviceCommand
 import com.openclaw.assistant.protocol.OpenClawLocationCommand
 import com.openclaw.assistant.protocol.OpenClawScreenCommand
 import com.openclaw.assistant.protocol.OpenClawSmsCommand
@@ -91,6 +92,7 @@ class ConnectionManager(
       add(OpenClawCanvasA2UICommand.PushJSONL.rawValue)
       add(OpenClawCanvasA2UICommand.Reset.rawValue)
       add(OpenClawScreenCommand.Record.rawValue)
+      OpenClawDeviceCommand.entries.forEach { add(it.rawValue) }
       if (cameraEnabled()) {
         add(OpenClawCameraCommand.Snap.rawValue)
         add(OpenClawCameraCommand.Clip.rawValue)

--- a/app/src/main/java/com/openclaw/assistant/node/DeviceHandler.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/DeviceHandler.kt
@@ -1,0 +1,114 @@
+package com.openclaw.assistant.node
+
+import android.Manifest
+import android.app.ActivityManager
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.os.BatteryManager
+import android.os.Build
+import android.os.Environment
+import android.os.PowerManager
+import android.os.StatFs
+import androidx.core.content.ContextCompat
+import com.openclaw.assistant.BuildConfig
+import com.openclaw.assistant.gateway.GatewaySession
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+class DeviceHandler(private val appContext: Context) {
+
+  fun handleDeviceInfo(): GatewaySession.InvokeResult {
+    val payload = buildJsonObject {
+      put("model", JsonPrimitive(Build.MODEL))
+      put("manufacturer", JsonPrimitive(Build.MANUFACTURER))
+      put("androidVersion", JsonPrimitive(Build.VERSION.RELEASE))
+      put("sdkInt", JsonPrimitive(Build.VERSION.SDK_INT))
+      put("appVersion", JsonPrimitive(BuildConfig.VERSION_NAME))
+    }
+    return GatewaySession.InvokeResult.ok(payload.toString())
+  }
+
+  fun handleDeviceStatus(): GatewaySession.InvokeResult {
+    val batteryStatus: Intent? = IntentFilter(Intent.ACTION_BATTERY_CHANGED).let { ifilter ->
+      appContext.registerReceiver(null, ifilter)
+    }
+    val status = batteryStatus?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
+    val isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING ||
+        status == BatteryManager.BATTERY_STATUS_FULL
+    val level = batteryStatus?.let { intent ->
+      val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+      val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+      if (level != -1 && scale != -1) (level * 100 / scale.toFloat()).toInt() else null
+    }
+
+    val powerManager = appContext.getSystemService(Context.POWER_SERVICE) as PowerManager
+    val isInteractive = powerManager.isInteractive
+
+    val payload = buildJsonObject {
+      put("battery", buildJsonObject {
+        put("level", if (level != null) JsonPrimitive(level) else JsonPrimitive(-1))
+        put("isCharging", JsonPrimitive(isCharging))
+      })
+      put("screen", buildJsonObject {
+        put("isInteractive", JsonPrimitive(isInteractive))
+      })
+    }
+    return GatewaySession.InvokeResult.ok(payload.toString())
+  }
+
+  fun handleDevicePermissions(): GatewaySession.InvokeResult {
+    val cameraGranted = try { hasPermission(Manifest.permission.CAMERA) } catch (e: Throwable) { false }
+    val micGranted = try { hasPermission(Manifest.permission.RECORD_AUDIO) } catch (e: Throwable) { false }
+    val fineLocationGranted = try { hasPermission(Manifest.permission.ACCESS_FINE_LOCATION) } catch (e: Throwable) { false }
+    val coarseLocationGranted = try { hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION) } catch (e: Throwable) { false }
+    val backgroundLocationGranted = try {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        hasPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+      } else {
+        fineLocationGranted || coarseLocationGranted
+      }
+    } catch (e: Throwable) { false }
+    val smsGranted = try { hasPermission(Manifest.permission.SEND_SMS) } catch (e: Throwable) { false }
+
+    val payload = buildJsonObject {
+      put("camera", JsonPrimitive(cameraGranted))
+      put("microphone", JsonPrimitive(micGranted))
+      put("location", buildJsonObject {
+        put("fine", JsonPrimitive(fineLocationGranted))
+        put("coarse", JsonPrimitive(coarseLocationGranted))
+        put("background", JsonPrimitive(backgroundLocationGranted))
+      })
+      put("sms", JsonPrimitive(smsGranted))
+    }
+    return GatewaySession.InvokeResult.ok(payload.toString())
+  }
+
+  fun handleDeviceHealth(): GatewaySession.InvokeResult {
+    val activityManager = appContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+    val memoryInfo = ActivityManager.MemoryInfo()
+    activityManager.getMemoryInfo(memoryInfo)
+
+    val stat = StatFs(Environment.getDataDirectory().path)
+    val totalStorage = stat.totalBytes
+    val availableStorage = stat.availableBytes
+
+    val payload = buildJsonObject {
+      put("memory", buildJsonObject {
+        put("total", JsonPrimitive(memoryInfo.totalMem))
+        put("available", JsonPrimitive(memoryInfo.availMem))
+        put("lowMemory", JsonPrimitive(memoryInfo.lowMemory))
+      })
+      put("storage", buildJsonObject {
+        put("total", JsonPrimitive(totalStorage))
+        put("available", JsonPrimitive(availableStorage))
+      })
+    }
+    return GatewaySession.InvokeResult.ok(payload.toString())
+  }
+
+  private fun hasPermission(permission: String): Boolean {
+    return ContextCompat.checkSelfPermission(appContext, permission) == PackageManager.PERMISSION_GRANTED
+  }
+}

--- a/app/src/main/java/com/openclaw/assistant/node/InvokeDispatcher.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/InvokeDispatcher.kt
@@ -4,6 +4,7 @@ import com.openclaw.assistant.gateway.GatewaySession
 import com.openclaw.assistant.protocol.OpenClawCanvasA2UICommand
 import com.openclaw.assistant.protocol.OpenClawCanvasCommand
 import com.openclaw.assistant.protocol.OpenClawCameraCommand
+import com.openclaw.assistant.protocol.OpenClawDeviceCommand
 import com.openclaw.assistant.protocol.OpenClawLocationCommand
 import com.openclaw.assistant.protocol.OpenClawScreenCommand
 import com.openclaw.assistant.protocol.OpenClawSmsCommand
@@ -14,6 +15,7 @@ class InvokeDispatcher(
   private val locationHandler: LocationHandler,
   private val screenHandler: ScreenHandler,
   private val smsHandler: SmsHandler,
+  private val deviceHandler: DeviceHandler,
   private val a2uiHandler: A2UIHandler,
   private val debugHandler: DebugHandler,
   private val appUpdateHandler: AppUpdateHandler,
@@ -158,6 +160,12 @@ class InvokeDispatcher(
 
       // SMS command
       OpenClawSmsCommand.Send.rawValue -> smsHandler.handleSmsSend(paramsJson)
+
+      // Device commands
+      OpenClawDeviceCommand.Info.rawValue -> deviceHandler.handleDeviceInfo()
+      OpenClawDeviceCommand.Status.rawValue -> deviceHandler.handleDeviceStatus()
+      OpenClawDeviceCommand.Permissions.rawValue -> deviceHandler.handleDevicePermissions()
+      OpenClawDeviceCommand.Health.rawValue -> deviceHandler.handleDeviceHealth()
 
       // Debug commands
       "debug.ed25519" -> debugHandler.handleEd25519()

--- a/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
@@ -116,6 +116,10 @@ class NodeRuntime(context: Context) {
     sms = sms,
   )
 
+  private val deviceHandler: DeviceHandler = DeviceHandler(
+    appContext = appContext,
+  )
+
   private val a2uiHandler: A2UIHandler = A2UIHandler(
     canvas = canvas,
     json = json,
@@ -140,6 +144,7 @@ class NodeRuntime(context: Context) {
     locationHandler = locationHandler,
     screenHandler = screenHandler,
     smsHandler = smsHandlerImpl,
+    deviceHandler = deviceHandler,
     a2uiHandler = a2uiHandler,
     debugHandler = debugHandler,
     appUpdateHandler = appUpdateHandler,

--- a/app/src/main/java/com/openclaw/assistant/protocol/OpenClawProtocolConstants.kt
+++ b/app/src/main/java/com/openclaw/assistant/protocol/OpenClawProtocolConstants.kt
@@ -69,3 +69,15 @@ enum class OpenClawLocationCommand(val rawValue: String) {
         const val NamespacePrefix: String = "location."
     }
 }
+
+enum class OpenClawDeviceCommand(val rawValue: String) {
+    Status("device.status"),
+    Info("device.info"),
+    Permissions("device.permissions"),
+    Health("device.health"),
+    ;
+
+    companion object {
+        const val NamespacePrefix: String = "device."
+    }
+}

--- a/app/src/test/java/com/openclaw/assistant/node/DeviceHandlerProtocolTest.kt
+++ b/app/src/test/java/com/openclaw/assistant/node/DeviceHandlerProtocolTest.kt
@@ -1,0 +1,89 @@
+package com.openclaw.assistant.node
+
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+class DeviceHandlerProtocolTest {
+
+    @Test
+    fun testDeviceInfoPayloadShape() {
+        val payload = buildJsonObject {
+            put("model", JsonPrimitive("Test Model"))
+            put("manufacturer", JsonPrimitive("Test Manufacturer"))
+            put("androidVersion", JsonPrimitive("13"))
+            put("sdkInt", JsonPrimitive(33))
+            put("appVersion", JsonPrimitive("1.2.3"))
+        }
+        val json = payload.toString()
+        assertTrue(json.contains("model"))
+        assertTrue(json.contains("manufacturer"))
+        assertTrue(json.contains("androidVersion"))
+        assertTrue(json.contains("sdkInt"))
+        assertTrue(json.contains("appVersion"))
+    }
+
+    @Test
+    fun testDeviceStatusPayloadShape() {
+        val payload = buildJsonObject {
+            put("battery", buildJsonObject {
+                put("level", JsonPrimitive(85))
+                put("isCharging", JsonPrimitive(true))
+            })
+            put("screen", buildJsonObject {
+                put("isInteractive", JsonPrimitive(true))
+            })
+        }
+        val json = payload.toString()
+        assertTrue(json.contains("battery"))
+        assertTrue(json.contains("level"))
+        assertTrue(json.contains("isCharging"))
+        assertTrue(json.contains("screen"))
+        assertTrue(json.contains("isInteractive"))
+    }
+
+    @Test
+    fun testDevicePermissionsPayloadShape() {
+        val payload = buildJsonObject {
+            put("camera", JsonPrimitive(true))
+            put("microphone", JsonPrimitive(true))
+            put("location", buildJsonObject {
+                put("fine", JsonPrimitive(true))
+                put("coarse", JsonPrimitive(true))
+                put("background", JsonPrimitive(true))
+            })
+            put("sms", JsonPrimitive(true))
+        }
+        val json = payload.toString()
+        assertTrue(json.contains("camera"))
+        assertTrue(json.contains("microphone"))
+        assertTrue(json.contains("location"))
+        assertTrue(json.contains("fine"))
+        assertTrue(json.contains("coarse"))
+        assertTrue(json.contains("background"))
+        assertTrue(json.contains("sms"))
+    }
+
+    @Test
+    fun testDeviceHealthPayloadShape() {
+        val payload = buildJsonObject {
+            put("memory", buildJsonObject {
+                put("total", JsonPrimitive(8000000000L))
+                put("available", JsonPrimitive(4000000000L))
+                put("lowMemory", JsonPrimitive(false))
+            })
+            put("storage", buildJsonObject {
+                put("total", JsonPrimitive(128000000000L))
+                put("available", JsonPrimitive(64000000000L))
+            })
+        }
+        val json = payload.toString()
+        assertTrue(json.contains("memory"))
+        assertTrue(json.contains("total"))
+        assertTrue(json.contains("available"))
+        assertTrue(json.contains("lowMemory"))
+        assertTrue(json.contains("storage"))
+    }
+}


### PR DESCRIPTION
Implemented the missing `device.status`, `device.info`, `device.permissions`, and `device.health` commands to achieve parity with the official OpenClaw app. The implementation uses standard Android APIs to retrieve device information, battery/screen status, permission states, and system health metrics. The commands are correctly wired into the node's invocation dispatcher and advertised to the gateway.

Fixes #168

---
*PR created automatically by Jules for task [7512062375099847820](https://jules.google.com/task/7512062375099847820) started by @yuga-hashimoto*