### PR TITLE
🎨 Polish: Improve SystemStatusCard connecting UI state

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1006,8 +1006,16 @@ fun SystemStatusCard(
 ) {
     val isConnecting = statusText.contains("Connecting", ignoreCase = true)
 
-    val backgroundColor = if (connected) Color(0xFFE8F5E9) else Color(0xFFFFEBEE)
-    val contentColor = if (connected) Color(0xFF1B5E20) else Color(0xFFB71C1C)
+    val backgroundColor = when {
+        connected -> Color(0xFFE8F5E9)
+        isConnecting -> Color(0xFFFFF3E0)
+        else -> Color(0xFFFFEBEE)
+    }
+    val contentColor = when {
+        connected -> Color(0xFF1B5E20)
+        isConnecting -> Color(0xFFE65100)
+        else -> Color(0xFFB71C1C)
+    }
 
     Card(
         modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
**What:** Updated the `SystemStatusCard` background and content color logic in `MainActivity.kt`.
**Why:** To distinctly separate the "Connecting" transition state from a "Disconnected" error state. Previously, "Connecting" used the same red color as "Disconnected".
**How:** Added a branch to the `when` expression mapping `isConnecting == true` to an amber/orange card color (`Color(0xFFFFF3E0)`) and text/icon color (`Color(0xFFE65100)`).

---
*PR created automatically by Jules for task [2475901184827833007](https://jules.google.com/task/2475901184827833007) started by @yuga-hashimoto*