### PR TITLE
fix(ci): use shared debug keystore to prevent conflicting app signature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,26 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Setup debug keystore
+        env:
+          DEBUG_KEYSTORE_B64: ${{ secrets.DEBUG_KEYSTORE_B64 }}
+        run: |
+          mkdir -p ~/.android
+          if [ -n "$DEBUG_KEYSTORE_B64" ]; then
+            # Own-repo PR: use shared keystore so APKs from different PRs share the same signature
+            echo "$DEBUG_KEYSTORE_B64" | base64 -d > ~/.android/debug.keystore
+          else
+            # Fork PR: generate a temporary keystore (expected – forks can't share secrets)
+            keytool -genkey -v \
+              -keystore ~/.android/debug.keystore \
+              -storepass android \
+              -alias androiddebugkey \
+              -keypass android \
+              -keyalg RSA -keysize 2048 -validity 10000 \
+              -dname "CN=Android Debug,O=Android,C=US" \
+              -noprompt
+          fi
+
       - name: Setup google-services.json
         env:
           DEBUG_GOOGLE_SERVICES_JSON: ${{ secrets.DEBUG_GOOGLE_SERVICES_JSON }}


### PR DESCRIPTION
## 問題

CIが毎回新しい debug.keystore を生成するため、PR ごとに APK の署名が異なります。
別の PR でインストール済みの APK の上に新しい APK をインストールしようとすると `INSTALL_FAILED_UPDATE_INCOMPATIBLE` (conflicting app signature) が発生します。

## 対策

共有の debug keystore を `DEBUG_KEYSTORE_B64` GitHub Secret に保存し、CI でそれを `~/.android/debug.keystore`（Android Gradle Plugin のデフォルトパス）に展開します。これにより全 PR で署名が一致します。

Fork PR はシークレットにアクセスできないため、一時的な keystore を生成します（フォークでは従来通り）。

## セットアップ手順（1回だけ実施）

### 1. debug.keystore を生成

```bash
keytool -genkey -v \
  -keystore debug.keystore \
  -storepass android \
  -alias androiddebugkey \
  -keypass android \
  -keyalg RSA -keysize 2048 -validity 10000 \
  -dname "CN=Android Debug,O=Android,C=US" \
  -noprompt
```

> すでに `~/.android/debug.keystore` がある場合はそれをそのまま使えます。

### 2. base64 エンコードしてシークレットに登録

```bash
# macOS
base64 -i debug.keystore | pbcopy
```

GitHub → Settings → Secrets and variables → Actions → **New repository secret**  
名前: `DEBUG_KEYSTORE_B64`  
値: クリップボードの内容をペースト

## Test plan
- [ ] このブランチの CI が通ること
- [ ] ダウンロードした APK を、別の PR の APK がインストール済みの端末にインストールできること

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)