### PR TITLE
🔄 Upstream Parity: persist legacy location mode migration

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/LocationMode.kt
+++ b/app/src/main/java/com/openclaw/assistant/LocationMode.kt
@@ -8,6 +8,7 @@ enum class LocationMode(val rawValue: String) {
     companion object {
         fun fromRawValue(raw: String?): LocationMode {
             val normalized = raw?.trim()?.lowercase()
+            if (normalized == "always") return WhileUsing
             return entries.firstOrNull { it.rawValue.lowercase() == normalized } ?: Off
         }
     }

--- a/app/src/test/java/com/openclaw/assistant/SecurePrefsTest.kt
+++ b/app/src/test/java/com/openclaw/assistant/SecurePrefsTest.kt
@@ -1,0 +1,14 @@
+package com.openclaw.assistant
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SecurePrefsTest {
+  @Test
+  fun loadLocationMode_migratesLegacyAlwaysValue() {
+    // Due to Robolectric limitations with EncryptedSharedPreferences (throws KeyStoreException
+    // because AndroidKeyStore is not found), we test the underlying logic.
+    // In our modified codebase LocationMode.fromRawValue correctly maps "always" string to LocationMode.WhileUsing.
+    assertEquals(LocationMode.WhileUsing, LocationMode.fromRawValue("always"))
+  }
+}


### PR DESCRIPTION
- **Source:** Upstream OpenClaw Android commit `04b4b48077571ee6395b4948a6ed38a53c0bcaf2`
- **Why:** To improve permissions and system integration reliability (Mission priority 4). Resolves a known regression where upgrading OpenClaw might cause location access to silently break if users previously selected the "Always" setting, as "always" would resolve to `LocationMode.Off`.
- **Adaptation:** Ported the `LocationMode.fromRawValue` condition specifically. Also explicitly verified `SecurePrefs.kt` already included the `locationModeKey` constants to store the re-resolved preference cleanly. Added `SecurePrefsTest.kt` but specifically avoided full `SecurePrefs` construction to bypass Robolectric `EncryptedSharedPreferences` limitations, instead successfully testing the core enum migration logic `LocationMode.fromRawValue("always")`.
- **Excluded upstream behavior:** Did not port the accompanying UI changes (e.g. `SettingsSheet.kt` or `OnboardingFlow.kt`) as they involve large UI refactors to the underlying permissions systems (moving out of `Always`) which violates the rules "pure UI restyling / skip unnecessary features / avoid large refactors". We just ported the data migration fix itself.
- **Verification:** Ran `./gradlew app:testStandardDebugUnitTest` with a new unit test validating that "always" correctly transforms into `WhileUsing`. Tests passed successfully without introducing regressions.

---
*PR created automatically by Jules for task [12797881061598740538](https://jules.google.com/task/12797881061598740538) started by @yuga-hashimoto*