### PR TITLE
🔄 Upstream Parity: preserve chat message identity on refresh

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/chat/ChatController.kt
+++ b/app/src/main/java/com/openclaw/assistant/chat/ChatController.kt
@@ -290,7 +290,7 @@ class ChatController(
       }
 
       val historyJson = session.request("chat.history", """{"sessionKey":"$key"}""")
-      val history = parseHistory(historyJson, sessionKey = key)
+      val history = parseHistory(historyJson, sessionKey = key, previousMessages = _messages.value)
       // Only update if sessionKey hasn't changed while we were waiting
       if (_sessionKey.value == key) {
         _messages.value = history.messages
@@ -383,7 +383,7 @@ class ChatController(
           try {
             val historyJson =
               session.request("chat.history", """{"sessionKey":"${_sessionKey.value}"}""")
-            val history = parseHistory(historyJson, sessionKey = _sessionKey.value)
+            val history = parseHistory(historyJson, sessionKey = _sessionKey.value, previousMessages = _messages.value)
             val lastMsg = history.messages.lastOrNull()
             Log.d("ChatDbg", "handleChatEvent: history reloaded msgCount=${history.messages.size} state=$state lastRole=${lastMsg?.role} lastText=${lastMsg?.content?.firstOrNull()?.text?.take(50)}")
             _messages.value = history.messages
@@ -485,7 +485,11 @@ class ChatController(
     }
   }
 
-  private fun parseHistory(historyJson: String, sessionKey: String): ChatHistory {
+  private fun parseHistory(
+    historyJson: String,
+    sessionKey: String,
+    previousMessages: List<ChatMessage>,
+  ): ChatHistory {
     val root = json.parseToJsonElement(historyJson).asObjectOrNull() ?: return ChatHistory(sessionKey, null, null, emptyList())
     val sid = root["sessionId"].asStringOrNull()
     val thinkingLevel = root["thinkingLevel"].asStringOrNull()
@@ -505,7 +509,12 @@ class ChatController(
         )
       }
 
-    return ChatHistory(sessionKey = sessionKey, sessionId = sid, thinkingLevel = thinkingLevel, messages = messages)
+    return ChatHistory(
+      sessionKey = sessionKey,
+      sessionId = sid,
+      thinkingLevel = thinkingLevel,
+      messages = reconcileMessageIds(previous = previousMessages, incoming = messages),
+    )
   }
 
   private fun parseMessageContent(el: JsonElement): ChatMessageContent? {
@@ -552,6 +561,47 @@ class ChatController(
       else -> "off"
     }
   }
+}
+
+internal fun reconcileMessageIds(previous: List<ChatMessage>, incoming: List<ChatMessage>): List<ChatMessage> {
+  if (previous.isEmpty() || incoming.isEmpty()) return incoming
+
+  val idsByKey = LinkedHashMap<String, ArrayDeque<String>>()
+  for (message in previous) {
+    val key = messageIdentityKey(message) ?: continue
+    idsByKey.getOrPut(key) { ArrayDeque() }.addLast(message.id)
+  }
+
+  return incoming.map { message ->
+    val key = messageIdentityKey(message) ?: return@map message
+    val ids = idsByKey[key] ?: return@map message
+    val reusedId = ids.removeFirstOrNull() ?: return@map message
+    if (ids.isEmpty()) {
+      idsByKey.remove(key)
+    }
+    if (reusedId == message.id) return@map message
+    message.copy(id = reusedId)
+  }
+}
+
+internal fun messageIdentityKey(message: ChatMessage): String? {
+  val role = message.role.trim().lowercase()
+  if (role.isEmpty()) return null
+
+  val timestamp = message.timestampMs?.toString().orEmpty()
+  val contentFingerprint =
+    message.content.joinToString(separator = "\u001E") { part ->
+      listOf(
+        part.type.trim().lowercase(),
+        part.text?.trim().orEmpty(),
+        part.mimeType?.trim()?.lowercase().orEmpty(),
+        part.fileName?.trim().orEmpty(),
+        part.base64?.hashCode()?.toString().orEmpty(),
+      ).joinToString(separator = "\u001F")
+    }
+
+  if (timestamp.isEmpty() && contentFingerprint.isEmpty()) return null
+  return listOf(role, timestamp, contentFingerprint).joinToString(separator = "|")
 }
 
 private fun JsonElement?.asObjectOrNull(): JsonObject? = this as? JsonObject

--- a/app/src/test/java/com/openclaw/assistant/chat/ChatControllerMessageIdentityTest.kt
+++ b/app/src/test/java/com/openclaw/assistant/chat/ChatControllerMessageIdentityTest.kt
@@ -1,0 +1,81 @@
+package com.openclaw.assistant.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class ChatControllerMessageIdentityTest {
+  @Test
+  fun reconcileMessageIdsReusesMatchingIdsAcrossHistoryReload() {
+    val previous =
+      listOf(
+        ChatMessage(
+          id = "msg-1",
+          role = "assistant",
+          content = listOf(ChatMessageContent(type = "text", text = "hello")),
+          timestampMs = 1000L,
+        ),
+        ChatMessage(
+          id = "msg-2",
+          role = "user",
+          content = listOf(ChatMessageContent(type = "text", text = "hi")),
+          timestampMs = 2000L,
+        ),
+      )
+
+    val incoming =
+      listOf(
+        ChatMessage(
+          id = "new-1",
+          role = "assistant",
+          content = listOf(ChatMessageContent(type = "text", text = "hello")),
+          timestampMs = 1000L,
+        ),
+        ChatMessage(
+          id = "new-2",
+          role = "user",
+          content = listOf(ChatMessageContent(type = "text", text = "hi")),
+          timestampMs = 2000L,
+        ),
+      )
+
+    val reconciled = reconcileMessageIds(previous = previous, incoming = incoming)
+
+    assertEquals(listOf("msg-1", "msg-2"), reconciled.map { it.id })
+  }
+
+  @Test
+  fun reconcileMessageIdsLeavesNewMessagesUntouched() {
+    val previous =
+      listOf(
+        ChatMessage(
+          id = "msg-1",
+          role = "assistant",
+          content = listOf(ChatMessageContent(type = "text", text = "hello")),
+          timestampMs = 1000L,
+        ),
+      )
+
+    val incoming =
+      listOf(
+        ChatMessage(
+          id = "new-1",
+          role = "assistant",
+          content = listOf(ChatMessageContent(type = "text", text = "hello")),
+          timestampMs = 1000L,
+        ),
+        ChatMessage(
+          id = "new-2",
+          role = "assistant",
+          content = listOf(ChatMessageContent(type = "text", text = "new reply")),
+          timestampMs = 3000L,
+        ),
+      )
+
+    val reconciled = reconcileMessageIds(previous = previous, incoming = incoming)
+
+    assertEquals("msg-1", reconciled[0].id)
+    assertEquals("new-2", reconciled[1].id)
+    assertNotEquals(reconciled[0].id, reconciled[1].id)
+  }
+}


### PR DESCRIPTION
- **Source**: Ported from upstream commit `a41be2585fca1d419f8e95f4c951a8612969aa8a` (fix(android): preserve chat message identity on refresh).
- **Why**: Reloading the chat history during refresh or lifecycle changes previously created entirely new `ChatMessage` IDs, breaking Jetpack Compose's `LazyColumn` item tracking. This caused severe UI jitter, unexpected scroll resets, and unnecessary recomposition churn.
- **Adaptation**: Ported the `reconcileMessageIds` and `messageIdentityKey` utility functions to `ChatController.kt`. Updated `parseHistory` and its call-sites to pass the previous messages into the reconciliation function. Ported the accompanying unit test.
- **Excluded upstream behavior**: No upstream layout or UI styling changes were included; this is a purely logic-driven stability fix targeting the controller.
- **Verification**: Ran `./gradlew app:testStandardDebugUnitTest` natively, successfully verifying the new unit tests and ensuring no regressions.

---
*PR created automatically by Jules for task [353533864909446443](https://jules.google.com/task/353533864909446443) started by @yuga-hashimoto*