### PR TITLE
🎨 Palette: Improve accessibility of chat action button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-02-16 - Replace plain text icons with semantic Icons in Compose
 **Learning:** Using simple string characters (like "×") as button labels inside `IconButton` leads to confusing screen reader announcements (e.g., "times" or "cross") instead of the actual action ("Close" or "Delete"). This negatively affects accessibility.
 **Action:** Always replace standalone text characters used as interactive visual symbols with standard Compose `Icon` components (e.g., `Icons.Default.Close`) alongside an explicit `contentDescription` (e.g., `stringResource(R.string.close)` or `delete`). This ensures the screen reader announces the correct semantic action.
+
+## 2025-02-19 - Accessibility descriptions must be localized
+**Learning:** Hardcoded English strings used for `contentDescription` in Android/Jetpack Compose will break internationalization (i18n) and trigger lint warnings.
+**Action:** Always define accessibility text in the `strings.xml` resource file and reference it using `stringResource(R.string.x)` when updating Compose components.

--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -1008,6 +1008,15 @@ fun ChatInputArea(
             containerColor = fabColor,
             shape = CircleShape
         ) {
+            val description = if (!canSend) {
+                when {
+                    isListening -> stringResource(R.string.chat_action_stop_recording)
+                    isSpeaking -> stringResource(R.string.chat_action_interrupt_listen)
+                    else -> stringResource(R.string.chat_action_start_recording)
+                }
+            } else {
+                stringResource(R.string.send_description)
+            }
             Icon(
                 imageVector = if (!canSend) {
                      when {
@@ -1018,7 +1027,7 @@ fun ChatInputArea(
                 } else {
                      Icons.AutoMirrored.Filled.Send
                 },
-                contentDescription = stringResource(R.string.send_description),
+                contentDescription = description,
                 tint = Color.White
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -605,6 +605,10 @@
     <string name="canvas_chat_not_connected">Connect to Gateway to chat</string>
     <string name="canvas_chat_send">Send</string>
     <string name="canvas_status_sending">Sending...</string>
+
+    <string name="chat_action_stop_recording">Stop recording</string>
+    <string name="chat_action_interrupt_listen">Interrupt and listen</string>
+    <string name="chat_action_start_recording">Start recording</string>
     <string name="canvas_status_thinking">Thinking...</string>
     <string name="canvas_status_tool">Using tools...</string>
     <string name="canvas_status_loading">Loading Canvas...</string>


### PR DESCRIPTION
💡 What: Dynamically update the `contentDescription` of the floating action button in `ChatActivity.kt` and add corresponding localized strings in `strings.xml`.
🎯 Why: The button's icon changes based on state (Stop, Mic, Send), but the description was hardcoded to "Send". This caused screen readers to announce "Send message" even when the user was actively recording voice, which was confusing.
♿ Accessibility: TalkBack will now accurately announce "Stop recording", "Interrupt and listen", "Start recording", or "Send" depending on the app's current state.

---
*PR created automatically by Jules for task [16550797055808084825](https://jules.google.com/task/16550797055808084825) started by @yuga-hashimoto*