### PR TITLE
fix(chat): only show attachment badge when base64 data is present

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
@@ -868,7 +868,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
         val mergedText = content.joinToString("\n") { it.text ?: "" }.trim().ifBlank { "(thinking)" }
         val preprocessed = ChatMarkdownPreprocessor.preprocess(mergedText)
         val isUserMessage = role.equals("user", ignoreCase = true)
-        val attachmentContents = content.filter { it.type != "text" || it.base64 != null }
+        val attachmentContents = content.filter { it.type != "text" && it.base64 != null }
         return ChatMessage(
             id = id,
             text = preprocessed,


### PR DESCRIPTION
## 問題
アシスタントの返信に常にFileバッジが表示されるバグ。

## 原因
`toUiChatMessage()` のフィルタ条件が `||`（OR）になっており、`type != "text"` だけで条件が成立していた。アシスタントの返信内容（tool_use等）が全てattachmentとして誤って表示されていた。

## 修正
`||` を `&&`（AND）に変更し、**非テキストかつbase64データが存在する** content のみをattachmentとして扱うようにした。

```diff
-val attachmentContents = content.filter { it.type != "text" || it.base64 != null }
+val attachmentContents = content.filter { it.type != "text" && it.base64 != null }
```