### PR TITLE
🛡️ Sentinel: Enforce secure URLs in CanvasController

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
@@ -101,7 +101,21 @@ class CanvasController {
 
   fun navigate(url: String) {
     val trimmed = url.trim()
-    this.url = if (trimmed.isBlank() || trimmed == "/") null else trimmed
+
+    val safeUrl = if (trimmed.isBlank() || trimmed == "/") {
+      null
+    } else {
+      val lowerUrl = trimmed.lowercase()
+      when {
+        lowerUrl.startsWith("http://") ||
+        lowerUrl.startsWith("https://") ||
+        lowerUrl.startsWith("file:///android_asset/") -> trimmed
+        lowerUrl.contains("://") -> null // Block other schemes like javascript:, content:, file:// (non-asset)
+        else -> "https://$trimmed" // Default to https for scheme-less URLs like "example.com"
+      }
+    }
+
+    this.url = safeUrl
     _isDefaultState.value = this.url == null
     if (this.url != null) _isPageLoading.value = true
     reload()


### PR DESCRIPTION
Update `CanvasController.navigate()` to explicitly whitelist secure schemes (`http://`, `https://`, and `file:///android_asset/`).

- Any URL matching these schemes is loaded safely.
- Any URL without a scheme (e.g. `example.com`) is upgraded to `https://`.
- Any URL containing `://` that doesn't match the whitelist (like `javascript:`, `content:`, or unauthorized `file://` schemes) evaluates to `null` and is blocked.

This effectively prevents malicious XSS payloads or file inclusion attempts from the gateway.

---
*PR created automatically by Jules for task [14356767704919412534](https://jules.google.com/task/14356767704919412534) started by @yuga-hashimoto*