### PR TITLE
chore: add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ firebase-debug.log
 
 # Agent instructions
 AGENTS.md
+
+# Claude Code settings
+.claude/


### PR DESCRIPTION
## Summary
- `.claude/` ディレクトリを `.gitignore` に追加

Claude Code のローカル設定ファイル（`.claude/`）がリポジトリに含まれないようにします。

## Test plan
- [ ] `.gitignore` に `.claude/` が追加されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)