### PR TITLE
⚡ Bolt: Optimize AndroidTTSProvider text splitting to prevent repetitive memory allocation

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/speech/AndroidTTSProvider.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/AndroidTTSProvider.kt
@@ -17,6 +17,9 @@ import kotlin.coroutines.resume
 
 private const val TAG = "AndroidTTSProvider"
 
+private val SENTENCE_ENDERS = listOf("。", "．", ". ", "! ", "? ", "！", "？")
+private val COMMA_ENDERS = listOf("。", "，", ", ")
+
 /**
  * Android native TTS provider (wrapper around TextToSpeech)
  */
@@ -249,9 +252,8 @@ class AndroidTTSProvider(private val context: Context) : TTSProvider {
         val paragraphBreak = text.lastIndexOf("\n\n")
         if (paragraphBreak > text.length / 2) return paragraphBreak + 2
         
-        val sentenceEnders = listOf("。", "．", ". ", "! ", "? ", "！", "？")
         var bestPos = -1
-        for (ender in sentenceEnders) {
+        for (ender in SENTENCE_ENDERS) {
             val pos = text.lastIndexOf(ender)
             if (pos > bestPos) bestPos = pos + ender.length
         }
@@ -260,8 +262,7 @@ class AndroidTTSProvider(private val context: Context) : TTSProvider {
         val lineBreak = text.lastIndexOf("\n")
         if (lineBreak > text.length / 3) return lineBreak + 1
         
-        val commaEnders = listOf("。", "，", ", ")
-        for (ender in commaEnders) {
+        for (ender in COMMA_ENDERS) {
             val pos = text.lastIndexOf(ender)
             if (pos > bestPos) bestPos = pos + ender.length
         }


### PR DESCRIPTION
💡 What: Hoisted the `sentenceEnders` and `commaEnders` variables out of the `findBestSplitPoint` method in `AndroidTTSProvider.kt` and converted them into file-level `private val` constants.

🎯 Why: The `findBestSplitPoint` method is repeatedly called in a `while` loop inside the `splitText` function to evaluate chunks of text. Previously, the `listOf(...)` collections for sentence and comma enders were being allocated inside `findBestSplitPoint` on every single iteration of the text-chunking algorithm. This caused entirely redundant object instantiation and induced unnecessary Garbage Collection (GC) pressure when processing long blocks of text for Text-to-Speech playback.

📊 Impact: Reduces array allocation during Android text-to-speech chunking by moving static arrays to file-level scope. 

🔬 Measurement: Verified functionality using `./gradlew app:testStandardDebugUnitTest`. The change applies standard Android/Kotlin performance best practices for optimizing tight parsing loops.

---
*PR created automatically by Jules for task [8341312353247354668](https://jules.google.com/task/8341312353247354668) started by @yuga-hashimoto*