### PR TITLE
🎨 Palette: Add accessibility labels to icon-only visibility buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-17 - Added contentDescription to visibility toggles
+**Learning:** In settings and input forms, icon-only buttons that toggle visibility (e.g., password visibility) often use `contentDescription = null`. This prevents screen readers from announcing the button's action, creating a critical accessibility barrier for visually impaired users attempting to toggle sensitive information.
+**Action:** When creating or reviewing UI components that feature toggles or icon-only actions, explicitly check for and provide dynamic `contentDescription` attributes that describe the resulting action based on the current state.

--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -661,7 +661,7 @@ fun SettingsScreen(
                                         IconButton(onClick = { showNodeToken = !showNodeToken }) {
                                             Icon(
                                                 if (showNodeToken) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                                                contentDescription = null
+                                                contentDescription = if (showNodeToken) "Hide token" else "Show token"
                                             )
                                         }
                                     },
@@ -678,7 +678,7 @@ fun SettingsScreen(
                                         IconButton(onClick = { showGatewayPassword = !showGatewayPassword }) {
                                             Icon(
                                                 if (showGatewayPassword) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                                                contentDescription = null
+                                                contentDescription = if (showGatewayPassword) "Hide password" else "Show password"
                                             )
                                         }
                                     },
@@ -731,7 +731,7 @@ fun SettingsScreen(
                                     IconButton(onClick = { showNodeToken = !showNodeToken }) {
                                         Icon(
                                             if (showNodeToken) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                                            contentDescription = null
+                                            contentDescription = if (showNodeToken) "Hide token" else "Show token"
                                         )
                                     }
                                 },
@@ -2021,7 +2021,7 @@ fun OpenAISettingsCard(
                     IconButton(onClick = { onShowApiKeyChange(!showApiKey) }) {
                         Icon(
                             if (showApiKey) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                            contentDescription = null
+                            contentDescription = if (showApiKey) "Hide API Key" else "Show API Key"
                         )
                     }
                 },


### PR DESCRIPTION
### 💡 What
Added dynamic `contentDescription` attributes to icon-only buttons (like password/token visibility toggles) in `SettingsActivity.kt`.

### 🎯 Why
Icon-only buttons with `contentDescription = null` are completely ignored by screen readers, making it impossible for visually impaired users to know what the button does or its current state. By providing dynamic labels ("Show token" / "Hide token"), we make the interface significantly more accessible.

### ♿ Accessibility
Improved screen reader compatibility for multiple sensitive inputs in the settings menu.

---
*PR created automatically by Jules for task [10416950885716184018](https://jules.google.com/task/10416950885716184018) started by @yuga-hashimoto*