### PR TITLE
fix: reduce wake word over-sensitivity and add adjustable threshold

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -250,6 +250,7 @@ fun SettingsScreen(
     var resumeLatestSession by rememberSaveable { mutableStateOf(settings.resumeLatestSession) }
     var wakeWordPreset by rememberSaveable { mutableStateOf(settings.wakeWordPreset) }
     var customWakeWord by rememberSaveable { mutableStateOf(settings.customWakeWord) }
+    var wakeWordSensitivity by rememberSaveable { mutableStateOf(settings.wakeWordSensitivity) }
     var speechSilenceTimeout by rememberSaveable { mutableStateOf(settings.speechSilenceTimeout.toFloat().coerceIn(5000f, 30000f)) }
     var speechLanguage by rememberSaveable { mutableStateOf(settings.speechLanguage) }
     var appLanguage by rememberSaveable { mutableStateOf(settings.appLanguage) }
@@ -465,6 +466,7 @@ fun SettingsScreen(
                             settings.resumeLatestSession = resumeLatestSession
                             settings.wakeWordPreset = wakeWordPreset
                             settings.customWakeWord = customWakeWord
+                            settings.wakeWordSensitivity = wakeWordSensitivity
                             settings.wakewordConnectionType = wakewordConnectionType
                             settings.speechSilenceTimeout = speechSilenceTimeout.toLong()
                             settings.speechLanguage = speechLanguage
@@ -1393,7 +1395,34 @@ fun SettingsScreen(
                                 )
                             }
 
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp), thickness = 0.5.dp)
 
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(stringResource(R.string.wake_word_sensitivity), style = MaterialTheme.typography.bodyLarge)
+                                Text(
+                                    text = "%.2f".format(wakeWordSensitivity),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                            Text(
+                                stringResource(R.string.wake_word_sensitivity_desc),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.Gray
+                            )
+                            Slider(
+                                value = wakeWordSensitivity,
+                                onValueChange = { wakeWordSensitivity = it },
+                                valueRange = 0.0f..1.0f,
+                                steps = 19,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
 
                         HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp), thickness = 0.5.dp)
 

