### PR TITLE
Fix accessibility: Use string resource for Settings icon contentDescription

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1025,7 +1025,7 @@ fun SystemStatusCard(
                     modifier = Modifier.weight(1f)
                 )
                 IconButton(onClick = onOpenSettings, modifier = Modifier.size(24.dp)) {
-                    Icon(Icons.Default.Settings, contentDescription = "Settings", tint = contentColor.copy(alpha = 0.6f))
+                    Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.settings_title), tint = contentColor.copy(alpha = 0.6f))
                 }
             }
 


### PR DESCRIPTION
🎨 Palette: Add localized ARIA label (contentDescription) to Settings icon button

💡 **What**: Replaced a hardcoded English string (`"Settings"`) with a proper string resource reference (`stringResource(R.string.settings_title)`) for the `contentDescription` on the Settings icon button inside the `SystemStatusCard`.
🎯 **Why**: When a screen reader focuses on the Settings gear icon, it would read the hardcoded English string "Settings" regardless of the user's selected language. By utilizing the existing Android string resource, the screen reader will now correctly announce the purpose of the button in the user's localized language (e.g., "設定" in Japanese or "Ajustes" in Spanish), directly improving accessibility and the overall user experience.
📸 **Before/After**: No visual changes, accessibility improvement only.
♿ **Accessibility**: Enhanced screen reader support for non-English speakers.

---
*PR created automatically by Jules for task [4053679184427687101](https://jules.google.com/task/4053679184427687101) started by @yuga-hashimoto*