### PR TITLE
🎨 Polish: Improve Chat UI accessibility and localization

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -650,7 +650,7 @@ fun MessageBubble(message: ChatMessage) {
                             Spacer(modifier = Modifier.width(4.dp))
                             Icon(
                                 imageVector = Icons.Default.ContentCopy,
-                                contentDescription = "Copy",
+                                contentDescription = stringResource(R.string.action_copy),
                                 tint = contentColor.copy(alpha = 0.4f),
                                 modifier = Modifier
                                     .size(14.dp)
@@ -709,7 +709,7 @@ fun ChatAttachmentPreview(attachment: com.openclaw.assistant.chat.ChatMessageCon
         ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.InsertDriveFile,
-                contentDescription = "File",
+                contentDescription = stringResource(R.string.file_attachment),
                 tint = contentColor,
                 modifier = Modifier.size(24.dp)
             )
@@ -968,7 +968,7 @@ fun ChatInputArea(
         ) {
             Icon(
                 imageVector = androidx.compose.material.icons.Icons.Default.AttachFile,
-                contentDescription = "Attach file",
+                contentDescription = stringResource(R.string.attach_file),
                 tint = MaterialTheme.colorScheme.primary
             )
         }
@@ -1018,7 +1018,11 @@ fun ChatInputArea(
                 } else {
                      Icons.AutoMirrored.Filled.Send
                 },
-                contentDescription = stringResource(R.string.send_description),
+                contentDescription = if (!canSend) {
+                    if (isListening || isSpeaking) stringResource(R.string.stop_description) else stringResource(R.string.listening)
+                } else {
+                    stringResource(R.string.send_description)
+                },
                 tint = Color.White
             )
         }

--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatMessageListCard.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatMessageListCard.kt
@@ -19,7 +19,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.openclaw.assistant.R
 import com.openclaw.assistant.chat.ChatMessage
 import com.openclaw.assistant.chat.ChatPendingToolCall
 
@@ -102,7 +104,7 @@ private fun EmptyChatHint(modifier: Modifier = Modifier) {
       tint = MaterialTheme.colorScheme.onSurfaceVariant,
     )
     Text(
-      text = "Message OpenClaw…",
+      text = stringResource(R.string.chat_empty_state_hint),
       style = MaterialTheme.typography.bodyMedium,
       color = MaterialTheme.colorScheme.onSurfaceVariant,
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,9 @@
     <string name="try_again_button">Try again</string>
     <string name="ask_hint">Ask OpenClaw…</string>
     <string name="send_description">Send</string>
+    <string name="action_copy">Copy</string>
+    <string name="attach_file">Attach file</string>
+    <string name="file_attachment">File</string>
     <string name="stop_description">Stop</string>
     <string name="listening">Listening…</string>
     <string name="thinking">Thinking…</string>
@@ -235,6 +238,7 @@
     <string name="notification_session_content">Voice session is active</string>
 
     <!-- Chat UI -->
+    <string name="chat_empty_state_hint">Message OpenClaw…</string>
     <string name="conversations_title">Conversations</string>
     <string name="new_chat">New Chat</string>
     <string name="delete">Delete</string>


### PR DESCRIPTION
**Why:**
The application had hardcoded strings in the UI, and interactive UI elements like icon buttons either lacked localized accessibility labels or had a static incorrect state. For example, the `FloatingActionButton` that toggles between Send, Listen, and Stop incorrectly hardcoded its content description to "Send" in all states, causing confusion for screen readers.

**What:**
- Extracted multiple string literals ("Copy", "File", "Attach file", "Message OpenClaw…") to `strings.xml`.
- Updated `ChatMessageListCard.kt` to use the localized string for its empty state text.
- Replaced the hardcoded static `contentDescription` on the Send/Listen/Stop FAB with dynamic state-aware logic that references appropriate string resources (`R.string.send_description`, `R.string.stop_description`, `R.string.listening`).
- Applied string resources to the rest of the file and clipboard icons in `ChatActivity.kt`.

**Impact:**
Improves accessibility by ensuring accurate and stateful screen reader announcements while simplifying future localization efforts. No product identity changes were made, and existing design language is fully preserved.

---
*PR created automatically by Jules for task [13216947852280987368](https://jules.google.com/task/13216947852280987368) started by @yuga-hashimoto*