### PR TITLE
🧪 Regression Guard: Fix startForeground crash on Android 12+

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -184,7 +184,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             } else {
                 startForeground(NOTIFICATION_ID, createNotification())
             }
-        } catch (e: SecurityException) {
+        } catch (e: Exception) {
             // This can happen on Android 14+ if the app is not in an eligible state
             // (e.g. started from background without a visible activity). Handled gracefully.
             Log.e(TAG, "Failed to start foreground service", e)

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -111,7 +111,7 @@ class NodeForegroundService : Service() {
         try {
           startForeground(NOTIFICATION_ID, notification, types)
           lastNotification = notification
-        } catch (e: SecurityException) {
+        } catch (e: Exception) {
           android.util.Log.w(TAG, "startForeground(mediaProjection) failed, falling back to dataSync: ${e.message}")
           try {
             val fallbackTypes = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC.let {
@@ -215,13 +215,13 @@ class NodeForegroundService : Service() {
 
     try {
       startForeground(NOTIFICATION_ID, notification, types)
-    } catch (e: SecurityException) {
+    } catch (e: Exception) {
       android.util.Log.w(TAG, "startForeground failed (types=$types): ${e.message}")
       // Fall back to dataSync-only if microphone type was the cause
       if (requiresMic) {
         try {
           startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
-        } catch (e2: SecurityException) {
+        } catch (e2: Exception) {
           android.util.Log.e(TAG, "startForeground fallback also failed: ${e2.message}")
         }
       }

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -66,11 +66,11 @@ class SessionForegroundService : Service() {
             } else {
                 startForeground(NOTIFICATION_ID, createNotification())
             }
-        } catch (e: SecurityException) {
+        } catch (e: Exception) {
             Log.w(TAG, "startForeground(microphone) failed, falling back: ${e.message}")
             try {
                 startForeground(NOTIFICATION_ID, createNotification())
-            } catch (e2: SecurityException) {
+            } catch (e2: Exception) {
                 Log.e(TAG, "startForeground fallback also failed: ${e2.message}")
                 stopSelf()
                 return START_NOT_STICKY


### PR DESCRIPTION
When starting foreground services from the background, Android 12+ (API 31+) throws `ForegroundServiceStartNotAllowedException`, and Android 14+ (API 34+) throws `InvalidForegroundServiceTypeException`. Both inherit from `IllegalStateException` or `IllegalArgumentException`, not `SecurityException`.

This commit broadens the catch block for `startForeground()` calls in `HotwordService`, `SessionForegroundService`, and `NodeForegroundService` to catch `Exception` instead of `SecurityException`. This ensures the fallback logic correctly executes or stops the service gracefully, preventing fatal app crashes on newer Android versions when background execution limits are enforced.

---
*PR created automatically by Jules for task [16263499690073581010](https://jules.google.com/task/16263499690073581010) started by @yuga-hashimoto*