### PR TITLE
🧪 Regression Guard: Fix startForeground exception handling

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -184,7 +184,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             } else {
                 startForeground(NOTIFICATION_ID, createNotification())
             }
-        } catch (e: SecurityException) {
+        } catch (e: Exception) {
             // This can happen on Android 14+ if the app is not in an eligible state
             // (e.g. started from background without a visible activity). Handled gracefully.
             Log.e(TAG, "Failed to start foreground service", e)

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -111,7 +111,7 @@ class NodeForegroundService : Service() {
         try {
           startForeground(NOTIFICATION_ID, notification, types)
           lastNotification = notification
-        } catch (e: SecurityException) {
+        } catch (e: Exception) {
           android.util.Log.w(TAG, "startForeground(mediaProjection) failed, falling back to dataSync: ${e.message}")
           try {
             val fallbackTypes = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC.let {
@@ -215,13 +215,13 @@ class NodeForegroundService : Service() {
 
     try {
       startForeground(NOTIFICATION_ID, notification, types)
-    } catch (e: SecurityException) {
+    } catch (e: Exception) {
       android.util.Log.w(TAG, "startForeground failed (types=$types): ${e.message}")
       // Fall back to dataSync-only if microphone type was the cause
       if (requiresMic) {
         try {
           startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
-        } catch (e2: SecurityException) {
+        } catch (e2: Exception) {
           android.util.Log.e(TAG, "startForeground fallback also failed: ${e2.message}")
         }
       }

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -66,11 +66,11 @@ class SessionForegroundService : Service() {
             } else {
                 startForeground(NOTIFICATION_ID, createNotification())
             }
-        } catch (e: SecurityException) {
+        } catch (e: Exception) {
             Log.w(TAG, "startForeground(microphone) failed, falling back: ${e.message}")
             try {
                 startForeground(NOTIFICATION_ID, createNotification())
-            } catch (e2: SecurityException) {
+            } catch (e2: Exception) {
                 Log.e(TAG, "startForeground fallback also failed: ${e2.message}")
                 stopSelf()
                 return START_NOT_STICKY


### PR DESCRIPTION
🧪 Regression Guard: Fix startForeground exception handling

**Issue:**
On Android 12+ (API 31+), if an app attempts to start a foreground service from the background without a valid exemption, the system throws a `ForegroundServiceStartNotAllowedException` (which extends `IllegalStateException` or `Service.StartForegroundFailedException`). It no longer strictly throws `SecurityException`. On Android 14+ (API 34+), it might also throw `InvalidForegroundServiceTypeException` (extends `IllegalArgumentException`).

By catching only `SecurityException`, `HotwordService`, `NodeForegroundService`, and `SessionForegroundService` could crash when the OS denies foreground service instantiation.

**Fix:**
Changed the `try-catch` blocks wrapping `startForeground()` calls to catch a generic `Exception` instead of `SecurityException`. This allows the existing fallback mechanisms to gracefully handle the failure (either by falling back to `DATA_SYNC` or gracefully stopping the service) rather than crashing the entire app.

**Verification:**
- Ran `./gradlew app:lintStandardDebug` (passed).
- Ran `./gradlew app:testStandardDebugUnitTest` (passed core logic tests; remaining failures are known Roboelectric/KeyStore limitations).

---
*PR created automatically by Jules for task [8779374207417185208](https://jules.google.com/task/8779374207417185208) started by @yuga-hashimoto*