### PR TITLE
🧪 Regression Guard: Fix startForeground crash on Android 12+

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -112,7 +112,7 @@ class NodeForegroundService : Service() {
           try {
             startForeground(NOTIFICATION_ID, notification, types)
             lastNotification = notification
-          } catch (e: SecurityException) {
+          } catch (e: Exception) {
             android.util.Log.w(TAG, "startForeground(mediaProjection) failed, falling back to dataSync: ${e.message}")
             try {
               val fallbackTypes = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC.let {
@@ -221,13 +221,13 @@ class NodeForegroundService : Service() {
 
       try {
         startForeground(NOTIFICATION_ID, notification, types)
-      } catch (e: SecurityException) {
+      } catch (e: Exception) {
         android.util.Log.w(TAG, "startForeground failed (types=$types): ${e.message}")
         // Fall back to dataSync-only if microphone type was the cause
         if (requiresMic) {
           try {
             startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
-          } catch (e2: SecurityException) {
+          } catch (e2: Exception) {
             android.util.Log.e(TAG, "startForeground fallback also failed: ${e2.message}")
           }
         }


### PR DESCRIPTION
This PR addresses an issue where calling `startForeground()` in `NodeForegroundService.kt` can throw `ForegroundServiceStartNotAllowedException` on Android 12+ when called under certain restricted background conditions. This exception inherits from `IllegalStateException`, not `SecurityException`. By broadening the `try-catch` to handle `Exception`, the service can gracefully fall back to safer foreground types (like `DATA_SYNC`) and prevent the app from hard-crashing.

---
*PR created automatically by Jules for task [17415504976816471450](https://jules.google.com/task/17415504976816471450) started by @yuga-hashimoto*