### PR TITLE
⚡ Bolt: Hoist TTS split point lists to reduce allocations

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/speech/AndroidTTSProvider.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/AndroidTTSProvider.kt
@@ -249,9 +249,8 @@ class AndroidTTSProvider(private val context: Context) : TTSProvider {
         val paragraphBreak = text.lastIndexOf("\n\n")
         if (paragraphBreak > text.length / 2) return paragraphBreak + 2
         
-        val sentenceEnders = listOf("。", "．", ". ", "! ", "? ", "！", "？")
         var bestPos = -1
-        for (ender in sentenceEnders) {
+        for (ender in SENTENCE_ENDERS) {
             val pos = text.lastIndexOf(ender)
             if (pos > bestPos) bestPos = pos + ender.length
         }
@@ -260,8 +259,7 @@ class AndroidTTSProvider(private val context: Context) : TTSProvider {
         val lineBreak = text.lastIndexOf("\n")
         if (lineBreak > text.length / 3) return lineBreak + 1
         
-        val commaEnders = listOf("。", "，", ", ")
-        for (ender in commaEnders) {
+        for (ender in COMMA_ENDERS) {
             val pos = text.lastIndexOf(ender)
             if (pos > bestPos) bestPos = pos + ender.length
         }
@@ -271,5 +269,10 @@ class AndroidTTSProvider(private val context: Context) : TTSProvider {
         if (space > text.length / 3) return space + 1
         
         return -1
+    }
+
+    companion object {
+        private val SENTENCE_ENDERS = listOf("。", "．", ". ", "! ", "? ", "！", "？")
+        private val COMMA_ENDERS = listOf("。", "，", ", ")
     }
 }


### PR DESCRIPTION
💡 What: Moved `sentenceEnders` and `commaEnders` lists out of the `findBestSplitPoint` method and into a companion object in `AndroidTTSProvider.kt`.
🎯 Why: `findBestSplitPoint` is a core utility method that gets called heavily when splitting text chunks for Android Text-to-Speech processing. Previously, these invariant lists were being instantiated on every single method call.
📊 Impact: Eliminates two redundant object allocations per split attempt, reducing unnecessary short-lived objects and lightening the load on the garbage collector during heavy text streaming/processing. 
🔬 Measurement: Verified with `app:lintStandardDebug` and `app:testStandardDebugUnitTest` that logic remains completely identical.

---
*PR created automatically by Jules for task [10431655041499283727](https://jules.google.com/task/10431655041499283727) started by @yuga-hashimoto*