### PR TITLE
🛡️ Sentinel: Add URL scheme validation to CanvasController to prevent unsafe navigation

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
@@ -101,7 +101,20 @@ class CanvasController {
 
   fun navigate(url: String) {
     val trimmed = url.trim()
-    this.url = if (trimmed.isBlank() || trimmed == "/") null else trimmed
+    val safeUrl = if (trimmed.isBlank() || trimmed == "/") {
+      null
+    } else {
+      val lower = trimmed.lowercase()
+      if (lower.startsWith("http://") ||
+          lower.startsWith("https://") ||
+          lower.startsWith("file:///android_asset/")) {
+        trimmed
+      } else {
+        Log.w("OpenClawCanvas", "Blocked unsafe navigation URL: $trimmed")
+        null
+      }
+    }
+    this.url = safeUrl
     _isDefaultState.value = this.url == null
     if (this.url != null) _isPageLoading.value = true
     reload()


### PR DESCRIPTION
In `CanvasController`, the URL passed to the `navigate` method was not sanitized for valid schemes before being loaded into a WebView.

This adds explicit URL validation matching against safe schemes (`http://`, `https://`, and `file:///android_asset/`). Any URLs that do not match these schemes are logged with a warning and default to the `null` state, loading the scaffold view instead of executing potentially malicious content like arbitrary JavaScript (`javascript:`) or reading arbitrary internal files (`file://`).

---
*PR created automatically by Jules for task [16050609424516280925](https://jules.google.com/task/16050609424516280925) started by @yuga-hashimoto*