### PR TITLE
fix(tts): send Preparing state before speak() in AndroidTTSProvider

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/speech/AndroidTTSProvider.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/AndroidTTSProvider.kt
@@ -207,9 +207,9 @@ class AndroidTTSProvider(private val context: Context) : TTSProvider {
 
         if (isInitialized) {
             setupVoice()
+            trySend(TTSState.Preparing)
             tts?.setOnUtteranceProgressListener(listener)
             tts?.speak(text, TextToSpeech.QUEUE_FLUSH, null, utteranceId)
-            trySend(TTSState.Preparing)
         } else {
             trySend(TTSState.Error(context.getString(R.string.tts_error_not_initialized)))
             close()


### PR DESCRIPTION
## Summary
- `TTSState.Preparing` was emitted **after** `tts.speak()` was called in `AndroidTTSProvider.speakWithProgress()`
- On fast TTS engines, `TTSState.Speaking` (from `onStart` callback) could arrive before `Preparing`, causing incorrect state ordering
- Fixed by moving `trySend(TTSState.Preparing)` to before `setOnUtteranceProgressListener()`, consistent with `OpenAIProvider` and `ElevenLabsProvider`

## Test plan
- [ ] Start a voice conversation using Android native TTS (local provider)
- [ ] Verify TTS plays correctly without UI glitches
- [ ] Verify log shows `Preparing` before `Speaking` in logcat

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)