### PR TITLE
🛡️ Sentinel: Disable WebView allowContentAccess to prevent content provider leakage

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
@@ -71,6 +71,7 @@ class CanvasController {
         javaScriptEnabled = true
         domStorageEnabled = true
         allowFileAccess = false
+        allowContentAccess = false
         mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
       }
       // Required so JavaScript interactions (dialogs, file choosers, etc.) work properly.


### PR DESCRIPTION
This explicitly sets `allowContentAccess = false` on the Canvas WebView. This mitigates content provider data leakage vulnerabilities and prevents untrusted URLs loaded in the WebView from querying local `content://` URIs. Local assets via `file:///android_asset/` continue to work safely.

---
*PR created automatically by Jules for task [2151688449638234473](https://jules.google.com/task/2151688449638234473) started by @yuga-hashimoto*