--- a/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
@@ -63,6 +63,11 @@ class SettingsRepository(context: Context) {
         get() = prefs.getString(KEY_CUSTOM_WAKE_WORD, "") ?: ""
         set(value) = prefs.edit().putString(KEY_CUSTOM_WAKE_WORD, value).apply()
 
+    // Wake word detection sensitivity threshold (0.0 = easiest to trigger, 1.0 = hardest)
+    var wakeWordSensitivity: Float
+        get() = prefs.getFloat(KEY_WAKE_WORD_SENSITIVITY, 0.7f)
+        set(value) = prefs.edit().putFloat(KEY_WAKE_WORD_SENSITIVITY, value.coerceIn(0.0f, 1.0f)).apply()
+
     // Get the actual wake words list for Vosk
     fun getWakeWords(): List<String> {
         return when (wakeWordPreset) {
@@ -282,6 +287,7 @@ class SettingsRepository(context: Context) {
         private const val KEY_HOTWORD_ENABLED = "hotword_enabled"
         private const val KEY_WAKE_WORD_PRESET = "wake_word_preset"
         private const val KEY_CUSTOM_WAKE_WORD = "custom_wake_word"
+        private const val KEY_WAKE_WORD_SENSITIVITY = "wake_word_sensitivity"
         private const val KEY_IS_VERIFIED = "is_verified"
         private const val KEY_TTS_ENABLED = "tts_enabled"
         private const val KEY_CONTINUOUS_MODE = "continuous_mode"

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -478,9 +478,9 @@ class HotwordService : Service(), VoskRecognitionListener {
         audioRetryCount = 0
 
         try {
-            // Get wake words from settings
+            // Get wake words from settings; add [unk] so Vosk can absorb non-matching speech
             val wakeWords = settings.getWakeWords()
-            val wakeWordsJson = wakeWords.joinToString("\", \"", "[\"", "\"]")
+            val wakeWordsJson = (wakeWords + "[unk]").joinToString("\", \"", "[\"", "\"]")
             Log.d(TAG, "Starting hotword detection with words: $wakeWordsJson")
 
             val rec = Recognizer(model, SAMPLE_RATE, wakeWordsJson)
@@ -513,6 +513,18 @@ class HotwordService : Service(), VoskRecognitionListener {
         }
     }
 
+    /**
+     * Parses Vosk keyword spotting confidence for [word] from result text.
+     * Vosk grammar mode returns results like "[open claw](0.92)" or plain "open claw".
+     * Returns the score (0.0–1.0), or 1.0 if plain text match, or 0.0 if not found.
+     */
+    private fun parseWakeWordConfidence(text: String, word: String): Float {
+        val pattern = Regex("\\[${Regex.escape(word)}\\]\\(([0-9.]+)\\)", RegexOption.IGNORE_CASE)
+        val match = pattern.find(text)
+        return match?.groupValues?.get(1)?.toFloatOrNull()
+            ?: if (text.contains(word, ignoreCase = true)) 1.0f else 0.0f
+    }
+
     override fun onPartialResult(hypothesis: String?) {}
 
     override fun onResult(hypothesis: String?) {
@@ -522,9 +534,11 @@ class HotwordService : Service(), VoskRecognitionListener {
                 val json = JSONObject(it)
                 val text = json.optString("text", "")
 
-                // Check against configured wake words
+                // Check against configured wake words with confidence threshold
                 val wakeWords = settings.getWakeWords()
-                val detected = wakeWords.any { word -> text.contains(word) }
+                val detected = wakeWords.any { word ->
+                    parseWakeWordConfidence(text, word) >= settings.wakeWordSensitivity
+                }
 
                 if (detected) {
                     Log.e(TAG, "Hotword detected! Text: $text")

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
@@ -373,13 +373,23 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
         listeningJob?.cancel()
         acquireWakeLock()
         sendPauseBroadcast()
-        
+
         currentState.value = AssistantState.PROCESSING
         displayText.value = ""
         userQuery.value = ""
         partialText.value = ""
         errorMessage.value = null
         audioLevel.value = 0f
+
+        // Fallback: if SpeechResult.Ready doesn't arrive within 2s, force LISTENING
+        // so users don't see "Processing" indefinitely while the recognizer warms up
+        scope.launch {
+            delay(2000L)
+            if (currentState.value == AssistantState.PROCESSING) {
+                Log.w(TAG, "SpeechResult.Ready timeout — forcing LISTENING state")
+                currentState.value = AssistantState.LISTENING
+            }
+        }
 
         listeningJob = scope.launch {
             val startTime = System.currentTimeMillis()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -195,6 +195,8 @@ Weitere Informationen finden Sie auf der offiziellen Website von VOICEVOX.</stri
 <string name="wake_word_jarvis">Jarvis</string>
 <string name="wake_word_computer">Computer</string>
 <string name="wake_word_custom">Brauch…</string>
+<string name="wake_word_sensitivity">Erkennungsempfindlichkeit</string>
+<string name="wake_word_sensitivity_desc">Höhere Werte erfordern mehr Sicherheit. Verringern, wenn das Aktivierungswort nicht erkannt wird; erhöhen, wenn es zu leicht ausgelöst wird.</string>
 <string name="mic_permission_rationale_title">Mikrofonberechtigung erforderlich</string>
 <string name="mic_permission_rationale_message">Die Wake-Word-Erkennung benötigt Zugriff auf das Mikrofon, um auf Ihren Sprachbefehl zu hören. Ohne diese Berechtigung kann die Aktivierungsworterkennung nicht funktionieren.\n\nBitte erteilen Sie auf dem nächsten Bildschirm die Mikrofonberechtigung.</string>
 <string name="mic_permission_denied_title">Mikrofonberechtigung verweigert</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -196,6 +196,8 @@ Para más detalles, consulta el sitio oficial de VOICEVOX.</string>
 <string name="wake_word_jarvis">Jarvis</string>
 <string name="wake_word_computer">Computadora</string>
 <string name="wake_word_custom">Personalizado…</string>
+<string name="wake_word_sensitivity">Sensibilidad de detección</string>
+<string name="wake_word_sensitivity_desc">Los valores más altos requieren mayor confianza para activarse. Reduce si la palabra de activación no se detecta; aumenta si se activa con demasiada facilidad.</string>
 <string name="mic_permission_rationale_title">Se requiere permiso de micrófono</string>
 <string name="mic_permission_rationale_message">La detección de palabras de activación necesita acceso al micrófono para escuchar su comando de voz. Sin este permiso, la detección de palabras de activación no puede funcionar.\n\nConceda permiso al micrófono en la siguiente pantalla.</string>
 <string name="mic_permission_denied_title">Permiso de micrófono denegado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -196,6 +196,8 @@ Pour plus de détails, consultez le site officiel de VOICEVOX.</string>
 <string name="wake_word_jarvis">Jarvis</string>
 <string name="wake_word_computer">Ordinateur</string>
 <string name="wake_word_custom">Custom…</string>
+<string name="wake_word_sensitivity">Sensibilité de détection</string>
+<string name="wake_word_sensitivity_desc">Des valeurs plus élevées requièrent plus de confiance pour se déclencher. Réduisez si le mot de réveil n\'est pas détecté ; augmentez s\'il se déclenche trop facilement.</string>
 <string name="mic_permission_rationale_title">Autorisation du microphone requise</string>
 <string name="mic_permission_rationale_message">La détection des mots de réveil nécessite un accès au microphone pour écouter votre commande vocale. Sans cette autorisation, la détection des mots d\'activation ne peut pas fonctionner.\n\nVeuillez accorder l\'autorisation du microphone sur l\'écran suivant.</string>
 <string name="mic_permission_denied_title">Autorisation du microphone refusée</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -196,6 +196,8 @@
 <string name="wake_word_jarvis">जार्विस</string>
 <string name="wake_word_computer">कंप्यूटर</string>
 <string name="wake_word_custom">रिवाज़…</string>
+<string name="wake_word_sensitivity">पहचान संवेदनशीलता</string>
+<string name="wake_word_sensitivity_desc">अधिक मान के लिए अधिक विश्वास की आवश्यकता होती है। यदि वेक वर्ड नहीं पकड़ा जाता तो कम करें; यदि बहुत आसानी से ट्रिगर होता है तो बढ़ाएं।</string>
 <string name="mic_permission_rationale_title">माइक्रोफ़ोन अनुमति आवश्यक है</string>
 <string name="mic_permission_rationale_message">वेक वर्ड डिटेक्शन को आपके वॉयस कमांड को सुनने के लिए माइक्रोफ़ोन एक्सेस की आवश्यकता होती है। इस अनुमति के बिना, वेक वर्ड डिटेक्शन काम नहीं कर सकता।\n\nकृपया अगली स्क्रीन पर माइक्रोफ़ोन की अनुमति दें।</string>
 <string name="mic_permission_denied_title">माइक्रोफ़ोन अनुमति अस्वीकृत</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -195,6 +195,8 @@
 <string name="wake_word_jarvis">Jarvis</string>
 <string name="wake_word_computer">Computer</string>
 <string name="wake_word_custom">カスタム…</string>
+<string name="wake_word_sensitivity">検知感度</string>
+<string name="wake_word_sensitivity_desc">値が高いほど確信度の高い発話でのみ反応します。検知されにくい場合は下げ、誤検知が多い場合は上げてください。</string>
 <string name="mic_permission_rationale_title">マイクの権限が必要です</string>
 <string name="mic_permission_rationale_message">ウェイクワード検知には、音声コマンドを聞き取るためにマイクへのアクセスが必要です。この権限がないと、ウェイクワード検知は動作しません。\n\n次の画面でマイクの権限を許可してください。</string>
 <string name="mic_permission_denied_title">マイクの権限が拒否されました</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -196,6 +196,8 @@
 <string name="wake_word_jarvis">Джарвис</string>
 <string name="wake_word_computer">Компьютер</string>
 <string name="wake_word_custom">Пользовательский…</string>
+<string name="wake_word_sensitivity">Чувствительность обнаружения</string>
+<string name="wake_word_sensitivity_desc">Более высокие значения требуют большей уверенности для срабатывания. Уменьшите, если слово не распознаётся; увеличьте, если срабатывает слишком легко.</string>
 <string name="mic_permission_rationale_title">Требуется разрешение микрофона</string>
 <string name="mic_permission_rationale_message">Для обнаружения слов требуется доступ к микрофону для прослушивания вашей голосовой команды. Без этого разрешения обнаружение слов пробуждения не может работать.\n\nПожалуйста, предоставьте разрешение микрофона на следующем экране.</string>
 <string name="mic_permission_denied_title">Разрешение на использование микрофона отклонено</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -196,6 +196,8 @@
 <string name="wake_word_jarvis">贾维斯</string>
 <string name="wake_word_computer">计算机</string>
 <string name="wake_word_custom">自定义…</string>
+<string name="wake_word_sensitivity">检测灵敏度</string>
+<string name="wake_word_sensitivity_desc">值越高，触发所需的置信度越高。若唤醒词未被检测到，请降低此值；若误触发过多，请提高此值。</string>
 <string name="mic_permission_rationale_title">需要麦克风权限</string>
 <string name="mic_permission_rationale_message">唤醒词检测需要麦克风访问权限来监听您的语音命令。如果没有此权限，唤醒词检测将无法工作。\n\n请在下一个屏幕上授予麦克风权限。</string>
 <string name="mic_permission_denied_title">麦克风权限被拒绝</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -195,6 +195,8 @@
 <string name="wake_word_jarvis">賈維斯</string>
 <string name="wake_word_computer">電腦</string>
 <string name="wake_word_custom">風俗…</string>
+<string name="wake_word_sensitivity">偵測靈敏度</string>
+<string name="wake_word_sensitivity_desc">值越高，觸發所需的信心度越高。若喚醒詞未被偵測到，請降低此值；若誤觸發過多，請提高此值。</string>
 <string name="mic_permission_rationale_title">需要麥克風許可</string>
 <string name="mic_permission_rationale_message">喚醒詞偵測需要麥克風存取權限來監聽您的語音命令。如果沒有此權限，喚醒單字偵測將無法運作。 \n\n請在下一個畫面上授予麥克風權限。</string>
 <string name="mic_permission_denied_title">麥克風權限被拒絕</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,6 +207,8 @@
     <string name="wake_word_jarvis">Jarvis</string>
     <string name="wake_word_computer">Computer</string>
     <string name="wake_word_custom">Custom…</string>
+    <string name="wake_word_sensitivity">Detection Sensitivity</string>
+    <string name="wake_word_sensitivity_desc">Higher values require more confidence to trigger. Reduce if the wake word isn\'t detected; increase if it fires too easily.</string>
     
 
     <!-- Permission handling -->


### PR DESCRIPTION
## Summary

- **Vosk confidence score filtering**: Wake word detection now parses the confidence score from Vosk's keyword spotting output (`[open claw](0.92)` format) and only triggers when the score meets the configured threshold. Previously, any substring match — even low-confidence detections — would fire.
- **`[unk]` grammar entry**: Added `[unk]` to the Vosk grammar so non-matching speech is absorbed by the recognizer rather than producing spurious wake word hits.
- **User-adjustable sensitivity**: Added a "Detection Sensitivity" slider (0.0–1.0, default 0.7) to Settings > Wake Word, localized for all 9 supported languages. Lower = easier to trigger; higher = stricter.
- **Fix long PROCESSING state**: After wake word activation, the overlay was stuck on yellow "Processing" for several seconds while the Android SpeechRecognizer warmed up. Added a 2-second fallback that forces transition to LISTENING if `onReadyForSpeech` is delayed.

## Test plan

- [ ] Say wake word clearly → assistant activates (sensitivity 0.70)
- [ ] Say similar-sounding words (e.g. background TV) → no false trigger
- [ ] Adjust slider lower → easier to trigger; adjust higher → harder
- [ ] Wake word overlay transitions from yellow → green within ~2s
- [ ] Settings save/restore correctly across app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)