### PR TITLE
feat(android): support selecting any file type for chat attachments

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatComposer.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatComposer.kt
@@ -50,7 +50,7 @@ fun ChatComposer(
   thinkingLevel: String,
   pendingRunCount: Int,
   errorText: String?,
-  attachments: List<PendingImageAttachment>,
+  attachments: List<PendingFileAttachment>,
   onPickImages: () -> Unit,
   onRemoveAttachment: (id: String) -> Unit,
   onSetThinkingLevel: (level: String) -> Unit,
@@ -246,7 +246,7 @@ private fun thinkingLabel(raw: String): String {
 
 @Composable
 private fun AttachmentsStrip(
-  attachments: List<PendingImageAttachment>,
+  attachments: List<PendingFileAttachment>,
   onRemoveAttachment: (id: String) -> Unit,
 ) {
   Row(

--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatSheetContent.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatSheetContent.kt
@@ -48,7 +48,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
   val resolver = context.contentResolver
   val scope = rememberCoroutineScope()
 
-  val attachments = remember { mutableStateListOf<PendingImageAttachment>() }
+  val attachments = remember { mutableStateListOf<PendingFileAttachment>() }
 
   val pickImages =
     rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { uris ->
@@ -57,7 +57,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
         val next =
           uris.take(8).mapNotNull { uri ->
             try {
-              loadImageAttachment(resolver, uri)
+              loadFileAttachment(resolver, uri)
             } catch (_: Throwable) {
               null
             }
@@ -92,7 +92,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
       pendingRunCount = pendingRunCount,
       errorText = errorText,
       attachments = attachments,
-      onPickImages = { pickImages.launch("image/*") },
+      onPickImages = { pickImages.launch("*/*") },
       onRemoveAttachment = { id -> attachments.removeAll { it.id == id } },
       onSetThinkingLevel = { level -> viewModel.setChatThinkingLevel(level) },
       onSelectSession = { key -> viewModel.switchChatSession(key) },
@@ -104,8 +104,10 @@ fun ChatSheetContent(viewModel: MainViewModel) {
       onSend = { text ->
         val outgoing =
           attachments.map { att ->
+            // If the MIME type indicates an image, use "image", otherwise use "document" (or "file" depending on backend support)
+            val attachType = if (att.mimeType.startsWith("image/")) "image" else "document"
             OutgoingAttachment(
-              type = "image",
+              type = attachType,
               mimeType = att.mimeType,
               fileName = att.fileName,
               base64 = att.base64,
@@ -118,16 +120,16 @@ fun ChatSheetContent(viewModel: MainViewModel) {
   }
 }
 
-data class PendingImageAttachment(
+data class PendingFileAttachment(
   val id: String,
   val fileName: String,
   val mimeType: String,
   val base64: String,
 )
 
-private suspend fun loadImageAttachment(resolver: ContentResolver, uri: Uri): PendingImageAttachment {
-  val mimeType = resolver.getType(uri) ?: "image/*"
-  val fileName = (uri.lastPathSegment ?: "image").substringAfterLast('/')
+private suspend fun loadFileAttachment(resolver: ContentResolver, uri: Uri): PendingFileAttachment {
+  val mimeType = resolver.getType(uri) ?: "application/octet-stream"
+  val fileName = (uri.lastPathSegment ?: "file").substringAfterLast('/')
   val bytes =
     withContext(Dispatchers.IO) {
       resolver.openInputStream(uri)?.use { input ->
@@ -138,7 +140,7 @@ private suspend fun loadImageAttachment(resolver: ContentResolver, uri: Uri): Pe
     }
   if (bytes.isEmpty()) throw IllegalStateException("empty attachment")
   val base64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
-  return PendingImageAttachment(
+  return PendingFileAttachment(
     id = uri.toString() + "#" + System.currentTimeMillis().toString(),
     fileName = fileName,
     mimeType = mimeType,


### PR DESCRIPTION
## Description
This PR modifies the Android app's file picker to allow selecting any file type (`*/*`) instead of just images (`image/*`). It also updates the attachment data structure to correctly identify non-image files as `document` attachments, making the system more robust for future backend support.

## Changes
- Changed `ActivityResultContracts.GetMultipleContents()` to accept `*/*`.
- Renamed `PendingImageAttachment` to `PendingFileAttachment` and `loadImageAttachment` to `loadFileAttachment` to reflect broader file support.
- Updated `OutgoingAttachment` to resolve the type as `image` if the MIME type starts with `image/`, otherwise `document`.

## Motivation
Previously, the app artificially restricted users from selecting files like PDF or TXT from the OS file picker. These changes remove that restriction so the app can send non-image files as base64 data to the API.