### PR TITLE
🛡️ Sentinel: [security improvement] Secure internal broadcast receivers

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -158,7 +158,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             addAction(ACTION_RESUME_HOTWORD)
             addAction(ACTION_PAUSE_HOTWORD)
         }
-        ContextCompat.registerReceiver(this, controlReceiver, filter, ContextCompat.RECEIVER_EXPORTED)
+        ContextCompat.registerReceiver(this, controlReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
@@ -51,7 +51,7 @@ class OpenClawAssistantService : VoiceInteractionService() {
         super.onCreate()
         Log.e(TAG, "VoiceInteractionService onCreate")
         val filter = IntentFilter(ACTION_SHOW_ASSISTANT)
-        ContextCompat.registerReceiver(this, debugReceiver, filter, ContextCompat.RECEIVER_EXPORTED)
+        ContextCompat.registerReceiver(this, debugReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {


### PR DESCRIPTION
Changed `ContextCompat.RECEIVER_EXPORTED` to `ContextCompat.RECEIVER_NOT_EXPORTED` for `HotwordService` and `OpenClawAssistantService`.

This prevents any other app on the device from broadcasting intents and controlling/triggering the assistant or pausing/resuming hotword detection.

---
*PR created automatically by Jules for task [4174064081776267069](https://jules.google.com/task/4174064081776267069) started by @yuga-hashimoto*