### PR TITLE
🎨 Palette: Prevent duplicate screen reader announcements in PairingRequiredCard

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
@@ -90,7 +90,7 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
                     contentPadding = PaddingValues(horizontal = 8.dp),
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
                 ) {
-                    Icon(Icons.Default.ContentCopy, contentDescription = stringResource(R.string.pairing_copy_command), modifier = Modifier.size(16.dp))
+                    Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(16.dp))
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(stringResource(R.string.pairing_approve_command), fontSize = 12.sp)
                 }
@@ -115,7 +115,7 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
             ) {
-                Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.pairing_refresh_status), modifier = Modifier.size(18.dp))
+                Icon(Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(stringResource(R.string.pairing_refresh_status))
             }
@@ -128,7 +128,7 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
                 Text(if (expanded) stringResource(R.string.hide_instructions) else stringResource(R.string.show_instructions))
                 Icon(
                     imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                    contentDescription = if (expanded) stringResource(R.string.hide_instructions) else stringResource(R.string.show_instructions)
+                    contentDescription = null
                 )
             }
 


### PR DESCRIPTION
**💡 What:** 
Set `contentDescription` to `null` for the ContentCopy, Refresh, and Expand icons inside `PairingRequiredCard.kt`.

**🎯 Why:**
When an `Icon` is used alongside descriptive `Text` within a button, having a `contentDescription` on the icon causes screen readers to announce the action twice (e.g., "Refresh status, Refresh status"). This change prevents the duplicate announcements.

**♿ Accessibility:**
Improves screen reader experience by eliminating redundant announcements in the `PairingRequiredCard`.

---
*PR created automatically by Jules for task [13076034083369245233](https://jules.google.com/task/13076034083369245233) started by @yuga-hashimoto*