### PR TITLE
🔄 Upstream Parity: Default Android TLS setup codes to port 443

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/utils/GatewayConfigUtils.kt
+++ b/app/src/main/java/com/openclaw/assistant/utils/GatewayConfigUtils.kt
@@ -36,12 +36,7 @@ object GatewayConfigUtils {
             "wss", "https" -> true
             else -> true
         }
-        val defaultPort = when (scheme) {
-            "wss", "https" -> 443
-            "ws", "http" -> 18789
-            else -> 443
-        }
-        val port = uri.port.takeIf { it in 1..65535 } ?: defaultPort
+        val port = uri.port.takeIf { it in 1..65535 } ?: if (tls) 443 else 18789
         val displayUrl = "${if (tls) "https" else "http"}://$host:$port"
 
         if (!tls && !NetworkUtils.isUrlSecure(displayUrl)) {


### PR DESCRIPTION
- Source: openclaw/openclaw@df765f602b
- Why: Ensures valid WSS/HTTPS setup codes without an explicit port correctly default to 443 rather than the local gateway port (18789), which would otherwise cause connection failures.
- Adaptation: Applied logic directly to GatewayConfigUtils.kt.
- Excluded upstream behavior: N/A
- Verification: Ran unit tests and linting locally.

---
*PR created automatically by Jules for task [8579669819567954625](https://jules.google.com/task/8579669819567954625) started by @yuga-hashimoto*