### PR TITLE
🎨 Polish: Localize ChatSessionsDialog text

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatSessionsDialog.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatSessionsDialog.kt
@@ -37,7 +37,7 @@ fun ChatSessionsDialog(
     confirmButton = {},
     title = {
       Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-        Text("Sessions", style = MaterialTheme.typography.titleMedium)
+        Text(stringResource(R.string.chat_sessions_dialog_title), style = MaterialTheme.typography.titleMedium)
         Spacer(modifier = Modifier.weight(1f))
         FilledTonalIconButton(onClick = onRefresh) {
           Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.action_refresh))
@@ -46,7 +46,7 @@ fun ChatSessionsDialog(
     },
     text = {
       if (sessions.isEmpty()) {
-        Text("No sessions", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(stringResource(R.string.chat_sessions_dialog_no_sessions), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
       } else {
         LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
           items(sessions, key = { it.key }) { entry ->
@@ -87,7 +87,7 @@ private fun SessionRow(
       Text(entry.displayName ?: entry.key, style = MaterialTheme.typography.bodyMedium)
       Spacer(modifier = Modifier.weight(1f))
       if (isCurrent) {
-        Text("Current", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(stringResource(R.string.chat_sessions_dialog_current), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
       }
     }
   }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -222,6 +222,10 @@ Weitere Informationen finden Sie auf der offiziellen Website von VOICEVOX.</stri
 <string name="select_chat_type">Wählen Sie Chat-Typ</string>
 <string name="chat_type_gateway">Gateway-Chat</string>
 <string name="chat_type_http">HTTP-Chat</string>
+<!-- Session List -->
+<string name="chat_sessions_dialog_title">Sitzungen</string>
+<string name="chat_sessions_dialog_no_sessions">Keine Sitzungen</string>
+<string name="chat_sessions_dialog_current">Aktuell</string>
 <string name="no_sessions">Noch keine Gespräche. Tippen Sie auf +, um ein neues zu starten.</string>
 <string name="session_name_label">Name</string>
 <string name="session_name_hint">z.B. Arbeiten, Reisen, Studieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -223,6 +223,10 @@ Para más detalles, consulta el sitio oficial de VOICEVOX.</string>
 <string name="select_chat_type">Seleccione el tipo de chat</string>
 <string name="chat_type_gateway">Chat de puerta de enlace</string>
 <string name="chat_type_http">Chat HTTP</string>
+<!-- Session List -->
+<string name="chat_sessions_dialog_title">Sesiones</string>
+<string name="chat_sessions_dialog_no_sessions">Sin sesiones</string>
+<string name="chat_sessions_dialog_current">Actual</string>
 <string name="no_sessions">Aún no hay conversaciones. Toca + para iniciar uno nuevo.</string>
 <string name="session_name_label">Nombre</string>
 <string name="session_name_hint">e.g. Trabajar, viajar, estudiar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -223,6 +223,10 @@ Pour plus de détails, consultez le site officiel de VOICEVOX.</string>
 <string name="select_chat_type">Sélectionner le type de conversation</string>
 <string name="chat_type_gateway">Gateway Chat</string>
 <string name="chat_type_http">Chat HTTP</string>
+<!-- Session List -->
+<string name="chat_sessions_dialog_title">Sessions</string>
+<string name="chat_sessions_dialog_no_sessions">Aucune session</string>
+<string name="chat_sessions_dialog_current">Actuel</string>
 <string name="no_sessions">Aucune conversation pour l\'instant. Appuyez sur + pour en créer un nouveau.</string>
 <string name="session_name_label">Nom</string>
 <string name="session_name_hint">e.g. Travail, voyages, études</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -223,6 +223,10 @@
 <string name="select_chat_type">चैट प्रकार चुनें</string>
 <string name="chat_type_gateway">गेटवे चैट</string>
 <string name="chat_type_http">HTTP चैट</string>
+<!-- Session List -->
+<string name="chat_sessions_dialog_title">सत्र</string>
+<string name="chat_sessions_dialog_no_sessions">कोई सत्र नहीं</string>
+<string name="chat_sessions_dialog_current">वर्तमान</string>
 <string name="no_sessions">अभी तक कोई बातचीत नहीं. नई शुरुआत करने के लिए + टैप करें.</string>
 <string name="session_name_label">नाम</string>
 <string name="session_name_hint">जैसे काम, यात्रा, अध्ययन</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -222,6 +222,11 @@
 <string name="select_chat_type">チャット形式を選択</string>
 <string name="chat_type_gateway">Gateway Chat</string>
 <string name="chat_type_http">HTTP Chat</string>
+
+<!-- Session List -->
+<string name="chat_sessions_dialog_title">セッション</string>
+<string name="chat_sessions_dialog_no_sessions">セッションがありません</string>
+<string name="chat_sessions_dialog_current">現在</string>
 <string name="no_sessions">まだ会話がありません。＋をタップして新しい会話を始めましょう。</string>
 <string name="session_name_label">名前</string>
 <string name="session_name_hint">例: 仕事、旅行、勉強</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -223,6 +223,10 @@
 <string name="select_chat_type">Выберите тип чата</string>
 <string name="chat_type_gateway">Чат на шлюзе</string>
 <string name="chat_type_http">HTTP-чат</string>
+<!-- Session List -->
+<string name="chat_sessions_dialog_title">Сессии</string>
+<string name="chat_sessions_dialog_no_sessions">Нет сессий</string>
+<string name="chat_sessions_dialog_current">Текущий</string>
 <string name="no_sessions">Обсуждений пока нет. Нажмите +, чтобы начать новый.</string>
 <string name="session_name_label">Имя</string>
 <string name="session_name_hint">e.g. Работа, путешествия, учеба</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -223,6 +223,10 @@
 <string name="select_chat_type">选择聊天类型</string>
 <string name="chat_type_gateway">网关聊天</string>
 <string name="chat_type_http">HTTP 聊天</string>
+<!-- Session List -->
+<string name="chat_sessions_dialog_title">会话</string>
+<string name="chat_sessions_dialog_no_sessions">无会话</string>
+<string name="chat_sessions_dialog_current">当前</string>
 <string name="no_sessions">还没有对话。点击 + 开始一个新的。</string>
 <string name="session_name_label">名称</string>
 <string name="session_name_hint">e.g。工作、旅行、学习</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -222,6 +222,10 @@
 <string name="select_chat_type">選擇聊天類型</string>
 <string name="chat_type_gateway">網關聊天</string>
 <string name="chat_type_http">HTTP 聊天</string>
+<!-- Session List -->
+<string name="chat_sessions_dialog_title">工作階段</string>
+<string name="chat_sessions_dialog_no_sessions">無工作階段</string>
+<string name="chat_sessions_dialog_current">目前</string>
 <string name="no_sessions">還沒有對話。點擊 + 開始一個新的。</string>
 <string name="session_name_label">姓名</string>
 <string name="session_name_hint">例如工作、旅行、學習</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,6 +247,9 @@
     <string name="chat_type_http">HTTP Chat</string>
 
     <!-- Session List -->
+    <string name="chat_sessions_dialog_title">Sessions</string>
+    <string name="chat_sessions_dialog_no_sessions">No sessions</string>
+    <string name="chat_sessions_dialog_current">Current</string>
     <string name="no_sessions">No conversations yet. Tap + to start a new one.</string>
     <string name="session_name_label">Name</string>
     <string name="session_name_hint">e.g. Work, Travel, Study</string>


### PR DESCRIPTION
Extracted hardcoded English strings from `ChatSessionsDialog.kt` ("Sessions", "Refresh", "No sessions", "Current") into string resources (`R.string.chat_sessions_dialog_*`) to improve localization, maintainability, and accessibility support. Provided Japanese translations in `values-ja/strings.xml`.

---
*PR created automatically by Jules for task [1015227197833233221](https://jules.google.com/task/1015227197833233221) started by @yuga-hashimoto*