### PR TITLE
🛡️ Sentinel: Disable content access in WebView

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
@@ -71,6 +71,7 @@ class CanvasController {
         javaScriptEnabled = true
         domStorageEnabled = true
         allowFileAccess = false
+        allowContentAccess = false
         mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
       }
       // Required so JavaScript interactions (dialogs, file choosers, etc.) work properly.


### PR DESCRIPTION
This PR sets `allowContentAccess = false` in the `WebView` configuration within `CanvasController.kt`.

### Why this is needed:
According to the repository's security convention, Android WebViews must configure both `allowFileAccess = false` and `allowContentAccess = false` to prevent local file inclusion and content provider data leakage vulnerabilities. Currently, `CanvasController.kt` has `allowFileAccess = false` but does not set `allowContentAccess = false`. This change closes that potential vector while still allowing safe local asset access (via `file:///android_asset/`).

### Verification
I've run the repo-native validation command: `./gradlew app:lintStandardDebug app:testStandardDebugUnitTest --offline` and everything builds correctly and passes tests.

---
*PR created automatically by Jules for task [8479597874497980593](https://jules.google.com/task/8479597874497980593) started by @yuga-hashimoto*