### PR TITLE
🛡️ Sentinel: Enforce secure transport for Canvas WebView navigation

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
@@ -105,9 +105,8 @@ class CanvasController {
       null
     } else {
       val lower = trimmed.lowercase()
-      if (lower.startsWith("http://") ||
-          lower.startsWith("https://") ||
-          lower.startsWith("file:///android_asset/")) {
+      if (lower.startsWith("file:///android_asset/") ||
+          com.openclaw.assistant.shared.utils.NetworkUtils.isUrlSecure(trimmed)) {
         trimmed
       } else {
         Log.w("OpenClawCanvas", "Blocked unsafe navigation URL: $trimmed")


### PR DESCRIPTION
🛡️ **Sentinel: Enforce secure transport for Canvas WebView navigation**

**What**
Modified `CanvasController.navigate(url: String)` to use `NetworkUtils.isUrlSecure(trimmed)` instead of manually allowing any `http://` or `https://` prefix.

**Why**
The previous implementation allowed navigation to arbitrary, unencrypted public HTTP URLs. While Android allows cleartext traffic globally for this application (`usesCleartextTraffic="true"`) to facilitate connections to local gateways, external public navigation must be explicitly constrained. By relying on the application's standard `NetworkUtils.isUrlSecure` method, the WebView is now restricted to `https://`, local IP `http://` paths, or internal `file:///android_asset/` content, preventing potential interception or manipulation of unencrypted public traffic.

**Verification**
- Cleaned up local test files and diff artifacts.
- Ran tests and linting locally.
- Reviewed and confirmed that internal asset loading remains functional.

---
*PR created automatically by Jules for task [1463578611196903475](https://jules.google.com/task/1463578611196903475) started by @yuga-hashimoto*