### PR TITLE
🎨 Palette: Fix FAB icon accessibility description in Chat Input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,7 +1,3 @@
-## 2025-02-17 - Added contentDescription to visibility toggles
-**Learning:** In settings and input forms, icon-only buttons that toggle visibility (e.g., password visibility) often use `contentDescription = null`. This prevents screen readers from announcing the button's action, creating a critical accessibility barrier for visually impaired users attempting to toggle sensitive information.
-**Action:** When creating or reviewing UI components that feature toggles or icon-only actions, explicitly check for and provide dynamic `contentDescription` attributes that describe the resulting action based on the current state.
-
-## 2025-02-16 - Replace plain text icons with semantic Icons in Compose
-**Learning:** Using simple string characters (like "×") as button labels inside `IconButton` leads to confusing screen reader announcements (e.g., "times" or "cross") instead of the actual action ("Close" or "Delete"). This negatively affects accessibility.
-**Action:** Always replace standalone text characters used as interactive visual symbols with standard Compose `Icon` components (e.g., `Icons.Default.Close`) alongside an explicit `contentDescription` (e.g., `stringResource(R.string.close)` or `delete`). This ensures the screen reader announces the correct semantic action.
+## 2025-02-13 - Dynamic Content Descriptions for Multi-state Buttons
+**Learning:** Hardcoded accessibility descriptions (`contentDescription`) on multi-purpose Compose elements (like a FAB that acts as "Send", "Stop", or "Mic" depending on state) will cause screen readers to announce misleading actions.
+**Action:** When evaluating or creating multi-state interactive icons or buttons in Compose, always ensure the `contentDescription` string is computed dynamically using the same state rules as the `imageVector` or `onClick` handler.

--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -1001,6 +1001,16 @@ fun ChatInputArea(
             else -> MaterialTheme.colorScheme.primary
         }
 
+        val iconDesc = if (!canSend) {
+            when {
+                isListening -> stringResource(R.string.stop_description)
+                isSpeaking -> stringResource(R.string.interrupt_description)
+                else -> stringResource(R.string.start_listening_description)
+            }
+        } else {
+            stringResource(R.string.send_description)
+        }
+
         FloatingActionButton(
             onClick = {
                 if (!canSend) onMicClick() else onSend()
@@ -1018,7 +1028,7 @@ fun ChatInputArea(
                 } else {
                      Icons.AutoMirrored.Filled.Send
                 },
-                contentDescription = stringResource(R.string.send_description),
+                contentDescription = iconDesc,
                 tint = Color.White
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,8 @@
     <string name="ask_hint">Ask OpenClaw…</string>
     <string name="send_description">Send</string>
     <string name="stop_description">Stop</string>
+    <string name="start_listening_description">Start listening</string>
+    <string name="interrupt_description">Interrupt and listen</string>
     <string name="listening">Listening…</string>
     <string name="thinking">Thinking…</string>
     <string name="speaking">Speaking…</string>


### PR DESCRIPTION
💡 **What:** The UX enhancement added: The main multi-function floating action button in the chat view now correctly updates its accessibility description based on whether it is functioning as "Send", "Start Listening", "Stop Listening", or "Interrupt".
🎯 **Why:** The user problem it solves: Blind or visually impaired users relying on TalkBack would previously always hear the button announced as "Send", even when it was displaying a microphone or a stop icon and performing voice-related actions.
📸 **Before/After:** N/A (Visuals remain the same, underlying accessibility label changes).
♿ **Accessibility:** This directly fixes a critical misleading state announcement for screen readers on the main action button.

---
*PR created automatically by Jules for task [3670918126643705532](https://jules.google.com/task/3670918126643705532) started by @yuga-hashimoto*