### PR TITLE
🎨 Palette: Add ARIA label to info icon in CompactActionCard

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1222,7 +1222,7 @@ fun CompactActionCard(modifier: Modifier = Modifier, icon: ImageVector, title: S
             Column(modifier = Modifier.weight(1f).fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
                 Row(modifier = Modifier.fillMaxWidth().height(32.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                     Icon(imageVector = icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(28.dp))
-                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable { onInfoClick?.invoke() })
+                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = stringResource(R.string.info_description), tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable { onInfoClick?.invoke() })
                     if (showSwitch) Switch(checked = switchValue, onCheckedChange = onSwitchChange, modifier = Modifier.scale(0.8f).offset(y = (-8).dp))
                 }
                 Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -397,6 +397,7 @@
     <string name="location_precise">Precise</string>
     <string name="location_info_title">Location Accuracy Modes</string>
     <string name="location_info_message">Off: AI cannot access your location.\n\nCoarse: City/neighborhood level. Uses less battery.\n\nPrecise: GPS accuracy. Higher battery usage.\n\nLong-press this card to see this info again.</string>
+    <string name="info_description">More information</string>
 
     <!-- App Version -->
     <string name="app_version">Version %s</string>

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./gradlew app:testStandardDebugUnitTest > test_output.txt 2>&1


### PR DESCRIPTION
💡 **What**: Added `contentDescription` to the `HelpOutline` info icon inside `CompactActionCard` in `MainActivity.kt`.
🎯 **Why**: Previously, the icon had a null `contentDescription`, making it invisible to screen readers when used as a clickable element. This change improves accessibility for users relying on TalkBack or similar assistive tools.
📸 **Before/After**: N/A (Non-visual accessibility change)
♿ **Accessibility**: Enhanced screen reader support by properly labeling interactive icon buttons.

---
*PR created automatically by Jules for task [614452645875741593](https://jules.google.com/task/614452645875741593) started by @yuga-hashimoto*