### PR TITLE
🛡️ Sentinel: Restrict user CA trust to debug builds only

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -3,7 +3,11 @@
     <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
-            <certificates src="user" />
         </trust-anchors>
     </base-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
 </network-security-config>

--- a/wear/src/main/res/xml/network_security_config.xml
+++ b/wear/src/main/res/xml/network_security_config.xml
@@ -3,7 +3,11 @@
     <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
-            <certificates src="user" />
         </trust-anchors>
     </base-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
 </network-security-config>


### PR DESCRIPTION
This restricts user-installed Certificate Authorities (CAs) from being trusted globally in the production `base-config`. User CAs are now only trusted inside `debug-overrides`, preventing potential Man-in-the-Middle (MITM) attacks while preserving debugging capabilities. This hardening applies to both the `app` and `wear` module `network_security_config.xml` files.

---
*PR created automatically by Jules for task [3135180188593933539](https://jules.google.com/task/3135180188593933539) started by @yuga-hashimoto*