### PR TITLE
fix: align approve command format with setup guide

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -745,10 +745,7 @@ fun MainScreen(
 @Composable
 fun OperatorOfflineCard(deviceId: String, displayName: String = "") {
     val context = LocalContext.current
-    val safeName = displayName.replace("\\", "\\\\").replace("'", "\\'")
-    val safeId = deviceId.replace("\\", "\\\\").replace("'", "\\'")
-    val pythonScript = "import sys,json;d=json.load(sys.stdin);ids={'$safeName','$safeId'};r=next((x for x in d.get('pending',[]) if any(str(v) in ids for v in x.values())),None);print(next((str(v) for k,v in (r or {}).items() if k.lower()=='request'),'NOT_FOUND'))"
-    val command = "openclaw devices approve \$(openclaw devices list --json | python3 -c \"$pythonScript\")"
+    val command = "openclaw devices approve $deviceId"
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(

--- a/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
@@ -31,13 +31,8 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
     val nodeRuntime = remember { (context.applicationContext as OpenClawApplication).nodeRuntime }
     val clipboardManager = remember { context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager }
 
-    // Command generation — match any field value against known identifiers (name or device ID hash).
-    // This avoids depending on specific field names that may change across openclaw versions.
-    val safeName = displayName.replace("\\", "\\\\").replace("'", "\\'")
-    val safeId = deviceId.replace("\\", "\\\\").replace("'", "\\'")
-    val pythonScript = "import sys,json;d=json.load(sys.stdin);ids={'$safeName','$safeId'};[print(v) for x in d.get('pending',[]) if any(str(v) in ids for v in x.values()) for k,v in x.items() if k.lower() in ('request','requestid')]"
-    val approveCommand = "openclaw devices list --json | python3 -c \"$pythonScript\" | while read id; do openclaw devices approve \"\$id\"; done"
-    val rejectCommand = "openclaw devices list --json | python3 -c \"$pythonScript\" | while read id; do openclaw devices reject \"\$id\"; done"
+    val approveCommand = "openclaw devices approve $deviceId"
+    val rejectCommand = "openclaw devices reject $deviceId"
 
     var expanded by remember { mutableStateOf(false) }
 


### PR DESCRIPTION
## Summary
- `OperatorOfflineCard` と `PairingRequiredCard` で表示される approve コマンドを、SetupGuideScreen と同じ形式に統一
- Python スクリプトを使ったデバイス ID ルックアップを削除し、`openclaw devices approve $deviceId` の直接形式に変更

## Test plan
- [ ] PairingRequired 状態でコマンドが `openclaw devices approve <hash>` 形式で表示されることを確認
- [ ] OperatorOffline 状態でコマンドが同形式で表示されることを確認
- [ ] SetupGuideScreen の表示と一致していることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)