### PR TITLE
🔄 Upstream Parity: auto-connect gateway on app open

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
@@ -533,33 +533,8 @@ class NodeRuntime(context: Context) {
 
     scope.launch(Dispatchers.Default) {
       gateways.collect { list ->
-        if (list.isNotEmpty()) {
-          // Security: don't let an unauthenticated discovery feed continuously steer autoconnect.
-          // UX parity with iOS: only set once when unset.
-          if (lastDiscoveredStableId.value.trim().isEmpty()) {
-            prefs.setLastDiscoveredStableId(list.first().stableId)
-          }
-        }
-
-        if (didAutoConnect) return@collect
-        if (_isConnected.value) return@collect
-
-        // In manual mode, we don't let discovery drive the connection.
-        // Connection is handled by startup check or user action.
-        if (manualEnabled.value) {
-          return@collect
-        }
-
-        val targetStableId = lastDiscoveredStableId.value.trim()
-        if (targetStableId.isEmpty()) return@collect
-        val target = list.firstOrNull { it.stableId == targetStableId } ?: return@collect
-
-        // Security: autoconnect only to previously trusted gateways (stored TLS pin).
-        val storedFingerprint = prefs.loadGatewayTlsFingerprint(target.stableId)?.trim().orEmpty()
-        if (storedFingerprint.isEmpty()) return@collect
-
-        didAutoConnect = true
-        connect(target)
+        seedLastDiscoveredGateway(list)
+        autoConnectIfNeeded()
       }
     }
 
@@ -582,6 +557,49 @@ class NodeRuntime(context: Context) {
 
   fun setForeground(value: Boolean) {
     _isForeground.value = value
+    if (value) {
+      reconnectPreferredGatewayOnForeground()
+    }
+  }
+
+  private fun seedLastDiscoveredGateway(list: List<GatewayEndpoint>) {
+    if (list.isEmpty()) return
+    if (lastDiscoveredStableId.value.trim().isNotEmpty()) return
+    prefs.setLastDiscoveredStableId(list.first().stableId)
+  }
+
+  private fun resolvePreferredGatewayEndpoint(): GatewayEndpoint? {
+    if (manualEnabled.value) {
+      val host = manualHost.value.trim()
+      val port = manualPort.value
+      if (host.isEmpty() || port !in 1..65535) return null
+      return GatewayEndpoint.manual(host = host, port = port)
+    }
+
+    val targetStableId = lastDiscoveredStableId.value.trim()
+    if (targetStableId.isEmpty()) return null
+    val endpoint = gateways.value.firstOrNull { it.stableId == targetStableId } ?: return null
+    val storedFingerprint = prefs.loadGatewayTlsFingerprint(endpoint.stableId)?.trim().orEmpty()
+    if (storedFingerprint.isEmpty()) return null
+    return endpoint
+  }
+
+  private fun autoConnectIfNeeded() {
+    if (didAutoConnect) return
+    if (_isConnected.value) return
+    val endpoint = resolvePreferredGatewayEndpoint() ?: return
+    didAutoConnect = true
+    connect(endpoint)
+  }
+
+  private fun reconnectPreferredGatewayOnForeground() {
+    if (_isConnected.value) return
+    if (_pendingGatewayTrust.value != null) return
+    if (connectedEndpoint != null) {
+      refreshGatewayConnection()
+      return
+    }
+    resolvePreferredGatewayEndpoint()?.let(::connect)
   }
 
   fun setDisplayName(value: String) {


### PR DESCRIPTION
Source: https://github.com/openclaw/openclaw/commit/0443ee82be776395ae521dc524a53bc94a925547

Why: Improves connectivity reliability by attempting to re-establish the gateway connection immediately upon entering the foreground, avoiding the need to wait for a discovery ping or user interaction.

Adaptation: The logic for determining the preferred gateway (whether manual or auto-discovered and trusted via TLS pin) was extracted into isolated helper methods (`seedLastDiscoveredGateway`, `resolvePreferredGatewayEndpoint`, `autoConnectIfNeeded`) in `NodeRuntime.kt`. The foreground transition in `setForeground` now directly utilizes this to attempt a clean connection refresh or new connection.

Excluded upstream behavior: The upstream commit `0443ee82be` also partially relied on another commit (`64e412e57e`) which deeply refactored how `NodeRuntime` is lazily initialized across the app (`MainViewModel`, `NodeApp`, `NodeForegroundService`). To adhere to rules against large refactors and to keep the patch focused solely on the bug fix (< 100 lines), that lazy-init refactor was skipped. The audio cleanup `stopActiveVoiceSession()` referenced upstream does not exist locally and was omitted.

Verification: Executed local unit tests and lint checks (`./gradlew app:testStandardDebugUnitTest app:lintStandardDebug`). The logic cleanly resolves and respects the existing `manualEnabled` configurations and TLS trust requirements.

---
*PR created automatically by Jules for task [676671696516063435](https://jules.google.com/task/676671696516063435) started by @yuga-hashimoto*