### PR TITLE
🛡️ Sentinel: Secure network security config by limiting user certs to debug overrides

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -3,7 +3,11 @@
     <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
-            <certificates src="user" />
         </trust-anchors>
     </base-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
 </network-security-config>

--- a/wear/src/main/res/xml/network_security_config.xml
+++ b/wear/src/main/res/xml/network_security_config.xml
@@ -3,7 +3,11 @@
     <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
-            <certificates src="user" />
         </trust-anchors>
     </base-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
 </network-security-config>


### PR DESCRIPTION
**What:** Hardens the application's network security configuration.
**Why:** Allowing user-installed certificates in the `<base-config>` exposes production builds to Man-In-The-Middle (MITM) attacks if a user's device has a malicious root CA installed.
**How:** Moved `<certificates src="user" />` out of `<base-config>` and into a new `<debug-overrides>` section in both `app/src/main/res/xml/network_security_config.xml` and `wear/src/main/res/xml/network_security_config.xml`. This ensures user certs are only trusted during debug builds.
**Verification:** Ran `./gradlew app:lintStandardDebug`, `./gradlew app:testStandardDebugUnitTest`, and `./gradlew wear:testDebugUnitTest`. All checks passed. Automated code review confirmed the safety and security benefit of the change.

---
*PR created automatically by Jules for task [6568701713900546266](https://jules.google.com/task/6568701713900546266) started by @yuga-hashimoto*