### PR TITLE
🧪 Regression Guard: Fix WebView allowFileAccess security vulnerability

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
@@ -69,7 +69,7 @@ class CanvasController {
       it.settings.apply {
         javaScriptEnabled = true
         domStorageEnabled = true
-        allowFileAccess = true
+        allowFileAccess = false
         mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
       }
       // Required so JavaScript interactions (dialogs, file choosers, etc.) work properly.


### PR DESCRIPTION
## Description
Disabled `allowFileAccess` in `CanvasController.kt`'s WebView configuration.

## Why this is necessary
Leaving `allowFileAccess` enabled while `javaScriptEnabled` is true exposes the application to potential local file inclusion and exfiltration vulnerabilities. Modern Android versions (API 30+) default this setting to `false` and allow access to local assets (`file:///android_asset/`) by default, so explicitly disabling it is a security best practice that does not break intended asset loading functionality.

## Verification
- ✅ Ran `./gradlew app:lintStandardDebug` - Passed with no errors.
- ✅ Ran `./gradlew app:testStandardDebugUnitTest` - Verified no new test regressions.
- ✅ Verified change size is minimal (under 100 lines).

---
*PR created automatically by Jules for task [12060624712533141825](https://jules.google.com/task/12060624712533141825) started by @yuga-hashimoto*