### PR TITLE
🛡️ Sentinel: Enforce secure transport for WebView navigation

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
@@ -105,8 +105,7 @@ class CanvasController {
       null
     } else {
       val lower = trimmed.lowercase()
-      if (lower.startsWith("http://") ||
-          lower.startsWith("https://") ||
+      if (com.openclaw.assistant.shared.utils.NetworkUtils.isUrlSecure(trimmed) ||
           lower.startsWith("file:///android_asset/")) {
         trimmed
       } else {


### PR DESCRIPTION
🛡️ Sentinel: Enforce secure transport for WebView navigation

## What
Updated the `CanvasController.navigate()` method to prevent arbitrary cleartext (`http://`) navigation on public networks, which exposes traffic to MITM interception.

## Why
Previously, the `navigate()` function allowed any URL starting with `http://` or `https://` to load in the persistent webview. This violated the app's standard networking requirement to only permit cleartext traffic on localhost/private IPs.

## Action
Substituted the broad `lower.startsWith("http://")` check with the project's standard `com.openclaw.assistant.shared.utils.NetworkUtils.isUrlSecure(url)` which enforces HTTPS for external URLs while retaining support for private network/localhost IPs and standard WebSockets.

## Verification
- Validated via `./gradlew app:lintStandardDebug`
- Confirmed compilation via `./gradlew app:compileStandardDebugKotlin`
- Unit tests run via `./gradlew app:testStandardDebugUnitTest` (expected KeyStore failures ignored)

---
*PR created automatically by Jules for task [13445293525015117223](https://jules.google.com/task/13445293525015117223) started by @yuga-hashimoto*