### PR TITLE
feat(http): support self-signed HTTPS certificates

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -240,13 +240,14 @@ fun SettingsScreen(
     var showAuthToken by rememberSaveable { mutableStateOf(false) }
     var showWakeWordMenu by rememberSaveable { mutableStateOf(false) }
     var showLanguageMenu by rememberSaveable { mutableStateOf(false) }
-    
+    var httpIgnoreSslErrors by rememberSaveable { mutableStateOf(settings.httpIgnoreSslErrors) }
+
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val runtime = remember(context.applicationContext) {
         (context.applicationContext as OpenClawApplication).nodeRuntime
     }
-    val apiClient = remember { OpenClawClient() }
+    val apiClient = remember(httpIgnoreSslErrors) { OpenClawClient(ignoreSslErrors = httpIgnoreSslErrors) }
     
     var isTesting by rememberSaveable { mutableStateOf(false) }
     var testResult by remember { mutableStateOf<TestResult?>(null) }
@@ -412,6 +413,7 @@ fun SettingsScreen(
                             // Save HTTP Settings
                             settings.httpUrl = httpInputUrl.trim()
                             settings.authToken = httpToken.trim()
+                            settings.httpIgnoreSslErrors = httpIgnoreSslErrors
 
                             settings.defaultAgentId = defaultAgentId
                             settings.ttsEnabled = ttsEnabled
@@ -829,6 +831,24 @@ fun SettingsScreen(
 
                             Spacer(modifier = Modifier.height(12.dp))
 
+                            // Ignore SSL Errors Toggle
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(stringResource(R.string.http_ignore_ssl_errors), style = MaterialTheme.typography.bodyLarge)
+                                    Text(stringResource(R.string.http_ignore_ssl_errors_desc), style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+                                }
+                                Switch(
+                                    checked = httpIgnoreSslErrors,
+                                    onCheckedChange = { httpIgnoreSslErrors = it; testResult = null }
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.height(12.dp))
+
                             // Test Connection Button
                             Button(
                                 onClick = {
@@ -846,6 +866,7 @@ fun SettingsScreen(
                                                     testResult = TestResult(success = true, message = context.getString(R.string.connected))
                                                     settings.httpUrl = httpInputUrl.trim()
                                                     settings.authToken = httpToken.trim()
+                                                    settings.httpIgnoreSslErrors = httpIgnoreSslErrors
                                                     settings.isVerified = true
                                                 },
                                                 onFailure = {

--- a/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
+++ b/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
@@ -11,18 +11,34 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
+import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509TrustManager
 
 /**
  * Simple client - POSTs to the configured HTTP connection
  */
-class OpenClawClient {
+class OpenClawClient(private val ignoreSslErrors: Boolean = false) {
 
-    private val client = OkHttpClient.Builder()
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .readTimeout(120, TimeUnit.SECONDS)
-        .writeTimeout(30, TimeUnit.SECONDS)
-        .build()
+    private val client: OkHttpClient = run {
+        val builder = OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(120, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+        if (ignoreSslErrors) {
+            val trustAll = object : X509TrustManager {
+                override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
+                override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}
+                override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+            }
+            val sslContext = SSLContext.getInstance("TLS")
+            sslContext.init(null, arrayOf(trustAll), null)
+            builder.sslSocketFactory(sslContext.socketFactory, trustAll)
+                .hostnameVerifier { _, _ -> true }
+        }
+        builder.build()
+    }
 
     private val gson = Gson()
 

--- a/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
@@ -209,6 +209,11 @@ class SettingsRepository(context: Context) {
         get() = prefs.getString(KEY_CONNECTION_TYPE, CONNECTION_TYPE_GATEWAY) ?: CONNECTION_TYPE_GATEWAY
         set(value) = prefs.edit().putString(KEY_CONNECTION_TYPE, value).apply()
 
+    // Ignore SSL certificate errors for HTTPS connections (for self-signed certs)
+    var httpIgnoreSslErrors: Boolean
+        get() = prefs.getBoolean(KEY_HTTP_IGNORE_SSL_ERRORS, false)
+        set(value) = prefs.edit().putBoolean(KEY_HTTP_IGNORE_SSL_ERRORS, value).apply()
+
     /**
      * Get the chat completions URL.
      * Supports both base URL (http://server) and full path (http://server/v1/chat/completions).
@@ -263,6 +268,7 @@ class SettingsRepository(context: Context) {
         private const val KEY_DEFAULT_AGENT_ID = "default_agent_id"
         private const val KEY_USE_NODE_CHAT = "use_node_chat"
         private const val KEY_CONNECTION_TYPE = "connection_type"
+        private const val KEY_HTTP_IGNORE_SSL_ERRORS = "http_ignore_ssl_errors"
         private const val KEY_SPEECH_SILENCE_TIMEOUT = "speech_silence_timeout"
         private const val KEY_THINKING_SOUND_ENABLED = "thinking_sound_enabled"
         private const val KEY_SPEECH_LANGUAGE = "speech_language"

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
@@ -69,7 +69,7 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
     }
 
     private val settings = SettingsRepository.getInstance(context)
-    private val apiClient = OpenClawClient()
+    private val apiClient = OpenClawClient(ignoreSslErrors = settings.httpIgnoreSslErrors)
     private lateinit var speechManager: SpeechRecognizerManager
     private lateinit var ttsManager: TTSManager
     

--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
@@ -60,7 +60,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
 
     private val settings = SettingsRepository.getInstance(application)
     private val chatRepository = com.openclaw.assistant.data.repository.ChatRepository.getInstance(application)
-    private val apiClient = OpenClawClient()
+    private val apiClient = OpenClawClient(ignoreSslErrors = settings.httpIgnoreSslErrors)
     private val nodeRuntime = (application as OpenClawApplication).nodeRuntime
     private val speechManager = SpeechRecognizerManager(application)
     private val toneGenerator = android.media.ToneGenerator(android.media.AudioManager.STREAM_MUSIC, 100)

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -169,6 +169,8 @@
     <string name="tab_http">HTTP</string>
     <string name="gateway_configuration">ゲートウェイ設定</string>
     <string name="http_api_configuration">HTTP API設定</string>
+    <string name="http_ignore_ssl_errors">SSL証明書エラーを無視</string>
+    <string name="http_ignore_ssl_errors_desc">自己署名証明書や無効なHTTPS証明書を許可します。信頼できるネットワークでのみ使用してください。</string>
     <string name="enter_session_name">セッション名を入力</string>
     <string name="session_name_optional">セッション名（任意）</string>
     <string name="running_tools">ツールを実行中</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -417,6 +417,8 @@
     <string name="tab_http">HTTP</string>
     <string name="gateway_configuration">Gateway Configuration</string>
     <string name="http_api_configuration">HTTP API Configuration</string>
+    <string name="http_ignore_ssl_errors">Ignore SSL Certificate Errors</string>
+    <string name="http_ignore_ssl_errors_desc">Allow self-signed or invalid HTTPS certificates. Use only on trusted networks.</string>
     <string name="enter_session_name">Enter session name</string>
     <string name="session_name_optional">Session Name (Optional)</string>
     <string name="running_tools">Running tools</string>


### PR DESCRIPTION
## Summary

Fixes #166

- Adds an **"Ignore SSL Certificate Errors"** toggle in Settings → HTTP tab
- When enabled, `OpenClawClient` uses a trust-all `X509TrustManager` and hostname verifier, allowing HTTPS connections to servers with self-signed or invalid certificates
- The setting is persisted and applied automatically in both the Chat screen and the voice overlay

## Security Note

The toggle is disabled by default and shows a warning description. Users should only enable it on trusted private networks (e.g. home lab, corporate VPN). The toggle label explicitly says "Use only on trusted networks."

## Test plan

- [ ] HTTPS server with self-signed cert → toggle OFF → "Test Connection" fails with SSL error (existing behavior)
- [ ] HTTPS server with self-signed cert → toggle ON → "Test Connection" succeeds
- [ ] Toggle persists across app restarts
- [ ] HTTP (non-TLS) server → behavior unchanged regardless of toggle
- [ ] Gateway connection mode → SSL toggle has no effect (Gateway uses its own TLS pinning)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)