### PR TITLE
🎨 Polish: Improve accessibility labels for screen readers

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
@@ -368,7 +368,7 @@ private fun WelcomeStep(onNext: () -> Unit) {
         ) {
             Icon(
                 imageVector = Icons.Default.Launch,
-                contentDescription = null,
+                contentDescription = stringResource(R.string.setup_guide_title),
                 modifier = Modifier.size(80.dp),
                 tint = OnboardingGradientMid
             )
@@ -514,7 +514,7 @@ private fun ConnectionStep(
                 ),
                 border = androidx.compose.foundation.BorderStroke(1.dp, OnboardingGradientMid)
             ) {
-                Icon(Icons.Default.QrCodeScanner, contentDescription = null)
+                Icon(Icons.Default.QrCodeScanner, contentDescription = stringResource(R.string.qr_scan_prompt))
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(stringResource(R.string.qr_scan_prompt), fontSize = 16.sp)
             }
@@ -825,7 +825,10 @@ private fun PermissionItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .combinedClickable(onClick = onClick)
+            .combinedClickable(
+                onClick = onClick,
+                onClickLabel = stringResource(R.string.permission_toggle_accessibility_label, name)
+            )
             .padding(vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -840,7 +843,7 @@ private fun PermissionItem(
         ) {
             Icon(
                 icon,
-                contentDescription = null,
+                contentDescription = name,
                 tint = if (isGranted) OnboardingGradientMid else OnboardingTextSecondary
             )
         }
@@ -1000,7 +1003,7 @@ private fun FinalCheckStep(
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(Icons.Default.Shield, contentDescription = null, tint = OnboardingGradientMid)
+            Icon(Icons.Default.Shield, contentDescription = stringResource(R.string.permission_summary_title), tint = OnboardingGradientMid)
             Spacer(modifier = Modifier.width(12.dp))
             Column {
                 Text(
@@ -1160,7 +1163,7 @@ private fun CommandBlock(command: String) {
         Spacer(modifier = Modifier.width(8.dp))
         Icon(
             imageVector = Icons.Default.ContentCopy,
-            contentDescription = null,
+            contentDescription = stringResource(R.string.pairing_copy_command),
             tint = Color(0xFF58A6FF),
             modifier = Modifier.size(16.dp)
         )

--- a/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
@@ -46,7 +46,7 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(Icons.Default.Devices, contentDescription = null, tint = MaterialTheme.colorScheme.error)
+                Icon(Icons.Default.Devices, contentDescription = stringResource(R.string.pairing_required_title), tint = MaterialTheme.colorScheme.error)
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = stringResource(R.string.pairing_required_title),
@@ -90,7 +90,7 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
                     contentPadding = PaddingValues(horizontal = 8.dp),
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
                 ) {
-                    Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(16.dp))
+                    Icon(Icons.Default.ContentCopy, contentDescription = stringResource(R.string.pairing_copy_command), modifier = Modifier.size(16.dp))
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(stringResource(R.string.pairing_approve_command), fontSize = 12.sp)
                 }
@@ -115,7 +115,7 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
             ) {
-                Icon(Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
+                Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.pairing_refresh_status), modifier = Modifier.size(18.dp))
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(stringResource(R.string.pairing_refresh_status))
             }
@@ -126,7 +126,10 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
                 modifier = Modifier.align(Alignment.CenterHorizontally)
             ) {
                 Text(if (expanded) stringResource(R.string.hide_instructions) else stringResource(R.string.show_instructions))
-                Icon(if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore, contentDescription = null)
+                Icon(
+                    imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                    contentDescription = if (expanded) stringResource(R.string.hide_instructions) else stringResource(R.string.show_instructions)
+                )
             }
 
             if (expanded) {

--- a/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -69,6 +71,15 @@ fun StatusIndicator(
                 .size(dotSize)
                 .alpha(alpha)
                 .background(dotColor, CircleShape)
+                .then(
+                    if (label == null) {
+                        Modifier.semantics {
+                            contentDescription = state.name
+                        }
+                    } else {
+                        Modifier
+                    }
+                )
         )
         if (label != null) {
             Text(

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -491,6 +491,7 @@
 <string name="permission_notification_listener_desc">AIが通知を読み取って管理するために必要です</string>
 <string name="permission_install_unknown_apps">不明なアプリのインストール</string>
 <string name="permission_install_unknown_apps_desc">AIがアプリのアップデートをインストールすることを許可します</string>
+<string name="permission_toggle_accessibility_label">%1$sの権限を切り替える</string>
 <string name="permission_summary_title">権限の概要</string>
 <string name="permission_summary_format">%1$d 個の標準権限、%2$d 個の特別なアクセスが許可されました</string>
 <string name="qr_scan_prompt">QRコードをスキャンしてください</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -585,6 +585,7 @@
     <string name="permission_notification_listener_desc">Required for AI to read and manage notifications</string>
     <string name="permission_install_unknown_apps">Install Unknown Apps</string>
     <string name="permission_install_unknown_apps_desc">Allow AI to install app updates</string>
+    <string name="permission_toggle_accessibility_label">Toggle %1$s permission</string>
     <string name="permission_summary_title">Permissions Summary</string>
     <string name="permission_summary_format">%1$d standard permissions, %2$d special access granted</string>
 


### PR DESCRIPTION
🎨 Polish: Improve accessibility labels for screen readers

- Add localized `onClickLabel` to permission toggles in `SetupGuideScreen` to properly announce their action to screen readers.
- Add an invisible `contentDescription` semantic modifier to `StatusIndicator` to announce the connection status (e.g. Connected, Disconnected) when no explicit text label is provided.

---
*PR created automatically by Jules for task [3606918467456320415](https://jules.google.com/task/3606918467456320415) started by @yuga-hashimoto*