### PR TITLE
🎨 Polish: Improve connection status clarity in setup guide

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
@@ -1028,8 +1028,15 @@ private fun FinalCheckStep(
                 textAlign = TextAlign.Center
             )
         } else {
+            val isConnecting = statusText.contains("Connecting", ignoreCase = true)
+            val state = when {
+                isConnected -> ConnectionState.Connected
+                isConnecting -> ConnectionState.Connecting
+                else -> ConnectionState.Disconnected
+            }
+
             StatusIndicator(
-                state = if (isConnected) ConnectionState.Connected else ConnectionState.Disconnected,
+                state = state,
                 label = statusText,
                 modifier = Modifier.padding(16.dp)
             )


### PR DESCRIPTION
Update the StatusIndicator in the FinalCheckStep of SetupGuideScreen.kt to accurately reflect the 'Connecting' state when the device is attempting to connect, instead of just defaulting to 'Disconnected'. This provides better visual feedback to the user during the setup process.

---
*PR created automatically by Jules for task [11176508292373383104](https://jules.google.com/task/11176508292373383104) started by @yuga-hashimoto*