### PR TITLE
🧪 Regression Guard: Fix SessionForegroundService crash on startForeground fallback

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -67,14 +67,13 @@ class SessionForegroundService : Service() {
                 startForeground(NOTIFICATION_ID, createNotification())
             }
         } catch (e: Exception) {
-            Log.w(TAG, "startForeground(microphone) failed, falling back: ${e.message}")
-            try {
-                startForeground(NOTIFICATION_ID, createNotification())
-            } catch (e2: Exception) {
-                Log.e(TAG, "startForeground fallback also failed: ${e2.message}")
-                stopSelf()
-                return START_NOT_STICKY
-            }
+            // This can happen on Android 14+ if the app is not in an eligible state
+            // (e.g. started from background without a visible activity).
+            // Attempting to fall back to an unrestricted type like dataSync for a microphone
+            // service violates Play Store policy. Handle gracefully by stopping.
+            Log.w(TAG, "startForeground(microphone) failed: ${e.message}")
+            stopSelf()
+            return START_NOT_STICKY
         }
         acquireWakeLock()
         Log.d(TAG, "Session foreground service started")


### PR DESCRIPTION
Removed the invalid fallback from MICROPHONE to DATA_SYNC.
When a foreground service of type MICROPHONE fails to start
due to background restrictions on Android 14+, attempting to
fall back to DATA_SYNC without proper manifest declaration
and permissions causes a secondary crash.
Even if declared, using DATA_SYNC to bypass audio restrictions
violates Google Play policy.

This change catches the exception and gracefully shuts down
the service using stopSelf().

---
*PR created automatically by Jules for task [11377438770424637181](https://jules.google.com/task/11377438770424637181) started by @yuga-hashimoto*