### PR TITLE
Parity: CanvasScreen UI implementation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -122,6 +122,12 @@
             android:exported="false"
             android:theme="@style/Theme.OpenClawAssistant" />
 
+        <!-- Canvas Activity -->
+        <activity
+            android:name="com.openclaw.assistant.CanvasActivity"
+            android:exported="false"
+            android:theme="@style/Theme.OpenClawAssistant" />
+
         <!-- Voice Interaction Service (Home button long press) -->
         <service
             android:name="com.openclaw.assistant.service.OpenClawAssistantService"

--- a/app/src/main/assets/CanvasScaffold/scaffold.html
+++ b/app/src/main/assets/CanvasScaffold/scaffold.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OpenClaw Canvas</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+            background-color: #f0f2f5;
+            color: #1c1e21;
+        }
+        .container {
+            text-align: center;
+            padding: 2rem;
+            background: white;
+            border-radius: 1rem;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+        h1 { margin-bottom: 0.5rem; }
+        p { color: #65676b; }
+        .status-badge {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            border-radius: 1rem;
+            background: #e4e6eb;
+            font-size: 0.875rem;
+            font-weight: 600;
+            margin-top: 1rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Canvas</h1>
+        <p>No content loaded</p>
+        <div id="status" class="status-badge">Offline</div>
+    </div>
+    <script>
+        window.__openclaw = {
+            setDebugStatusEnabled: (enabled) => {
+                console.log("Debug Status Enabled:", enabled);
+            },
+            setStatus: (title, subtitle) => {
+                const statusEl = document.getElementById('status');
+                if (statusEl) {
+                    statusEl.textContent = title + (subtitle ? ' - ' + subtitle : '');
+                }
+            }
+        };
+    </script>
+</body>
+</html>

--- a/app/src/main/java/com/openclaw/assistant/CanvasActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/CanvasActivity.kt
@@ -1,0 +1,64 @@
+package com.openclaw.assistant
+
+import android.content.Context
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.openclaw.assistant.data.SettingsRepository
+import com.openclaw.assistant.ui.CanvasScreen
+import com.openclaw.assistant.ui.theme.OpenClawAssistantTheme
+
+class CanvasActivity : ComponentActivity() {
+
+    private val viewModel: MainViewModel by viewModels()
+
+    override fun attachBaseContext(newBase: Context) {
+        val tag = try {
+            SettingsRepository.getInstance(newBase).appLanguage.trim()
+        } catch (e: Exception) { "" }
+        if (tag.isNotBlank()) {
+            val locale = java.util.Locale.forLanguageTag(tag)
+            val config = android.content.res.Configuration(newBase.resources.configuration)
+            config.setLocale(locale)
+            super.attachBaseContext(newBase.createConfigurationContext(config))
+        } else {
+            super.attachBaseContext(newBase)
+        }
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            OpenClawAssistantTheme {
+                Scaffold(
+                    topBar = {
+                        TopAppBar(
+                            title = { Text(stringResource(R.string.canvas)) },
+                            navigationIcon = {
+                                IconButton(onClick = { finish() }) {
+                                    Icon(
+                                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                        contentDescription = stringResource(R.string.back)
+                                    )
+                                }
+                            }
+                        )
+                    }
+                ) { paddingValues ->
+                    CanvasScreen(
+                        viewModel = viewModel,
+                        modifier = Modifier.padding(paddingValues)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -731,14 +731,30 @@ fun MainScreen(
             Spacer(modifier = Modifier.height(24.dp))
             
             val chatContext = LocalContext.current
-            Button(
-                onClick = { chatContext.startActivity(Intent(chatContext, SessionListActivity::class.java)) },
-                modifier = Modifier.fillMaxWidth().height(56.dp),
-                shape = RoundedCornerShape(16.dp)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                Icon(Icons.AutoMirrored.Filled.Chat, contentDescription = null)
-                Spacer(modifier = Modifier.width(12.dp))
-                Text(stringResource(R.string.open_chat), fontSize = 18.sp, fontWeight = FontWeight.Medium)
+                Button(
+                    onClick = { chatContext.startActivity(Intent(chatContext, SessionListActivity::class.java)) },
+                    modifier = Modifier.weight(1f).height(56.dp),
+                    shape = RoundedCornerShape(16.dp)
+                ) {
+                    Icon(Icons.AutoMirrored.Filled.Chat, contentDescription = null)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(R.string.open_chat), fontSize = 16.sp, fontWeight = FontWeight.Medium)
+                }
+
+                Button(
+                    onClick = { chatContext.startActivity(Intent(chatContext, CanvasActivity::class.java)) },
+                    modifier = Modifier.weight(1f).height(56.dp),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary)
+                ) {
+                    Icon(Icons.Default.Palette, contentDescription = null)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(R.string.canvas), fontSize = 16.sp, fontWeight = FontWeight.Medium)
+                }
             }
 
             // Legacy warning if ONLY legacy is configured and fails

--- a/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
@@ -45,6 +45,10 @@ class CanvasController {
     applyDebugStatus()
   }
 
+  fun detach() {
+    this.webView = null
+  }
+
   fun navigate(url: String) {
     val trimmed = url.trim()
     this.url = if (trimmed.isBlank() || trimmed == "/") null else trimmed

--- a/app/src/main/java/com/openclaw/assistant/ui/CanvasScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/CanvasScreen.kt
@@ -1,0 +1,71 @@
+package com.openclaw.assistant.ui
+
+import android.annotation.SuppressLint
+import android.graphics.Bitmap
+import android.util.Log
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import com.openclaw.assistant.MainViewModel
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+fun CanvasScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val webView = remember {
+        WebView(context).apply {
+            settings.apply {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                loadWithOverviewMode = true
+                useWideViewPort = true
+                databaseEnabled = true
+                mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+            }
+            webViewClient = object : WebViewClient() {
+                override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+                    super.onPageStarted(view, url, favicon)
+                    Log.d("CanvasScreen", "Page started: $url")
+                }
+
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    super.onPageFinished(view, url)
+                    Log.d("CanvasScreen", "Page finished: $url")
+                    viewModel.canvas.onPageFinished()
+                }
+
+                override fun onReceivedError(
+                    view: WebView?,
+                    request: WebResourceRequest?,
+                    error: WebResourceError?
+                ) {
+                    super.onReceivedError(view, request, error)
+                    Log.e("CanvasScreen", "Error loading ${request?.url}: ${error?.description}")
+                }
+            }
+        }
+    }
+
+    DisposableEffect(webView) {
+        viewModel.canvas.attach(webView)
+        onDispose {
+            viewModel.canvas.detach()
+            webView.stopLoading()
+            webView.destroy()
+        }
+    }
+
+    AndroidView(
+        factory = { webView },
+        modifier = modifier.fillMaxSize()
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -441,6 +441,7 @@
     <string name="diagnostic_app_permissions">App Permissions</string>
     <string name="technical_details">Technical Details:</string>
     <!-- Update Checker -->
+    <string name="canvas">Canvas</string>
     <string name="check_for_updates">Check for Updates</string>
     <string name="checking_update">Checking…</string>
     <string name="update_available">New version (%s) available</string>


### PR DESCRIPTION
This change implements the `CanvasScreen` UI layer to achieve feature parity with the official OpenClaw Android application. 

Key changes:
- `CanvasController.kt`: Added `detach()` method to safely clear the `WebView` reference.
- `CanvasScreen.kt`: New composable using `AndroidView` to host a `WebView` with JavaScript and DOM storage enabled. Handles lifecycle via `DisposableEffect`.
- `CanvasActivity.kt`: New Activity that serves as the entry point for the Canvas feature.
- `MainActivity.kt`: Added a button to the main dashboard to launch `CanvasActivity`.
- `AndroidManifest.xml`: Registered `CanvasActivity`.
- `scaffold.html`: Added a default HTML asset for the initial canvas state.
- `strings.xml`: Added "Canvas" string for UI labels.

Fixes #196

---
*PR created automatically by Jules for task [8740846985421675790](https://jules.google.com/task/8740846985421675790) started by @yuga-hashimoto*