### PR TITLE
🧪 Regression Guard: Fix startForeground crash by catching Exception

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -112,7 +112,7 @@ class NodeForegroundService : Service() {
           try {
             startForeground(NOTIFICATION_ID, notification, types)
             lastNotification = notification
-          } catch (e: SecurityException) {
+          } catch (e: Exception) {
             android.util.Log.w(TAG, "startForeground(mediaProjection) failed, falling back to dataSync: ${e.message}")
             try {
               val fallbackTypes = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC.let {
@@ -221,13 +221,13 @@ class NodeForegroundService : Service() {
 
       try {
         startForeground(NOTIFICATION_ID, notification, types)
-      } catch (e: SecurityException) {
+      } catch (e: Exception) {
         android.util.Log.w(TAG, "startForeground failed (types=$types): ${e.message}")
         // Fall back to dataSync-only if microphone type was the cause
         if (requiresMic) {
           try {
             startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
-          } catch (e2: SecurityException) {
+          } catch (e2: Exception) {
             android.util.Log.e(TAG, "startForeground fallback also failed: ${e2.message}")
           }
         }


### PR DESCRIPTION
🧪 Regression Guard: Fix startForeground crash by catching Exception

## Why
On Android 12 (API 31) and higher, there are strict restrictions on starting foreground services from the background. If these restrictions are violated, the OS throws a `ForegroundServiceStartNotAllowedException`, which extends `IllegalStateException` (not `SecurityException`). OEM-specific skins can also throw varying exceptions. `NodeForegroundService` was previously only catching `SecurityException` when attempting to call `startForeground()`, leaving the app vulnerable to hard crashes in these increasingly common scenarios.

## What
Updated the `try/catch` blocks around `startForeground()` in `NodeForegroundService.kt` to catch the broader `Exception` instead of just `SecurityException`. This aligns the error handling with standard defensive practices for this notoriously unstable Android API and matches the correct behavior already implemented in `SessionForegroundService` and `HotwordService`. 

## Verification
- Verified the code compiles correctly (`./gradlew app:compileStandardDebugKotlin`).
- Verified unit tests pass (`./gradlew app:testStandardDebugUnitTest`).
- Verified no lint errors were introduced (`./gradlew app:lintStandardDebug`).

---
*PR created automatically by Jules for task [12175996259797673053](https://jules.google.com/task/12175996259797673053) started by @yuga-hashimoto*