### PR TITLE
🎨 Polish: Improve session action discoverability

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SessionListActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SessionListActivity.kt
@@ -7,8 +7,7 @@ import androidx.activity.ComponentActivity
 import com.openclaw.assistant.data.SettingsRepository
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenu
@@ -471,7 +471,6 @@ fun SessionListScreen(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun SessionListItem(
     session: SessionUiModel,
@@ -481,7 +480,7 @@ private fun SessionListItem(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
+            .clickable(onClick = onClick)
     ) {
         Row(
             modifier = Modifier
@@ -517,6 +516,12 @@ private fun SessionListItem(
                         )
                     }
                 }
+            }
+            IconButton(onClick = onLongClick) {
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = stringResource(R.string.menu)
+                )
             }
         }
     }


### PR DESCRIPTION
Removed the hidden `combinedClickable` (long-press) for session list items and replaced it with a standard `clickable` combined with an explicit `IconButton` containing `Icons.Default.MoreVert` (More options). This significantly improves UX accessibility and discoverability by visually indicating that more actions (Rename/Delete) are available, following the project's UI/UX conventions.

---
*PR created automatically by Jules for task [643074326803630471](https://jules.google.com/task/643074326803630471) started by @yuga-hashimoto*