### PR TITLE
fix: upgrade Compose BOM to 2024.12.01 to fix startup crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -172,7 +172,7 @@ dependencies {
     implementation("androidx.webkit:webkit:1.10.0")
 
     // Compose
-    implementation(platform("androidx.compose:compose-bom:2024.09.03"))
+    implementation(platform("androidx.compose:compose-bom:2024.12.01"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
@@ -240,7 +240,7 @@ dependencies {
     testImplementation("org.robolectric:robolectric:4.16")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2024.09.03"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.12.01"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")


### PR DESCRIPTION
## Summary
- Upgrades Compose BOM from `2024.09.03` to `2024.12.01`
- Fixes a FATAL startup crash seen in Firebase Crashlytics (15 events, 8 affected users, signal: EARLY/FRESH)
- Root cause: `FontWeightAdjustmentHelperApi31` accesses `Configuration.fontWeightAdjustment` (API 31 field) on devices that report API 31 but lack the field (e.g. OnePlus custom ROMs, x86 emulators running Android 11)
- The upstream Compose fix is included in BOM 2024.11.00+

## Crashlytics issue
- Issue ID: `5c3f76729005f60fffa2beae30e770c7`
- Error: `java.lang.NoSuchFieldError: No instance field fontWeightAdjustment`
- Affected versions: 2.1.0 → **2.3.3 (current)**
- 93% of crashes in first second of session (SIGNAL_EARLY) — user can't even open the app

## Test plan
- [ ] Build succeeds (verified locally with `assembleDebug`)
- [ ] Smoke test on affected device type if available (Android 11 / OnePlus)
- [ ] Monitor Crashlytics after release for reduction in this issue

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)