### PR TITLE
🛡️ Sentinel: [security improvement] Disable local file access in WebView

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
@@ -69,7 +69,7 @@ class CanvasController {
       it.settings.apply {
         javaScriptEnabled = true
         domStorageEnabled = true
-        allowFileAccess = true
+        allowFileAccess = false
         mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
       }
       // Required so JavaScript interactions (dialogs, file choosers, etc.) work properly.


### PR DESCRIPTION
- Set `allowFileAccess = false` in `CanvasController` WebView to prevent local file inclusion vulnerabilities.
- Modern Android WebViews securely handle asset loading (`file:///android_asset/`) independent of this setting in API 30+, so this hardens security without breaking UI scaffolds.

---
*PR created automatically by Jules for task [12644789389503666317](https://jules.google.com/task/12644789389503666317) started by @yuga-hashimoto*