### PR TITLE
⚡ Bolt: Hoist static lists in TTS chunking to prevent redundant allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-28 - Pre-compiled Regex patterns
 **Learning:** Frequent initialization of `Regex("...")` objects inside hot loops or parsing functions (like text-to-speech text normalization or markdown parsing) introduces significant, measurable performance overhead because the regular expression pattern has to be compiled on every invocation. In this Kotlin Android codebase, extracting them to `private val` properties avoids repeated compilation, especially in methods like `stripMarkdownForSpeech` which parses an entire text block multiple times per message string.
 **Action:** When working on text parsing features (e.g. ChatMarkdown blocks, TTS filters, Tool output formatting), always ensure `Regex` objects are pre-compiled as top-level file constants, or inside a `companion object` of a class, or as a property within a singleton `object`.
+
+## 2024-05-24 - Hoist Static Collection Allocations in Loop Parsers
+**Learning:** Instantiating static data structures like `listOf(...)` inside frequently called parsing methods (such as text chunking) causes redundant memory allocations and garbage collection pressure, leading to hidden CPU overhead.
+**Action:** Always hoist static parsing collections (like sentence or comma enders) to `private val` properties at the file or object level to ensure they are created exactly once.

--- a/app/src/main/java/com/openclaw/assistant/speech/TTSUtils.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/TTSUtils.kt
@@ -27,6 +27,9 @@ object TTSUtils {
     private val REGEX_BULLET = Regex("^\\s*[-*+]\\s+", RegexOption.MULTILINE)
     private val REGEX_NEWLINE = Regex("\n{3,}")
 
+    private val SENTENCE_ENDERS = listOf("。", "．", ". ", "! ", "? ", "！", "？")
+    private val COMMA_ENDERS = listOf("、", "，", ", ")
+
     /**
      * Setup locale and high-quality voice
      */
@@ -186,9 +189,8 @@ object TTSUtils {
         val paragraphBreak = text.lastIndexOf("\n\n")
         if (paragraphBreak > text.length / 2) return paragraphBreak + 2
 
-        val sentenceEnders = listOf("。", "．", ". ", "! ", "? ", "！", "？")
         var bestPos = -1
-        for (ender in sentenceEnders) {
+        for (ender in SENTENCE_ENDERS) {
             val pos = text.lastIndexOf(ender)
             if (pos > bestPos) bestPos = pos + ender.length
         }
@@ -197,8 +199,7 @@ object TTSUtils {
         val lineBreak = text.lastIndexOf("\n")
         if (lineBreak > text.length / 3) return lineBreak + 1
 
-        val commaEnders = listOf("、", "，", ", ")
-        for (ender in commaEnders) {
+        for (ender in COMMA_ENDERS) {
             val pos = text.lastIndexOf(ender)
             if (pos > bestPos) bestPos = pos + ender.length
         }


### PR DESCRIPTION
💡 What: Hoisted `sentenceEnders` and `commaEnders` from `findBestSplitPoint` to be `private val` properties of the `TTSUtils` object.
🎯 Why: `findBestSplitPoint` is called repeatedly inside a `while` loop within `splitTextForTTS`. Allocating these static string lists dynamically on every iteration adds unnecessary CPU overhead and garbage collection pressure.
📊 Impact: Eliminates O(N) redundant list instantiations where N is the number of chunked sub-strings parsed during TTS playback preparation.
🔬 Measurement: Redundant GC invocations are reduced during text-to-speech splitting. Validate that unit tests continue to pass and text splits appropriately.

---
*PR created automatically by Jules for task [9662402376991920222](https://jules.google.com/task/9662402376991920222) started by @yuga-hashimoto*