### PR TITLE
🔄 Upstream Parity: Default camera snap to high-quality image

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
@@ -100,8 +100,8 @@ class CameraCaptureManager(private val context: Context) {
       ensureCameraPermission()
       val owner = lifecycleOwner ?: throw IllegalStateException("UNAVAILABLE: camera not ready")
       val facing = parseFacing(paramsJson) ?: "front"
-      val quality = (parseQuality(paramsJson) ?: 0.5).coerceIn(0.1, 1.0)
-      val maxWidth = parseMaxWidth(paramsJson) ?: 800
+      val quality = (parseQuality(paramsJson) ?: 0.95).coerceIn(0.1, 1.0)
+      val maxWidth = parseMaxWidth(paramsJson) ?: 1600
 
       val provider = context.cameraProvider()
       val capture = ImageCapture.Builder().build()


### PR DESCRIPTION
- Source: Upstream commit 8117a13dd646a7c043b48ab6c1093a4e9fb76f20
- Why: Using a higher default resolution and quality when taking a picture improves the resulting image's clarity and detail, benefiting downstream usage like computer vision without significantly impacting performance.
- Adaptation: Modified the exact corresponding logic in `CameraCaptureManager.kt` for our local app's package structure. 
- Excluded upstream behavior: N/A, the change is fully ported.
- Verification: Compiled and passed unit tests (`./gradlew app:testStandardDebugUnitTest`) and lint checks (`./gradlew app:lintStandardDebug`).

---
*PR created automatically by Jules for task [4424794046163969250](https://jules.google.com/task/4424794046163969250) started by @yuga-hashimoto*