### PR TITLE
fix: correct bugs introduced by PR #352 and PR #354

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
@@ -571,6 +571,9 @@ class NodeRuntime(context: Context) {
   private fun resolvePreferredGatewayEndpoint(): GatewayEndpoint? {
     if (manualEnabled.value) {
       val host = manualHost.value.trim()
+        .removePrefix("https://")
+        .removePrefix("http://")
+        .removeSuffix("/")
       val port = manualPort.value
       if (host.isEmpty() || port !in 1..65535) return null
       return GatewayEndpoint.manual(host = host, port = port)
@@ -587,6 +590,9 @@ class NodeRuntime(context: Context) {
   private fun autoConnectIfNeeded() {
     if (didAutoConnect) return
     if (_isConnected.value) return
+    // Manual mode startup connection is handled by the dedicated startup block; skip here
+    // to avoid a double-connect race when discovery fires before the 500 ms delay elapses.
+    if (manualEnabled.value) return
     val endpoint = resolvePreferredGatewayEndpoint() ?: return
     didAutoConnect = true
     connect(endpoint)

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -543,7 +543,7 @@ class HotwordService : Service(), VoskRecognitionListener {
      * Returns the score (0.0–1.0), or 1.0 if plain text match, or 0.0 if not found.
      */
     private fun parseWakeWordConfidence(text: String, word: String): Float {
-        val pattern = wakeWordRegexCache.getOrPut(word) {
+        val pattern = wakeWordRegexCache.computeIfAbsent(word) {
             Regex("\\[${Regex.escape(word)}\\]\\(([0-9.]+)\\)", RegexOption.IGNORE_CASE)
         }
         val match = pattern.find(text)


### PR DESCRIPTION
## Summary / 概要

Fixes two bugs that slipped through the review of #352 and #354.

### Bug 1 — Manual-mode double-connect race (PR #352)

`autoConnectIfNeeded()` now resolves and connects to the manual endpoint via `resolvePreferredGatewayEndpoint()`. However, a separate startup block already calls `connectManual()` after a 500 ms delay. If network discovery fires before that delay elapses, both paths execute concurrently, triggering two back-to-back `connect()` calls.

Fix: restore the `if (manualEnabled.value) return` guard in `autoConnectIfNeeded()`, matching the original intent ("manual mode startup connection is handled by the dedicated startup block"). The foreground-reconnect path (`reconnectPreferredGatewayOnForeground`) is unaffected and continues to handle both modes.

### Bug 2 — Missing host normalization (PR #352)

`resolvePreferredGatewayEndpoint()` passes `manualHost.value.trim()` directly to `GatewayEndpoint.manual()`. `connectManual()` strips `http://`, `https://`, and trailing `/` before doing the same, because the host input field accepts free-form text. Without normalization, a value like `http://192.168.1.1` would be passed as a hostname, causing connection failures.

Fix: apply the same `.removePrefix` / `.removeSuffix` chain that `connectManual()` uses.

### Bug 3 — Non-atomic regex cache (PR #354)

`ConcurrentHashMap.getOrPut` is a Kotlin extension function that performs a non-atomic `get → put`. Under concurrent access two threads can both miss the cache and create a `Regex` object. `computeIfAbsent` (JVM) is atomic.

Fix: replace `getOrPut` with `computeIfAbsent`.

---

## 概要（日本語）

PR #352 と #354 のレビューで見逃したバグを修正します。

| バグ | 場所 | 内容 |
|---|---|---|
| double-connect race | `NodeRuntime.autoConnectIfNeeded` | manual モードを discovery フローから除外するガードが削除されていた。startup block と競合して二重接続が発生する |
| ホスト正規化漏れ | `NodeRuntime.resolvePreferredGatewayEndpoint` | `connectManual()` はプロトコルプレフィックス等を strip するが新関数はしていなかった |
| 非アトミックキャッシュ | `HotwordService.parseWakeWordConfidence` | `getOrPut` は非アトミック。`computeIfAbsent` に置換 |

## Test plan / テスト計画

- [ ] Manual mode: app launch → single connect attempt (no duplicate)
- [ ] Manual mode: host entered as `http://192.168.1.1` → connects correctly
- [ ] Discovery mode: unaffected auto-connect behavior
- [ ] Foreground reconnect (`reconnectPreferredGatewayOnForeground`) still works for both modes
- [ ] Hotword detection: wake word still triggers correctly after regex cache warms up

🤖 Generated with [Claude Code](https://claude.com/claude-code)