### PR TITLE
🔄 Upstream Parity: reduce chat recomposition churn

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatMessageListCard.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatMessageListCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowCircleDown
@@ -16,6 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -32,10 +34,18 @@ fun ChatMessageListCard(
   modifier: Modifier = Modifier,
 ) {
   val listState = rememberLazyListState()
+  val displayMessages = remember(messages) { messages.asReversed() }
+  val stream = streamingAssistantText?.trim()
 
-  // With reverseLayout the newest item is at index 0 (bottom of screen).
-  LaunchedEffect(messages.size, pendingRunCount, pendingToolCalls.size, streamingAssistantText) {
+  // New list items/tool rows should animate into view, but token streaming should not restart
+  // that animation on every delta.
+  LaunchedEffect(messages.size, pendingRunCount, pendingToolCalls.size) {
     listState.animateScrollToItem(index = 0)
+  }
+  LaunchedEffect(stream) {
+    if (!stream.isNullOrEmpty()) {
+      listState.scrollToItem(index = 0)
+    }
   }
 
   Card(
@@ -58,7 +68,6 @@ fun ChatMessageListCard(
         // With reverseLayout = true, index 0 renders at the BOTTOM.
         // So we emit newest items first: streaming → tools → typing → messages (newest→oldest).
 
-        val stream = streamingAssistantText?.trim()
         if (!stream.isNullOrEmpty()) {
           item(key = "stream") {
             ChatStreamingAssistantBubble(text = stream)
@@ -77,8 +86,8 @@ fun ChatMessageListCard(
           }
         }
 
-        items(count = messages.size, key = { idx -> messages[messages.size - 1 - idx].id }) { idx ->
-          ChatMessageBubble(message = messages[messages.size - 1 - idx])
+        items(items = displayMessages, key = { it.id }) { message ->
+          ChatMessageBubble(message = message)
         }
       }
 


### PR DESCRIPTION
- Source: openclaw/openclaw commit 56e23a887f46d954bca87e20b8beec791b52f5bb
- Why: Fixes an issue where chat token streaming constantly restarts the layout animation on every text delta, causing UI jank and churn.
- Adaptation: Adapted to local `ChatMessageListCard.kt`. Replaced manual index math with `messages.asReversed()`. Splitted `LaunchedEffect` for full list items and token stream.
- Excluded upstream behavior: None.
- Verification: Ran `./gradlew app:lintStandardDebug app:testStandardDebugUnitTest`. Checked UI logic in Compose.

---
*PR created automatically by Jules for task [16373630679411850287](https://jules.google.com/task/16373630679411850287) started by @yuga-hashimoto*