### PR TITLE
⚡ Bolt: Pre-compile Regex patterns to avoid recompilation overhead

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/chat/ChatMarkdownPreprocessor.kt
+++ b/app/src/main/java/com/openclaw/assistant/chat/ChatMarkdownPreprocessor.kt
@@ -21,6 +21,8 @@ object ChatMarkdownPreprocessor {
         """(?m)^\[[A-Za-z]{3}\s+\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}(?::\d{2})?\s+(?:GMT|UTC)[+-]?\d{0,2}\]\s*"""
     )
 
+    private val leadingNewlinesRegex = Regex("^\\n+")
+
     fun preprocess(raw: String): String {
         val withoutContextBlocks = stripInboundContextBlocks(raw)
         val withoutTimestamps = stripPrefixedTimestamps(withoutContextBlocks)
@@ -64,7 +66,7 @@ object ChatMarkdownPreprocessor {
         }
 
         return outputLines.joinToString("\n")
-            .replace(Regex("^\\n+"), "")
+            .replace(leadingNewlinesRegex, "")
     }
 
     private fun stripPrefixedTimestamps(raw: String): String =

--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewayTls.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewayTls.kt
@@ -166,8 +166,10 @@ private fun sha256Hex(data: ByteArray): String {
   return out.toString()
 }
 
+private val SHA256_PREFIX_REGEX = Regex("^sha-?256\\s*:?\\s*", RegexOption.IGNORE_CASE)
+
 private fun normalizeFingerprint(raw: String): String {
   val stripped = raw.trim()
-    .replace(Regex("^sha-?256\\s*:?\\s*", RegexOption.IGNORE_CASE), "")
+    .replace(SHA256_PREFIX_REGEX, "")
   return stripped.lowercase(Locale.US).filter { it in '0'..'9' || it in 'a'..'f' }
 }

--- a/app/src/main/java/com/openclaw/assistant/node/CameraHandler.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CameraHandler.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.asRequestBody
 
+private val URL_REGEX = Regex("\"url\":\"([^\"]+)\"")
+
 class CameraHandler(
   private val appContext: Context,
   private val camera: CameraCaptureManager,
@@ -136,7 +138,7 @@ class CameraHandler(
           filePayload.file.delete()
           if (!resp.isSuccessful) throw Exception("upload failed: HTTP ${resp.code}")
           // Parse URL from response
-          val urlMatch = Regex("\"url\":\"([^\"]+)\"").find(respBody)
+          val urlMatch = URL_REGEX.find(respBody)
           urlMatch?.groupValues?.get(1) ?: throw Exception("no url in response: $respBody")
         }
       } catch (err: Throwable) {


### PR DESCRIPTION
💡 **What**: Extracted inline `Regex` instantiations to `private val` constants across `ChatMarkdownPreprocessor.kt`, `GatewayTls.kt`, and `CameraHandler.kt`.
🎯 **Why**: Instantiating a `Regex("...")` inline forces the JVM to recompile the regular expression pattern every time the containing method executes.
📊 **Impact**: Eliminates recurring regex compilation overhead, marginally decreasing CPU spikes and parsing latency, specifically noticeable during streaming chunk pre-processing and repeated network callbacks.
🔬 **Measurement**: Inspect memory dumps/profiling indicating fewer `java.util.regex.Pattern` allocations. Tested via app lint checks and unit tests.

---
*PR created automatically by Jules for task [1014781385326305810](https://jules.google.com/task/1014781385326305810) started by @yuga-hashimoto*