### PR TITLE
🧪 Regression Guard: Fix media projection fallback crash

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -119,8 +119,16 @@ class NodeForegroundService : Service() {
             }
             startForeground(NOTIFICATION_ID, notification, fallbackTypes)
             lastNotification = notification
-          } catch (e2: SecurityException) {
+          } catch (e2: Exception) {
             android.util.Log.e(TAG, "startForeground fallback also failed: ${e2.message}")
+            if (lastRequiresMic) {
+              try {
+                startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+                lastNotification = notification
+              } catch (e3: Exception) {
+                android.util.Log.e(TAG, "startForeground final fallback failed: ${e3.message}")
+              }
+            }
           }
         }
         mediaProjectionReady.getAndSet(null)?.complete(Unit)


### PR DESCRIPTION
**What**
Updated the fallback logic in `NodeForegroundService.kt` when starting the foreground service with `MEDIA_PROJECTION` fails. The code now catches `Exception` instead of just `SecurityException` and includes a final fallback that explicitly drops the `MICROPHONE` type.

**Why**
On modern Android versions (Android 12+), attempting to start a restricted foreground service from the background (like microphone) may throw `ForegroundServiceStartNotAllowedException` (which is an `IllegalStateException`, not a `SecurityException`). The previous code only caught `SecurityException`, which would result in a hard crash if the system denied the background start. Additionally, the first fallback attempt included the `MICROPHONE` type, which would simply cause a secondary crash if the mic permission or state was the root cause. This fix ensures the service stays alive by falling back gracefully to the basic `DATA_SYNC` type.

**Impact**
Prevents hard crashes related to Android's strict background Foreground Service execution limits.

**Testing**
Ran `./gradlew app:lintStandardDebug` and `./gradlew app:testStandardDebugUnitTest`.
No regressions introduced.

---
*PR created automatically by Jules for task [2986102307428864196](https://jules.google.com/task/2986102307428864196) started by @yuga-hashimoto*