### PR TITLE
🔄 Upstream Parity: fix: default Android TLS setup codes to port 443

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/utils/GatewayConfigUtils.kt
+++ b/app/src/main/java/com/openclaw/assistant/utils/GatewayConfigUtils.kt
@@ -38,7 +38,7 @@ object GatewayConfigUtils {
         }
         val defaultPort = when (scheme) {
             "wss", "https" -> 443
-            "ws", "http" -> 80
+            "ws", "http" -> 18789
             else -> 443
         }
         val port = uri.port.takeIf { it in 1..65535 } ?: defaultPort


### PR DESCRIPTION
Source: Upstream commit df765f6
Why: The Gateway config resolver previously fell back to port 80 for non-TLS configurations (ws/http) when no port was specified. However, the local unencrypted Gateway service operates on port 18789.
Adaptation: Ported the fallback logic to `GatewayConfigUtils.kt` to use 18789 for non-TLS URLs instead of 80, matching the intent of `if (tls) 443 else 18789`.
Excluded upstream behavior: Did not port the upstream file path or exact regex/parsing structure, integrating purely into the local `GatewayConfigUtils.kt` implementation.
Verification: Lint, compilation, and unit tests passed. No UI side effects.

---
*PR created automatically by Jules for task [3806590060088332098](https://jules.google.com/task/3806590060088332098) started by @yuga-hashimoto*