### PR TITLE
fix: use Theme.Material3 to fix AppCompat AlertDialog error in screen.record

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.OpenClawAssistant" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.OpenClawAssistant" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>


### PR DESCRIPTION
## Summary

- The app theme was `android:Theme.Material.Light.NoActionBar` (non-AppCompat), while `ScreenCaptureRequester` used `androidx.appcompat.app.AlertDialog.Builder`
- This caused an `IllegalArgumentException` ("You need to use a Theme.AppCompat theme") which was caught and surfaced as `UNAVAILABLE: You need to use a Theme.AppCompat theme (or descendant) with this activity` when `screen.record` was invoked
- Fix: change the theme parent to `Theme.Material3.DayNight.NoActionBar`, which extends `Theme.AppCompat` and is already available via the existing `com.google.android.material:material` dependency

## Changes

- `app/src/main/res/values/themes.xml`: `android:Theme.Material.Light.NoActionBar` → `Theme.Material3.DayNight.NoActionBar`

## Test plan

- [ ] Ensure `screen.record` is enabled in gateway config (`gateway.nodes.allowCommands: ["screen.record"]`)
- [ ] Invoke `screen.record` from the gateway against the Android node
- [ ] Confirm "Screen recording required" rationale dialog appears (previously failed with UNAVAILABLE error)
- [ ] Confirm the system MediaProjection permission dialog appears after tapping Continue
- [ ] Confirm recording completes and returns an mp4 payload

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)