### PR TITLE
🔄 Upstream Parity: Remove background location mode & persist migration

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/LocationMode.kt
+++ b/app/src/main/java/com/openclaw/assistant/LocationMode.kt
@@ -3,7 +3,6 @@ package com.openclaw.assistant
 enum class LocationMode(val rawValue: String) {
     Off("off"),
     WhileUsing("whileUsing"),
-    Always("always"),
     ;
 
     companion object {

--- a/app/src/main/java/com/openclaw/assistant/SecurePrefs.kt
+++ b/app/src/main/java/com/openclaw/assistant/SecurePrefs.kt
@@ -21,6 +21,7 @@ class SecurePrefs(context: Context) {
     val defaultWakeWords: List<String> = listOf("openclaw", "claude")
     private const val displayNameKey = "node.displayName"
     private const val voiceWakeModeKey = "voiceWake.mode"
+    private const val locationModeKey = "location.enabledMode"
   }
 
   private val appContext = context.applicationContext
@@ -45,8 +46,7 @@ class SecurePrefs(context: Context) {
   private val _cameraEnabled = MutableStateFlow(prefs.getBoolean("camera.enabled", false))
   val cameraEnabled: StateFlow<Boolean> = _cameraEnabled
 
-  private val _locationMode =
-    MutableStateFlow(LocationMode.fromRawValue(prefs.getString("location.enabledMode", "off")))
+  private val _locationMode = MutableStateFlow(loadLocationMode())
   val locationMode: StateFlow<LocationMode> = _locationMode
 
   private val _locationPreciseEnabled =
@@ -116,7 +116,7 @@ class SecurePrefs(context: Context) {
   }
 
   fun setLocationMode(mode: LocationMode) {
-    prefs.edit { putString("location.enabledMode", mode.rawValue) }
+    prefs.edit { putString(locationModeKey, mode.rawValue) }
     _locationMode.value = mode
   }
 
@@ -233,6 +233,19 @@ class SecurePrefs(context: Context) {
     val resolved = candidate.ifEmpty { "Android Node" }
 
     prefs.edit { putString(displayNameKey, resolved) }
+    return resolved
+  }
+
+  private fun loadLocationMode(): LocationMode {
+    val raw = prefs.getString(locationModeKey, "off")
+    var resolved = LocationMode.fromRawValue(raw)
+
+    // Migrate legacy "always" value to "whileUsing"
+    if (raw?.trim()?.lowercase() == "always") {
+      resolved = LocationMode.WhileUsing
+      prefs.edit { putString(locationModeKey, resolved.rawValue) }
+    }
+
     return resolved
   }
 

--- a/app/src/main/java/com/openclaw/assistant/node/DeviceHandler.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/DeviceHandler.kt
@@ -72,11 +72,6 @@ class DeviceHandler(
   fun handlePermissions(): GatewaySession.InvokeResult {
     val fineLocation = hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     val coarseLocation = hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
-    val backgroundLocation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      hasPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-    } else {
-      fineLocation || coarseLocation
-    }
 
     val payload = buildJsonObject {
       put("camera", JsonPrimitive(hasPermission(Manifest.permission.CAMERA)))
@@ -84,7 +79,6 @@ class DeviceHandler(
       put("location", buildJsonObject {
         put("fine", JsonPrimitive(fineLocation))
         put("coarse", JsonPrimitive(coarseLocation))
-        put("background", JsonPrimitive(backgroundLocation))
       })
       put("sms", JsonPrimitive(hasPermission(Manifest.permission.SEND_SMS)))
     }

--- a/app/src/main/java/com/openclaw/assistant/node/LocationHandler.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/LocationHandler.kt
@@ -36,31 +36,18 @@ class LocationHandler(
       )
   }
 
-  fun hasBackgroundLocationPermission(): Boolean {
-    return (
-      ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
-        PackageManager.PERMISSION_GRANTED
-      )
-  }
-
   suspend fun handleLocationGet(paramsJson: String?): GatewaySession.InvokeResult {
     val mode = locationMode()
-    if (!isForeground() && mode != LocationMode.Always) {
+    if (!isForeground()) {
       return GatewaySession.InvokeResult.error(
         code = "LOCATION_BACKGROUND_UNAVAILABLE",
-        message = "LOCATION_BACKGROUND_UNAVAILABLE: background location requires Always",
+        message = "LOCATION_BACKGROUND_UNAVAILABLE: background location is not available",
       )
     }
     if (!hasFineLocationPermission() && !hasCoarseLocationPermission()) {
       return GatewaySession.InvokeResult.error(
         code = "LOCATION_PERMISSION_REQUIRED",
         message = "LOCATION_PERMISSION_REQUIRED: grant Location permission",
-      )
-    }
-    if (!isForeground() && mode == LocationMode.Always && !hasBackgroundLocationPermission()) {
-      return GatewaySession.InvokeResult.error(
-        code = "LOCATION_PERMISSION_REQUIRED",
-        message = "LOCATION_PERMISSION_REQUIRED: enable Always in system Settings",
       )
     }
     val (maxAgeMs, timeoutMs, desiredAccuracy) = parseLocationParams(paramsJson)


### PR DESCRIPTION
- **Source:** Upstream commits `1230cefe25b8d4d2ab7cb5a8fae7738332a3462e` (remove background location mode) and `04b4b48077571ee6395b4948a6ed38a53c0bcaf2` (persist legacy location mode migration).
- **Why:** Android background location permissions are heavily restricted and often require complicated settings flows. Removing the "Always" background location feature simplifies app compliance, user onboarding, and aligns with the upstream priority of improving permissions/system integration.
- **Adaptation:** Implemented the upstream migration logic directly into our `SecurePrefs.kt` via `loadLocationMode()`. The `Always` enum value is removed from `LocationMode.kt`. The `LocationHandler` no longer checks for background permissions and requires the app to be in the foreground. Removed the `background` key from the `DeviceHandler` JSON response.
- **Excluded upstream behavior:** Didn't blindly copy file paths or unrelated logic changes. Kept the changes minimal and targeted to just the background location removal and migration within our existing architecture.
- **Verification:** Compiled cleanly with `./gradlew app:compileStandardDebugKotlin` and ran `./gradlew app:testStandardDebugUnitTest` (ignoring pre-existing KeyStore sandbox failures). Verified the migration logic successfully updates "always" to "whileUsing".

---
*PR created automatically by Jules for task [885822459318078049](https://jules.google.com/task/885822459318078049) started by @yuga-hashimoto*