### PR TITLE
🛡️ Sentinel: [security improvement] Disable WebView local file access to prevent LFI

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
@@ -69,7 +69,7 @@ class CanvasController {
       it.settings.apply {
         javaScriptEnabled = true
         domStorageEnabled = true
-        allowFileAccess = true
+        allowFileAccess = false
         mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
       }
       // Required so JavaScript interactions (dialogs, file choosers, etc.) work properly.


### PR DESCRIPTION
This change implements a security hardening improvement by setting `allowFileAccess = false` on the persistent `WebView` used by `CanvasController`. 

When `allowFileAccess` is combined with `javaScriptEnabled = true` (which is needed for the canvas components to function), it creates a Local File Inclusion (LFI) vulnerability. This vulnerability could allow malicious JS payloads (e.g. from compromised external content or MitM) to read arbitrary local files via `file://` URIs and exfiltrate them. 

Setting `allowFileAccess = false` is a standard Android security best practice that neutralizes this threat while still allowing legitimate access to embedded local resources via `file:///android_asset/` and `file:///android_res/` (as per the default behavior on modern Android versions). 

Changes:
- Set `allowFileAccess = false` in `CanvasController.kt`'s `getOrCreateWebView`.

---
*PR created automatically by Jules for task [14162434641386572190](https://jules.google.com/task/14162434641386572190) started by @yuga-hashimoto*