### PR TITLE
🎨 Polish: Improve connection status accessibility labels

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import com.openclaw.assistant.R
 
 enum class ConnectionState {
     Connected,
@@ -50,6 +52,12 @@ fun StatusIndicator(
         ConnectionState.Disconnected -> Color(0xFF757575)
     }
 
+    val stateDesc = when (state) {
+        ConnectionState.Connected -> stringResource(R.string.connected)
+        ConnectionState.Connecting -> stringResource(R.string.gateway_connecting)
+        ConnectionState.Disconnected -> stringResource(R.string.disconnected)
+    }
+
     val transition = rememberInfiniteTransition(label = "pulse")
     val alpha by transition.animateFloat(
         initialValue = 1f,
@@ -74,7 +82,7 @@ fun StatusIndicator(
                 .then(
                     if (label == null) {
                         Modifier.semantics {
-                            contentDescription = state.name
+                            contentDescription = stateDesc
                         }
                     } else {
                         Modifier


### PR DESCRIPTION
Improved the `contentDescription` of the `StatusIndicator` composable. Previously, it used the hardcoded `state.name` (e.g., "Connected", "Connecting"). Now it uses localized string resources (`R.string.connected`, `R.string.gateway_connecting`, `R.string.disconnected`) which are much better for screen reader accessibility and internationalization.

---
*PR created automatically by Jules for task [10823872110930104](https://jules.google.com/task/10823872110930104) started by @yuga-hashimoto*