### PR TITLE
fix: improve `SpeechRecognizerManager` reliability and use system defaults

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/speech/SpeechRecognizerManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/SpeechRecognizerManager.kt
@@ -55,12 +55,7 @@ class SpeechRecognizerManager(private val context: Context) {
             }
             if (SpeechRecognizer.isRecognitionAvailable(context)) {
                 val appContext = context.applicationContext
-                val serviceComponent = findRecognitionService(appContext)
-                recognizer = if (serviceComponent != null) {
-                    SpeechRecognizer.createSpeechRecognizer(appContext, serviceComponent)
-                } else {
-                    SpeechRecognizer.createSpeechRecognizer(appContext)
-                }
+                recognizer = SpeechRecognizer.createSpeechRecognizer(appContext)
                 android.util.Log.d("SpeechRecognizerManager", "Created new recognizer instance")
             }
         }
@@ -196,22 +191,6 @@ class SpeechRecognizerManager(private val context: Context) {
      */
     fun stopListening() { 
         // No-op, flow cancellation triggers cleanup
-    }
-
-    /**
-     * Find a real speech recognition service, skipping our own stub service.
-     * This app registers a no-op RecognitionService (required for VoiceInteractionService),
-     * which some devices (e.g. LineageOS) may select as the default, causing Error 12.
-     */
-    private fun findRecognitionService(context: Context): ComponentName? {
-        val pm = context.packageManager
-        val services = pm.queryIntentServices(
-            Intent(RecognitionService.SERVICE_INTERFACE),
-            PackageManager.GET_META_DATA
-        )
-        val ownPackage = context.packageName
-        val other = services.firstOrNull { it.serviceInfo.packageName != ownPackage }
-        return other?.let { ComponentName(it.serviceInfo.packageName, it.serviceInfo.name) }
     }
 
     /**


### PR DESCRIPTION
## Summary

Refactor speech recognition logic to improve compatibility across different Android devices and engines.



## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change, no api change)

## Description
- Use the system default `SpeechRecognizer` instead of explicitly searching for and forcing Google's recognition service. This respects user settings and prevents issues where a forced engine might lack specific language data.
- Remove `findRecognitionService()` logic that filtered out the app's own stub service, relying instead on standard system resolution.
- Remove `EXTRA_ONLY_RETURN_LANGUAGE_PREFERENCE` from the recognition intent. This intent extra is known to cause `ERROR_INSUFFICIENT_PERMISSIONS` (error 12) on various engines when the requested language is not fully optimized or available offline.
- Simplify thread dispatching by using `withContext(Dispatchers.Main)` instead of manual `Dispatchers.Main.dispatch` calls for starting the listener.
## How Has This Been Verified?

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
