### PR TITLE
fix: hand off chat TTS to latest response

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
@@ -14,6 +14,7 @@ import com.openclaw.assistant.speech.SpeechRecognizerManager
 import com.openclaw.assistant.speech.SpeechResult
 import com.openclaw.assistant.speech.TTSManager
 import com.openclaw.assistant.speech.TTSState
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -681,16 +682,37 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     private var speakingJob: kotlinx.coroutines.Job? = null
+    private val speechRequests = SpeechRequestTracker()
+
+    private fun nextSpeechRequestId(): Long = speechRequests.nextRequest()
+
+    private fun isCurrentSpeechRequest(requestId: Long): Boolean = speechRequests.isCurrent(requestId)
+
+    private fun ensureCurrentSpeechRequest(requestId: Long) {
+        if (!isCurrentSpeechRequest(requestId)) {
+            throw CancellationException("Speech request superseded")
+        }
+    }
+
+    // Wait for the previous speech job to unwind before starting replacement playback.
+    private suspend fun cancelSupersededSpeech(previousJob: Job?) {
+        _uiState.update { it.copy(isSpeaking = false, isPreparingSpeech = false) }
+        cancelAndAwaitSpeechReplacement(previousJob, stopPlayback = { ttsManager?.stop() })
+    }
 
     private fun speak(text: String) {
         val cleanText = com.openclaw.assistant.speech.TTSUtils.stripMarkdownForSpeech(text)
+        val previousJob = speakingJob
+        val requestId = nextSpeechRequestId()
         speakingJob = viewModelScope.launch {
-            _uiState.update { it.copy(isPreparingSpeech = true) }
-
             try {
+                cancelSupersededSpeech(previousJob)
+                ensureCurrentSpeechRequest(requestId)
+                _uiState.update { it.copy(isPreparingSpeech = true, isSpeaking = false) }
+
                 val manager = ttsManager
                 val success = if (manager != null && manager.isReady()) {
-                    speakWithTTSManager(manager, cleanText)
+                    speakWithTTSManager(manager, cleanText, requestId)
                 } else {
                     if (manager == null) {
                         Log.e(TAG, "TTS: ttsManager is null")
@@ -700,6 +722,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
                     false
                 }
 
+                ensureCurrentSpeechRequest(requestId)
                 _uiState.update { it.copy(isSpeaking = false, isPreparingSpeech = false) }
 
                 // If it was a voice conversation and continuous mode is on, continue listening
@@ -709,23 +732,33 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
                     kotlinx.coroutines.delay(1000)
 
                     // Restart listening
+                    ensureCurrentSpeechRequest(requestId)
                     startListening()
                 } else {
                     // Conversation ended
                     releaseWakeLock()
                     sendResumeBroadcast()
                 }
+            } catch (e: CancellationException) {
+                Log.d(TAG, "TTS speak cancelled (requestId=$requestId)")
             } catch (e: Exception) {
                 Log.e(TAG, "TTS speak error", e)
+                if (!isCurrentSpeechRequest(requestId)) {
+                    return@launch
+                }
                 _uiState.update { it.copy(isSpeaking = false, isPreparingSpeech = false) }
                 ttsManager?.stop()
                 releaseWakeLock()
                 sendResumeBroadcast()
+            } finally {
+                if (isCurrentSpeechRequest(requestId)) {
+                    speakingJob = null
+                }
             }
         }
     }
 
