### PR TITLE
🧪 Regression Guard: Fix ForegroundServiceStartNotAllowedException crash

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -46,10 +46,14 @@ class HotwordService : Service(), VoskRecognitionListener {
         
         fun start(context: Context) {
             val intent = Intent(context, HotwordService::class.java)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(intent)
-            } else {
-                context.startService(intent)
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(intent)
+                } else {
+                    context.startService(intent)
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }
         }
 

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -272,7 +272,11 @@ class NodeForegroundService : Service() {
 
     fun start(context: Context) {
       val intent = Intent(context, NodeForegroundService::class.java)
-      context.startForegroundService(intent)
+      try {
+        context.startForegroundService(intent)
+      } catch (e: Exception) {
+        android.util.Log.e(TAG, "Failed to start NodeForegroundService: ${e.message}", e)
+      }
     }
 
     fun stop(context: Context) {
@@ -291,7 +295,11 @@ class NodeForegroundService : Service() {
       mediaProjectionReady.set(deferred)
       val intent = Intent(context, NodeForegroundService::class.java)
         .setAction(ACTION_PREPARE_MEDIA_PROJECTION)
-      context.startForegroundService(intent)
+      try {
+        context.startForegroundService(intent)
+      } catch (e: Exception) {
+        android.util.Log.e(TAG, "Failed to start prepareForMediaProjection: ${e.message}", e)
+      }
     }
   }
 }

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -32,10 +32,14 @@ class SessionForegroundService : Service() {
 
         fun start(context: Context) {
             val intent = Intent(context, SessionForegroundService::class.java)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(intent)
-            } else {
-                context.startService(intent)
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(intent)
+                } else {
+                    context.startService(intent)
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }
         }
 


### PR DESCRIPTION
Added try-catch blocks for Exception around `context.startForegroundService()` calls in `HotwordService`, `SessionForegroundService`, and `NodeForegroundService`. This prevents hard crashes from `ForegroundServiceStartNotAllowedException` when the system prevents starting foreground services from the background on Android 12+ (API 31+). Tested locally and verified with `app:testStandardDebugUnitTest`.

---
*PR created automatically by Jules for task [12680110002779316357](https://jules.google.com/task/12680110002779316357) started by @yuga-hashimoto*