### PR TITLE
🎨 Palette: Replace text close button with accessible semantic Icon in AttachmentChip

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-17 - Added contentDescription to visibility toggles
 **Learning:** In settings and input forms, icon-only buttons that toggle visibility (e.g., password visibility) often use `contentDescription = null`. This prevents screen readers from announcing the button's action, creating a critical accessibility barrier for visually impaired users attempting to toggle sensitive information.
 **Action:** When creating or reviewing UI components that feature toggles or icon-only actions, explicitly check for and provide dynamic `contentDescription` attributes that describe the resulting action based on the current state.
+
+## 2025-02-16 - Replace plain text icons with semantic Icons in Compose
+**Learning:** Using simple string characters (like "×") as button labels inside `IconButton` leads to confusing screen reader announcements (e.g., "times" or "cross") instead of the actual action ("Close" or "Delete"). This negatively affects accessibility.
+**Action:** Always replace standalone text characters used as interactive visual symbols with standard Compose `Icon` components (e.g., `Icons.Default.Close`) alongside an explicit `contentDescription` (e.g., `stringResource(R.string.close)` or `delete`). This ensures the screen reader announces the correct semantic action.

--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.SmartToy
@@ -1061,7 +1062,11 @@ fun AttachmentChip(fileName: String, onRemove: () -> Unit) {
                 onClick = onRemove,
                 modifier = Modifier.size(30.dp),
             ) {
-                Text("×")
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(R.string.delete),
+                    modifier = Modifier.size(16.dp)
+                )
             }
         }
     }


### PR DESCRIPTION
💡 **What**: Replaced the plain text `"×"` character inside the `FilledTonalIconButton` of `AttachmentChip` with a standard Material `Icon(Icons.Default.Close)` accompanied by an explicit `contentDescription` (`R.string.delete`).
🎯 **Why**: A screen reader announces the literal character `"×"` as "times" or "cross", causing confusion about the button's action. A semantic `Icon` with a correct description ensures screen readers correctly interpret and announce the button as "Delete" or "Close". 
♿ **Accessibility**: Enhanced screen reader compatibility and accuracy without altering the visual footprint (maintaining an explicit 16.dp size).

---
*PR created automatically by Jules for task [3912607570856770011](https://jules.google.com/task/3912607570856770011) started by @yuga-hashimoto*