### PR TITLE
🛡️ Sentinel: Move user CAs to debug-overrides to prevent MITM

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -3,7 +3,11 @@
     <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
-            <certificates src="user" />
         </trust-anchors>
     </base-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
 </network-security-config>

--- a/wear/src/main/res/xml/network_security_config.xml
+++ b/wear/src/main/res/xml/network_security_config.xml
@@ -3,7 +3,11 @@
     <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
-            <certificates src="user" />
         </trust-anchors>
     </base-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
 </network-security-config>


### PR DESCRIPTION
Moves user-added Certificate Authorities (CAs) from `base-config` to `debug-overrides` in the network security configuration for both the app and wear modules. This ensures production/release builds are not vulnerable to Man-in-the-Middle (MITM) attacks via user-installed malicious certificates, while still allowing developers to proxy traffic in debug builds.

---
*PR created automatically by Jules for task [17485425985566472425](https://jules.google.com/task/17485425985566472425) started by @yuga-hashimoto*