### PR TITLE
fix: remove MEDIA_PROJECTION type from NodeForegroundService regular startForeground

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -187,8 +187,7 @@ class NodeForegroundService : Service() {
     }
 
     lastRequiresMic = requiresMic
-    var types = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or
-        ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
+    var types = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
     if (requiresMic) {
         types = types or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
     }


### PR DESCRIPTION
## Summary

- `NodeForegroundService.startForegroundWithTypes()` was always including `FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION` in the FGS type bitmask, even during normal service startup (`onCreate`)
- This type requires the OS-granted `project_media` permission which is only available after the user approves the media projection dialog — not at service creation time
- This caused a `SecurityException` crash on service start (Crashlytics issue `458e1539`, 4 events in v2.4.2)

The correct flow already exists in `ACTION_PREPARE_MEDIA_PROJECTION` (in `onStartCommand`), which is called from within the `ActivityResult` callback after user grants permission — only that path should include `MEDIA_PROJECTION` type.

## Root Cause

```kotlin
// Before: always included MEDIA_PROJECTION — crash at startup
var types = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or
    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION

// After: only DATA_SYNC (and MICROPHONE when mic is active)
var types = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
```

## Test plan

- [ ] Launch the app and confirm NodeForegroundService starts without crashing
- [ ] Start a screen recording session and confirm it still works (MEDIA_PROJECTION type applied via `ACTION_PREPARE_MEDIA_PROJECTION`)
- [ ] Confirm no `SecurityException` in Crashlytics after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)