### PR TITLE
fix: restore bottom tab navigation (#225 regression) and improve system notifications

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -82,6 +82,14 @@ data class PermissionInfo(
     val descResId: Int
 )
 
+sealed class AppTab(val route: String, val labelResId: Int, val icon: ImageVector) {
+    object Home     : AppTab("home",     R.string.tab_nav_home,     Icons.Default.Home)
+    object Chat     : AppTab("chat",     R.string.tab_nav_chat,     Icons.AutoMirrored.Filled.Chat)
+    object Canvas   : AppTab("canvas",   R.string.tab_nav_canvas,   Icons.Default.Brush)
+    object Settings : AppTab("settings", R.string.tab_nav_settings, Icons.Default.Settings)
+    companion object { val ALL by lazy { listOf(Home, Chat, Canvas, Settings) } }
+}
+
 class MainActivity : ComponentActivity(), TextToSpeech.OnInitListener {
 
     private lateinit var settings: SettingsRepository
@@ -90,6 +98,7 @@ class MainActivity : ComponentActivity(), TextToSpeech.OnInitListener {
     private var missingPermissions by mutableStateOf<List<PermissionInfo>>(emptyList())
     private var allPermissionsStatus by mutableStateOf<List<PermissionStatusInfo>>(emptyList())
     private var pendingHotwordStart = false
+    private var chatRefreshTrigger by mutableStateOf(0)
 
     private lateinit var screenCaptureRequester: ScreenCaptureRequester
     private lateinit var permissionRequester: PermissionRequester
@@ -192,12 +201,12 @@ class MainActivity : ComponentActivity(), TextToSpeech.OnInitListener {
                         }
                     )
                 } else {
-                    MainScreen(
+                    MainNavHost(
                         settings = settings,
                         diagnostic = voiceDiagnostic,
                         missingPermissions = missingPermissions,
                         allPermissionsStatus = allPermissionsStatus,
-                        onOpenSettings = { startActivity(Intent(this, SettingsActivity::class.java)) },
+                        chatRefreshTrigger = chatRefreshTrigger,
                         onOpenAssistantSettings = { openAssistantSettings() },
                         onRefreshDiagnostics = {
                             initializeTTS() // Re-init on manual refresh
@@ -368,6 +377,7 @@ class MainActivity : ComponentActivity(), TextToSpeech.OnInitListener {
 
     override fun onResume() {
         super.onResume()
+        chatRefreshTrigger++
         refreshMissingPermissions()
         refreshAllPermissionsStatus()
 
@@ -392,6 +402,142 @@ class MainActivity : ComponentActivity(), TextToSpeech.OnInitListener {
     override fun onDestroy() {
         super.onDestroy()
         tts?.shutdown()
+    }
+}
+
+@Composable
+fun MainNavHost(
+    settings: SettingsRepository,
+    diagnostic: VoiceDiagnostic?,
+    missingPermissions: List<PermissionInfo>,
+    allPermissionsStatus: List<PermissionStatusInfo>,
+    chatRefreshTrigger: Int,
+    onOpenAssistantSettings: () -> Unit,
+    onRefreshDiagnostics: () -> Unit,
+    onRequestPermissions: (List<String>) -> Unit,
+    onOpenAppSettings: () -> Unit
+) {
+    var selectedTab by rememberSaveable(
+        stateSaver = androidx.compose.runtime.saveable.Saver(
+            save    = { it.route },
+            restore = { route ->
+                when (route) {
+                    AppTab.Chat.route     -> AppTab.Chat
+                    AppTab.Canvas.route   -> AppTab.Canvas
+                    AppTab.Settings.route -> AppTab.Settings
+                    else                  -> AppTab.Home
+                }
+            }
+        )
+    ) { mutableStateOf<AppTab>(AppTab.Home) }
+    var showSettingsCredits by rememberSaveable { mutableStateOf(false) }
+
+    val sessionListViewModel: SessionListViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
+
+    LaunchedEffect(selectedTab) {
+        if (selectedTab == AppTab.Chat) sessionListViewModel.refreshSessions()
+    }
+    LaunchedEffect(chatRefreshTrigger) {
+        sessionListViewModel.refreshSessions()
+    }
+
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                AppTab.ALL.forEach { tab ->
+                    NavigationBarItem(
+                        selected  = selectedTab == tab,
+                        onClick   = { selectedTab = tab },
+                        icon      = { Icon(tab.icon, contentDescription = null) },
+                        label     = { Text(stringResource(tab.labelResId)) }
+                    )
+                }
+            }
+        }
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding).fillMaxSize()) {
+            when (selectedTab) {
+                AppTab.Home -> MainScreen(
+                    settings             = settings,
+                    diagnostic           = diagnostic,
+                    missingPermissions   = missingPermissions,
+                    allPermissionsStatus = allPermissionsStatus,
+                    onOpenSettings       = { selectedTab = AppTab.Settings },
+                    onOpenAssistantSettings = onOpenAssistantSettings,
+                    onRefreshDiagnostics = onRefreshDiagnostics,
+                    onRequestPermissions = onRequestPermissions,
+                    onOpenAppSettings    = onOpenAppSettings
+                )
+                AppTab.Chat -> {
+                    val sessions        by sessionListViewModel.allSessions.collectAsState()
+                    val agentListResult by sessionListViewModel.agentList.collectAsState()
+                    val context = LocalContext.current
+                    SessionListScreen(
+                        sessions            = sessions,
+                        isGatewayConfigured = sessionListViewModel.isGatewayConfigured,
+                        isHttpConfigured    = sessionListViewModel.isHttpConfigured,
+                        agents              = agentListResult?.agents ?: emptyList(),
+                        defaultAgentId      = agentListResult?.defaultId ?: "main",
+                        onBack              = { selectedTab = AppTab.Home },
+                        onSessionClick      = { session ->
+                            sessionListViewModel.setUseNodeChat(session.isGateway)
+                            context.startActivity(
+                                Intent(context, ChatActivity::class.java).apply {
+                                    putExtra(ChatActivity.EXTRA_SESSION_ID, session.id)
+                                }
+                            )
+                        },
+                        onCreateSession     = { name, isGateway, agentId ->
+                            sessionListViewModel.setUseNodeChat(isGateway)
+                            sessionListViewModel.createSession(name, isGateway, agentId) { sessionId, _ ->
+                                context.startActivity(
+                                    Intent(context, ChatActivity::class.java).apply {
+                                        putExtra(ChatActivity.EXTRA_SESSION_ID, sessionId)
+                                        putExtra(ChatActivity.EXTRA_SESSION_TITLE, name)
+                                    }
+                                )
+                            }
+                        },
+                        onDeleteSession     = { id, gw -> sessionListViewModel.deleteSession(id, gw) },
+                        onRenameSession     = { id, nm, gw -> sessionListViewModel.renameSession(id, nm, gw) }
+                    )
+                }
+                AppTab.Canvas -> {
+                    val context = LocalContext.current
+                    val (canvasController, nodeRuntime) = remember(context.applicationContext) {
+                        val nr = (context.applicationContext as OpenClawApplication).nodeRuntime
+                        nr.canvas to nr
+                    }
+                    com.openclaw.assistant.ui.CanvasScreen(
+                        canvasController = canvasController,
+                        nodeRuntime = nodeRuntime,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+                AppTab.Settings -> {
+                    if (showSettingsCredits) {
+                        com.openclaw.assistant.ui.settings.CreditsScreen(
+                            settings = settings,
+                            onBack   = { showSettingsCredits = false }
+                        )
+                    } else {
+                        val context = LocalContext.current
+                        SettingsScreen(
+                            settings  = settings,
+                            onSave    = {
+                                android.widget.Toast.makeText(
+                                    context,
+                                    context.getString(R.string.saved),
+                                    android.widget.Toast.LENGTH_SHORT
+                                ).show()
+                            },
+                            onBack    = { selectedTab = AppTab.Home },
+                            onCredits = { showSettingsCredits = true }
+                        )
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
@@ -4,10 +4,16 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.os.Looper
 import android.util.Log
+import android.content.Context
+import android.webkit.WebChromeClient
+import android.webkit.WebSettings
 import android.webkit.WebView
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.scale
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import java.io.ByteArrayOutputStream
@@ -32,6 +38,19 @@ class CanvasController {
   @Volatile private var debugStatusTitle: String? = null
   @Volatile private var debugStatusSubtitle: String? = null
 
+  @Volatile var gatewayToken: String? = null
+  @Volatile var gatewayOrigin: String? = null
+
+  // Persistent WebView: survives tab switches so canvas state is preserved
+  @Volatile private var cachedWebView: WebView? = null
+  private var initialLoadDone = false
+
+  private val _isDefaultState = MutableStateFlow(true)
+  val isDefaultFlow: StateFlow<Boolean> = _isDefaultState.asStateFlow()
+
+  private val _isPageLoading = MutableStateFlow(false)
+  val isPageLoadingFlow: StateFlow<Boolean> = _isPageLoading.asStateFlow()
+
   private val scaffoldAssetUrl = "file:///android_asset/CanvasScaffold/scaffold.html"
 
   private fun clampJpegQuality(quality: Double?): Int {
@@ -39,15 +58,52 @@ class CanvasController {
     return (q * 100.0).toInt().coerceIn(1, 100)
   }
 
+  fun setGatewayAuth(origin: String?, token: String?) {
+    gatewayOrigin = origin
+    gatewayToken = token
+  }
+
+  /** Returns the persistent WebView, creating it on first call. */
+  fun getOrCreateWebView(context: Context): WebView {
+    return cachedWebView ?: WebView(context.applicationContext).also {
+      it.settings.apply {
+        javaScriptEnabled = true
+        domStorageEnabled = true
+        allowFileAccess = true
+        mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+      }
+      // Required so JavaScript interactions (dialogs, file choosers, etc.) work properly.
+      // Without this, alert()/confirm() calls silently fail and can halt button actions.
+      it.webChromeClient = WebChromeClient()
+      if (com.openclaw.assistant.BuildConfig.DEBUG) {
+        WebView.setWebContentsDebuggingEnabled(true)
+      }
+      cachedWebView = it
+    }
+  }
+
   fun attach(webView: WebView) {
     this.webView = webView
-    reload()
+    _isDefaultState.value = url == null
+    // Only load on first attach; subsequent attaches (tab switch back) preserve canvas state
+    if (!initialLoadDone) {
+      initialLoadDone = true
+      reload()
+    }
     applyDebugStatus()
+  }
+
+  fun detach() {
+    // Remove from parent ViewGroup but keep cachedWebView alive
+    (webView?.parent as? android.view.ViewGroup)?.removeView(webView)
+    webView = null
   }
 
   fun navigate(url: String) {
     val trimmed = url.trim()
     this.url = if (trimmed.isBlank() || trimmed == "/") null else trimmed
+    _isDefaultState.value = this.url == null
+    if (this.url != null) _isPageLoading.value = true
     reload()
   }
 
@@ -67,6 +123,7 @@ class CanvasController {
   }
 
   fun onPageFinished() {
+    _isPageLoading.value = false
     applyDebugStatus()
   }
 
@@ -77,6 +134,11 @@ class CanvasController {
     } else {
       wv.post { block(wv) }
     }
+  }
+
+  private fun authHeaders(): Map<String, String> {
+    val t = gatewayToken?.takeIf { it.isNotBlank() } ?: return emptyMap()
+    return mapOf("Authorization" to "Bearer $t")
   }
 
   private fun reload() {
@@ -91,7 +153,7 @@ class CanvasController {
         if (BuildConfig.DEBUG) {
           Log.d("OpenClawCanvas", "load url: $currentUrl")
         }
-        wv.loadUrl(currentUrl)
+        wv.loadUrl(currentUrl, authHeaders())
       }
     }
   }

--- a/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
@@ -735,6 +735,7 @@ class NodeRuntime(context: Context) {
 
   fun attachPermissionRequester(requester: PermissionRequester) {
     notificationsHandler.attachPermissionRequester(requester)
+    systemHandler.attachPermissionRequester(requester)
     contactsHandler.attachPermissionRequester(requester)
     calendarHandler.attachPermissionRequester(requester)
     photosHandler.attachPermissionRequester(requester)

--- a/app/src/main/java/com/openclaw/assistant/node/SystemHandler.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/SystemHandler.kt
@@ -3,28 +3,39 @@ package com.openclaw.assistant.node
 import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.media.AudioManager
 import android.os.Build
+import android.provider.Settings
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
+import com.openclaw.assistant.MainActivity
+import com.openclaw.assistant.PermissionRequester
 import com.openclaw.assistant.R
 import com.openclaw.assistant.gateway.GatewaySession
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.intOrNull
-import android.media.AudioManager
-import android.provider.Settings
+import kotlinx.serialization.json.jsonObject
 
 class SystemHandler(private val appContext: Context) {
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    fun handleNotify(paramsJson: String?): GatewaySession.InvokeResult {
+    @Volatile private var permissionRequester: PermissionRequester? = null
+
+    fun attachPermissionRequester(requester: PermissionRequester) {
+        permissionRequester = requester
+    }
+
+    suspend fun handleNotify(paramsJson: String?): GatewaySession.InvokeResult {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (ContextCompat.checkSelfPermission(appContext, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
-                return GatewaySession.InvokeResult.error("PERMISSION_REQUIRED", "POST_NOTIFICATIONS permission required")
+                permissionRequester?.requestIfMissing(listOf(Manifest.permission.POST_NOTIFICATIONS))
+                return GatewaySession.InvokeResult.error("NOT_AUTHORIZED", "NOT_AUTHORIZED: POST_NOTIFICATIONS permission required")
             }
         }
 
@@ -37,28 +48,74 @@ class SystemHandler(private val appContext: Context) {
         } ?: return GatewaySession.InvokeResult.error("INVALID_REQUEST", "Expected JSON object")
 
         val title = (params["title"] as? JsonPrimitive)?.content ?: "OpenClaw Assistant"
-        val message = (params["message"] as? JsonPrimitive)?.content ?: ""
+        // Support both "body" (original spec) and "message" (legacy fallback)
+        val body = (params["body"] as? JsonPrimitive)?.content
+            ?: (params["message"] as? JsonPrimitive)?.content
+            ?: ""
 
-        if (message.isEmpty()) {
-            return GatewaySession.InvokeResult.error("INVALID_REQUEST", "Message is required")
+        if (body.isEmpty()) {
+            return GatewaySession.InvokeResult.error("INVALID_REQUEST", "body is required")
+        }
+
+        val priority = (params["priority"] as? JsonPrimitive)?.content?.lowercase() ?: "active"
+        val sound = (params["sound"] as? JsonPrimitive)?.content?.lowercase()
+        val silent = sound == "none" || sound == "silent" || sound == "off" || sound == "false" || sound == "0"
+
+        // Channel config based on priority
+        val (channelId, channelImportance, notifPriority) = when (priority) {
+            "passive" -> Triple(
+                "openclaw.system.notify.passive",
+                NotificationManager.IMPORTANCE_LOW,
+                NotificationCompat.PRIORITY_LOW,
+            )
+            "timesensitive" -> Triple(
+                "openclaw.system.notify.timesensitive",
+                NotificationManager.IMPORTANCE_HIGH,
+                NotificationCompat.PRIORITY_HIGH,
+            )
+            else -> Triple(
+                "openclaw.system.notify.active",
+                NotificationManager.IMPORTANCE_DEFAULT,
+                NotificationCompat.PRIORITY_DEFAULT,
+            )
         }
 
         val notificationManager = appContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val channelId = "openclaw_system"
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(channelId, "OpenClaw System Notifications", NotificationManager.IMPORTANCE_DEFAULT)
+            val channelName = when (priority) {
+                "passive" -> "OpenClaw Passive Notifications"
+                "timesensitive" -> "OpenClaw Time-Sensitive Notifications"
+                else -> "OpenClaw Notifications"
+            }
+            val channel = NotificationChannel(channelId, channelName, channelImportance)
             notificationManager.createNotificationChannel(channel)
         }
 
-        val notification = NotificationCompat.Builder(appContext, channelId)
+        val tapIntent = Intent(appContext, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        val tapPendingIntent = PendingIntent.getActivity(
+            appContext,
+            0,
+            tapIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val builder = NotificationCompat.Builder(appContext, channelId)
             .setSmallIcon(R.mipmap.ic_launcher)
             .setContentTitle(title)
-            .setContentText(message)
+            .setContentText(body)
             .setAutoCancel(true)
-            .build()
+            .setOnlyAlertOnce(true)
+            .setPriority(notifPriority)
+            .setContentIntent(tapPendingIntent)
 
-        notificationManager.notify(System.currentTimeMillis().toInt(), notification)
+        if (silent) {
+            builder.setSilent(true)
+        }
+
+        notificationManager.notify(System.currentTimeMillis().toInt(), builder.build())
 
         return GatewaySession.InvokeResult.ok("""{"ok":true}""")
     }
@@ -72,7 +129,7 @@ class SystemHandler(private val appContext: Context) {
             val level = (params["level"] as? JsonPrimitive)?.intOrNull
 
             val audioManager = appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-            
+
             if (level != null) {
                 // Set volume
                 val maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
@@ -107,11 +164,11 @@ class SystemHandler(private val appContext: Context) {
                 // Set brightness
                 val safeLevel = level.coerceIn(0, 100)
                 val newBrightness = (safeLevel / 100f * 255).toInt()
-                
+
                 // Disable auto-brightness if setting manually
                 Settings.System.putInt(appContext.contentResolver, Settings.System.SCREEN_BRIGHTNESS_MODE, Settings.System.SCREEN_BRIGHTNESS_MODE_MANUAL)
                 Settings.System.putInt(appContext.contentResolver, Settings.System.SCREEN_BRIGHTNESS, newBrightness)
-                
+
                 GatewaySession.InvokeResult.ok("""{"level":$safeLevel}""")
             } else {
                 // Get brightness

--- a/app/src/main/java/com/openclaw/assistant/ui/CanvasScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/CanvasScreen.kt
@@ -1,0 +1,370 @@
+package com.openclaw.assistant.ui
+
+import android.annotation.SuppressLint
+import android.view.MotionEvent
+import android.view.ViewGroup
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.openclaw.assistant.R
+import com.openclaw.assistant.chat.ChatMessageContent
+import com.openclaw.assistant.node.CanvasController
+import com.openclaw.assistant.node.NodeRuntime
+import kotlinx.coroutines.delay
+import java.net.HttpURLConnection
+import java.net.URL
+
+@SuppressLint("ClickableViewAccessibility")
+@Composable
+fun CanvasScreen(
+    canvasController: CanvasController,
+    nodeRuntime: NodeRuntime,
+    modifier: Modifier = Modifier
+) {
+    val nodeRuntimeRef = remember { mutableStateOf(nodeRuntime) }
+    SideEffect { nodeRuntimeRef.value = nodeRuntime }
+
+    // Box layers the chat bar (Compose) directly on top of the WebView (AndroidView).
+    // CanvasChatBar lives in the main Compose composition → state flows (pendingRunCount,
+    // messages, etc.) properly trigger recomposition and isAiBusy stays accurate.
+    Box(modifier = modifier) {
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { context ->
+                // WebView returned directly — no FrameLayout wrapper.
+                // setOnTouchListener ensures ACTION_DOWN tells Compose not to intercept scrolls.
+                canvasController.getOrCreateWebView(context).also {
+                    (it.parent as? ViewGroup)?.removeView(it)
+                    it.webViewClient = CanvasWebViewClient(canvasController)
+                    it.setOnTouchListener { v, event ->
+                        if (event.action == MotionEvent.ACTION_DOWN) {
+                            v.parent?.requestDisallowInterceptTouchEvent(true)
+                        }
+                        false
+                    }
+                    canvasController.attach(it)
+                    it.requestFocus()
+                }
+            },
+            onRelease = { _ -> canvasController.detach() }
+        )
+        CanvasChatBar(
+            canvasController = canvasController,
+            nodeRuntimeRef = nodeRuntimeRef,
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+        )
+    }
+}
+
+@Composable
+private fun CanvasChatBar(
+    canvasController: CanvasController,
+    nodeRuntimeRef: androidx.compose.runtime.State<NodeRuntime>,
+    modifier: Modifier = Modifier
+) {
+    val nodeRuntime = nodeRuntimeRef.value
+    val isDefault by canvasController.isDefaultFlow.collectAsState()
+    val isPageLoading by canvasController.isPageLoadingFlow.collectAsState()
+    val healthOk by nodeRuntime.chatHealthOk.collectAsState()
+    val streamingText by nodeRuntime.chatStreamingAssistantText.collectAsState()
+    val pendingTools by nodeRuntime.chatPendingToolCalls.collectAsState()
+    val pendingRunCount by nodeRuntime.pendingRunCount.collectAsState()
+    val messages by nodeRuntime.chatMessages.collectAsState()
+
+    var inputText by remember { mutableStateOf("") }
+    var isSending by remember { mutableStateOf(false) }
+    var lastAiText by remember { mutableStateOf<String?>(null) }
+    // Count of assistant messages at send time — used to detect a NEW response
+    var assistantCountAtSend by remember { mutableStateOf(0) }
+
+    // pendingRunCount covers the full AI processing window (send → tools → complete)
+    val isAiBusy = isSending || pendingRunCount > 0
+
+    // Clear isSending only when a NEW assistant message arrives (not a pre-existing one)
+    LaunchedEffect(messages) {
+        val assistantCount = messages.count { it.role == "assistant" }
+        if (isSending && assistantCount > assistantCountAtSend) {
+            isSending = false
+        }
+        val lastAssistant = messages.lastOrNull { it.role == "assistant" }
+        val text = lastAssistant?.content
+            ?.firstOrNull { it.type == "text" }?.text
+        if (!text.isNullOrBlank()) lastAiText = text
+    }
+
+    // Auto-hide text response after 10 seconds
+    LaunchedEffect(lastAiText) {
+        if (lastAiText != null) {
+            delay(10_000L)
+            lastAiText = null
+        }
+    }
+
+    // Clear isSending as soon as any AI activity is detected
+    LaunchedEffect(streamingText, pendingTools.size, pendingRunCount) {
+        if (streamingText != null || pendingTools.isNotEmpty() || pendingRunCount > 0) {
+            isSending = false
+        }
+    }
+    // Safety timeout — generous to cover slow AI gateway responses (observed ~73s latency)
+    LaunchedEffect(isSending) {
+        if (isSending) {
+            delay(120_000L)
+            isSending = false
+        }
+    }
+
+    fun sendMessage() {
+        val text = inputText.trim()
+        if (text.isBlank() || !healthOk || isAiBusy) return
+        inputText = ""
+        lastAiText = null
+        assistantCountAtSend = messages.count { it.role == "assistant" }
+        isSending = true
+        val canvasInstruction = "[CANVAS MODE] You MUST use canvas tools to respond to this message. " +
+            "Use canvas.eval() to display your response as HTML in the canvas, " +
+            "or canvas.navigate() to load a page. " +
+            "Do NOT reply with plain text only — the user cannot see plain text responses here.\n\n"
+        nodeRuntimeRef.value.sendChat(canvasInstruction + text, "low", emptyList())
+    }
+
+    val statusLabel: String? = when {
+        streamingText != null     -> stringResource(R.string.canvas_status_thinking)
+        pendingTools.isNotEmpty() -> stringResource(R.string.canvas_status_tool)
+        isPageLoading             -> stringResource(R.string.canvas_status_loading)
+        isAiBusy                  -> stringResource(R.string.canvas_status_sending)
+        !healthOk                 -> stringResource(R.string.canvas_chat_not_connected)
+        else                      -> null
+    }
+    val showSpinner = isAiBusy || isPageLoading
+
+    Surface(
+        modifier = modifier,
+        shadowElevation = 8.dp,
+        color = MaterialTheme.colorScheme.surface
+    ) {
+        Column {
+            // ── Diagnostic card: AI responded with text but no Canvas ────────
+            AnimatedVisibility(
+                visible = isDefault && !isAiBusy && !isPageLoading && lastAiText != null,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                if (lastAiText != null) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 240.dp)
+                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                            .verticalScroll(rememberScrollState())
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.canvas_diag_no_canvas),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        Text(
+                            text = lastAiText!!,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    HorizontalDivider()
+                }
+            }
+
+            // ── Not-connected warning ────────────────────────────────────────
+            AnimatedVisibility(
+                visible = !healthOk,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                Text(
+                    text = stringResource(R.string.canvas_diag_not_connected),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.errorContainer)
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                )
+            }
+
+            // ── Status row (spinner + label) ─────────────────────────────────
+            AnimatedVisibility(
+                visible = statusLabel != null && healthOk,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                if (statusLabel != null) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(MaterialTheme.colorScheme.secondaryContainer)
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        if (showSpinner) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(14.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer
+                            )
+                        }
+                        Text(
+                            text = statusLabel,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer
+                        )
+                    }
+                }
+            }
+
+            // ── Streaming text preview ───────────────────────────────────────
+            AnimatedVisibility(
+                visible = streamingText != null,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                val st = streamingText
+                if (st != null) {
+                    Text(
+                        text = st,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 4,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
+            }
+
+            // ── Input row ────────────────────────────────────────────────────
+            Row(
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextField(
+                    value = inputText,
+                    onValueChange = { inputText = it },
+                    placeholder = { Text(text = stringResource(R.string.canvas_chat_hint)) },
+                    enabled = healthOk && !isAiBusy,
+                    modifier = Modifier.weight(1f),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                    keyboardActions = KeyboardActions(onSend = { sendMessage() }),
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        disabledContainerColor = Color.Transparent,
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                        disabledIndicatorColor = Color.Transparent,
+                    )
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                IconButton(
+                    onClick = { sendMessage() },
+                    enabled = healthOk && !isAiBusy && inputText.isNotBlank()
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.Send,
+                        contentDescription = stringResource(R.string.canvas_chat_send)
+                    )
+                }
+            }
+        }
+    }
+}
+
+private class CanvasWebViewClient(
+    private val canvasController: CanvasController
+) : WebViewClient() {
+
+    override fun onPageFinished(view: WebView, url: String) {
+        super.onPageFinished(view, url)
+        canvasController.onPageFinished()
+    }
+
+    override fun shouldInterceptRequest(
+        view: WebView,
+        request: WebResourceRequest
+    ): WebResourceResponse? {
+        val token = canvasController.gatewayToken?.takeIf { it.isNotBlank() } ?: return null
+        val origin = canvasController.gatewayOrigin ?: return null
+        if (!request.url.toString().startsWith(origin)) return null
+
+        return try {
+            val conn = URL(request.url.toString()).openConnection() as HttpURLConnection
+            request.requestHeaders.forEach { (k, v) -> conn.setRequestProperty(k, v) }
+            conn.setRequestProperty("Authorization", "Bearer $token")
+            conn.connect()
+            WebResourceResponse(
+                conn.contentType?.substringBefore(";") ?: "text/html",
+                conn.contentEncoding ?: "utf-8",
+                conn.inputStream
+            )
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -491,4 +491,24 @@
     <string name="credits_support_title">開発をサポートする</string>
     <string name="operator_offline_command">openclaw devices approve $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="reject_command_format">openclaw devices reject $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
+
+    <!-- Bottom tab navigation -->
+    <string name="tab_nav_home">ホーム</string>
+    <string name="tab_nav_chat">チャット</string>
+    <string name="tab_nav_canvas">Canvas</string>
+    <string name="tab_nav_settings">設定</string>
+
+    <!-- Canvas screen -->
+    <string name="canvas_placeholder_title">Canvas</string>
+    <string name="canvas_placeholder_body">Canvas は AI アシスタントが操作する表示エリアです。チャットでアシスタントに「Canvas に表示して」と依頼してみてください。</string>
+    <string name="canvas_go_to_chat">チャットへ</string>
+    <string name="canvas_chat_hint">Canvas を使ってみよう</string>
+    <string name="canvas_chat_not_connected">Gateway に接続してください</string>
+    <string name="canvas_chat_send">送信</string>
+    <string name="canvas_status_sending">送信中...</string>
+    <string name="canvas_status_thinking">考え中...</string>
+    <string name="canvas_status_tool">ツール使用中...</string>
+    <string name="canvas_status_loading">Canvas読み込み中...</string>
+    <string name="canvas_diag_no_canvas">AIはCanvasを使いませんでした。テキストで返答しています。\nCanvasツールが有効になっているか確認してください。</string>
+    <string name="canvas_diag_not_connected">Gatewayに接続されていません。接続するとAIがCanvasを操作できます。</string>
 </resources>


### PR DESCRIPTION
## Summary

- **タブナビゲーション復元**: PR #238 が誤って #225 のタブ実装を削除してしまった regression を修正。`AppTab`、`MainNavHost`、`CanvasScreen.kt`、`CanvasController` の関連メソッド、および `values-ja` のタブ/Canvas 文字列を復元
- **システム通知の改善**: `SystemHandler.handleNotify()` を本家 OpenClaw Android 実装に合わせてアップグレード

## Tab Navigation (regression from #238)

Restored the following components removed by #238:
- `AppTab` sealed class (Home / Chat / Canvas / Settings)
- `MainNavHost` composable with `NavigationBar` at the bottom
- `chatRefreshTrigger` state + increment in `onResume()` (refreshes chat list when returning from `ChatActivity`)
- `CanvasScreen.kt` (fully restored)
- `CanvasController`: `getOrCreateWebView()`, `attach()`, `detach()`, `isDefaultFlow`, `isPageLoadingFlow`, `gatewayToken`, `gatewayOrigin`, `setGatewayAuth()`
- `values-ja/strings.xml`: `tab_nav_*` and `canvas_*` strings (other locales already had these)

## System Notification improvements

- **`priority` field**: `passive` / `active` (default) / `timesensitive` — each maps to a dedicated notification channel and importance level
- **`body` field**: upstream spec uses `body`; falls back to `message` for backwards compatibility
- **`sound` field**: `none` / `silent` / `off` / `false` / `0` → silent notification
- **`PendingIntent`**: tapping the notification opens `MainActivity`
- **`POST_NOTIFICATIONS` permission**: integrates `PermissionRequester` to show permission dialog on demand (Android 13+) instead of silently returning an error
- **`NodeRuntime.attachPermissionRequester()`**: wires `systemHandler` in

## Test plan

- [ ] Bottom tabs (Home / Chat / Canvas / Settings) visible after launch
- [ ] Switching to Chat tab refreshes session list
- [ ] Returning from `ChatActivity` refreshes session list
- [ ] Canvas tab shows WebView with chat bar
- [ ] Settings tab renders inline (no separate Activity)
- [ ] `system.notify` with `priority: "timesensitive"` shows high-priority notification
- [ ] `system.notify` with `body` field shows notification body
- [ ] `system.notify` with `sound: "none"` shows silent notification
- [ ] Tapping notification opens the app
- [ ] First `system.notify` on Android 13+ prompts for `POST_NOTIFICATIONS` permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)