-    private suspend fun speakWithTTSManager(manager: TTSManager, text: String): Boolean {
+    private suspend fun speakWithTTSManager(manager: TTSManager, text: String, requestId: Long): Boolean {
         // Query the engine's actual max input length
         val engineMaxLen = com.openclaw.assistant.speech.TTSUtils.getMaxInputLength(null)
         // Further limit to 1000 for stability and consistent timeout behavior
@@ -734,7 +767,8 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
         Log.d(TAG, "TTS splitting text (${text.length} chars) into ${chunks.size} chunks (targetMaxLen=$maxLen, engineMaxLen=$engineMaxLen)")
 
         for ((index, chunk) in chunks.withIndex()) {
-            val success = speakSingleChunkWithManager(manager, chunk)
+            ensureCurrentSpeechRequest(requestId)
+            val success = speakSingleChunkWithManager(manager, chunk, requestId)
             if (!success) {
                 Log.e(TAG, "TTS chunk $index failed, aborting remaining chunks")
                 return false
@@ -743,12 +777,14 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
         return true
     }
 
-    private suspend fun speakSingleChunkWithManager(manager: TTSManager, text: String): Boolean {
+    private suspend fun speakSingleChunkWithManager(manager: TTSManager, text: String, requestId: Long): Boolean {
         var completed = false
         var error = false
         
         try {
+            ensureCurrentSpeechRequest(requestId)
             manager.speakWithProgress(text).collect { state ->
+                ensureCurrentSpeechRequest(requestId)
                 when (state) {
                     is TTSState.Preparing -> {
                         Log.d(TAG, "TTS Preparing")
@@ -767,6 +803,8 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
                     }
                 }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "TTS flow error", e)
             error = true
@@ -776,6 +814,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun stopSpeaking() {
+        nextSpeechRequestId()
         lastInputWasVoice = false // Stop loop if manually stopped
         ttsManager?.stop()
         speakingJob?.cancel()
@@ -796,6 +835,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun interruptAndListen() {
+        nextSpeechRequestId()
         ttsManager?.stop()
         speakingJob?.cancel()
         speakingJob = null

--- a/app/src/main/java/com/openclaw/assistant/ui/chat/SpeechPlaybackTransitions.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/SpeechPlaybackTransitions.kt
@@ -1,0 +1,29 @@
+package com.openclaw.assistant.ui.chat
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.withTimeoutOrNull
+
+internal class SpeechRequestTracker {
+    private var currentRequestId = 0L
+
+    fun nextRequest(): Long {
+        currentRequestId += 1
+        return currentRequestId
+    }
+
+    fun isCurrent(requestId: Long): Boolean = requestId == currentRequestId
+}
+
+internal suspend fun cancelAndAwaitSpeechReplacement(
+    previousJob: Job?,
+    stopPlayback: () -> Unit,
+    waitTimeoutMs: Long = 500L,
+) {
+    stopPlayback()
+    previousJob?.cancel()
+    previousJob?.let { job ->
+        withTimeoutOrNull(waitTimeoutMs) {
+            job.join()
+        }
+    }
+}

--- a/app/src/test/java/com/openclaw/assistant/ui/chat/SpeechPlaybackTransitionsTest.kt
+++ b/app/src/test/java/com/openclaw/assistant/ui/chat/SpeechPlaybackTransitionsTest.kt
@@ -1,0 +1,51 @@
+package com.openclaw.assistant.ui.chat
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpeechPlaybackTransitionsTest {
+    @Test
+    fun requestTrackerInvalidatesSupersededRequests() {
+        val tracker = SpeechRequestTracker()
+
+        val first = tracker.nextRequest()
+        val second = tracker.nextRequest()
+        val stopped = tracker.nextRequest()
+
+        assertFalse(tracker.isCurrent(first))
+        assertFalse(tracker.isCurrent(second))
+        assertTrue(tracker.isCurrent(stopped))
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun cancelAndAwaitSpeechReplacementWaitsForPreviousCleanup() = runTest {
+        val cleanupFinished = CompletableDeferred<Unit>()
+        val previousJob = launch {
+            try {
+                awaitCancellation()
+            } finally {
+                cleanupFinished.complete(Unit)
+            }
+        }
+        var stopped = false
+        runCurrent()
+
+        cancelAndAwaitSpeechReplacement(
+            previousJob = previousJob,
+            stopPlayback = { stopped = true },
+            waitTimeoutMs = 1_000L,
+        )
+
+        assertTrue(stopped)
+        assertTrue(previousJob.isCancelled)
+        assertTrue(cleanupFinished.isCompleted)
+    }
+}


### PR DESCRIPTION
## Summary
- cancel and drain the previous chat TTS job before starting a replacement response
- track active speech requests so stale jobs cannot stop or clean up the newer playback
- add regression tests for speech replacement sequencing

## Testing
- FIREBASE_ENABLED=false ./gradlew :app:testStandardDebugUnitTest --tests com.openclaw.assistant.ui.chat.SpeechPlaybackTransitionsTest --tests com.openclaw.assistant.ui.chat.SessionFiltersTest

## Notes
- `FIREBASE_ENABLED=false ./gradlew :app:testStandardDebugUnitTest` still hits unrelated existing failures in Device/Calendar/Contacts/Notifications/Photos handler tests