### PR TITLE
🛡️ Sentinel: Remove insecure ignoreSslErrors feature

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -267,7 +267,6 @@ fun SettingsScreen(
     var showWakeWordMenu by rememberSaveable { mutableStateOf(false) }
     var showLanguageMenu by rememberSaveable { mutableStateOf(false) }
     var showDisplayLanguageMenu by rememberSaveable { mutableStateOf(false) }
-    var httpIgnoreSslErrors by rememberSaveable { mutableStateOf(settings.httpIgnoreSslErrors) }
     var wakewordConnectionType by rememberSaveable { mutableStateOf(settings.wakewordConnectionType) }
 
     val scope = rememberCoroutineScope()
@@ -275,7 +274,7 @@ fun SettingsScreen(
     val runtime = remember(context.applicationContext) {
         (context.applicationContext as OpenClawApplication).nodeRuntime
     }
-    val apiClient = remember(httpIgnoreSslErrors) { OpenClawClient(ignoreSslErrors = httpIgnoreSslErrors) }
+    val apiClient = remember { OpenClawClient() }
     
     var isTesting by rememberSaveable { mutableStateOf(false) }
     var testResult by remember { mutableStateOf<TestResult?>(null) }
@@ -462,7 +461,6 @@ fun SettingsScreen(
                                 settings.httpUrl = httpInputUrl.trim()
                             }
                             settings.authToken = httpToken.trim()
-                            settings.httpIgnoreSslErrors = httpIgnoreSslErrors
 
                             settings.defaultAgentId = defaultAgentId
                             settings.ttsEnabled = ttsEnabled
@@ -927,41 +925,6 @@ fun SettingsScreen(
 
                             Spacer(modifier = Modifier.height(12.dp))
 
-                            // Ignore SSL Errors Toggle
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(stringResource(R.string.http_ignore_ssl_errors), style = MaterialTheme.typography.bodyLarge)
-                                    Text(stringResource(R.string.http_ignore_ssl_errors_desc), style = MaterialTheme.typography.bodySmall, color = Color.Gray)
-                                }
-                                Switch(
-                                    checked = httpIgnoreSslErrors,
-                                    onCheckedChange = { httpIgnoreSslErrors = it; testResult = null }
-                                )
-                            }
-
-                            if (httpIgnoreSslErrors) {
-                                Spacer(modifier = Modifier.height(8.dp))
-                                Card(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    colors = CardDefaults.cardColors(
-                                        containerColor = MaterialTheme.colorScheme.errorContainer
-                                    )
-                                ) {
-                                    Text(
-                                        text = stringResource(R.string.http_ignore_ssl_errors_warning),
-                                        modifier = Modifier.padding(12.dp),
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onErrorContainer
-                                    )
-                                }
-                            }
-
-                            Spacer(modifier = Modifier.height(12.dp))
-
                             // Test Connection Button
                             Button(
                                 onClick = {
@@ -983,7 +946,6 @@ fun SettingsScreen(
                                                     testResult = TestResult(success = true, message = context.getString(R.string.connected))
                                                     settings.httpUrl = httpInputUrl.trim()
                                                     settings.authToken = httpToken.trim()
-                                                    settings.httpIgnoreSslErrors = httpIgnoreSslErrors
                                                     settings.isVerified = true
                                                 },
                                                 onFailure = {

--- a/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
+++ b/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
@@ -20,24 +20,13 @@ import javax.net.ssl.X509TrustManager
 /**
  * Simple client - POSTs to the configured HTTP connection
  */
-class OpenClawClient(private val ignoreSslErrors: Boolean = false) {
+class OpenClawClient() {
 
     private val client: OkHttpClient = run {
         val builder = OkHttpClient.Builder()
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(120, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
-        if (ignoreSslErrors) {
-            val trustAll = object : X509TrustManager {
-                override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
-                override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}
-                override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
-            }
-            val sslContext = SSLContext.getInstance("TLS")
-            sslContext.init(null, arrayOf(trustAll), null)
-            builder.sslSocketFactory(sslContext.socketFactory, trustAll)
-                .hostnameVerifier { _, _ -> true }
-        }
         builder.build()
     }
 

--- a/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
@@ -239,11 +239,6 @@ class SettingsRepository(context: Context) {
         get() = prefs.getString(KEY_CONNECTION_TYPE, CONNECTION_TYPE_GATEWAY) ?: CONNECTION_TYPE_GATEWAY
         set(value) = prefs.edit().putString(KEY_CONNECTION_TYPE, value).apply()
 
-    // Ignore SSL certificate errors for HTTPS connections (for self-signed certs)
-    var httpIgnoreSslErrors: Boolean
-        get() = prefs.getBoolean(KEY_HTTP_IGNORE_SSL_ERRORS, false)
-        set(value) = prefs.edit().putBoolean(KEY_HTTP_IGNORE_SSL_ERRORS, value).apply()
-
     // Connection type used by the voice session (wakeword / long-press home)
     // Defaults to the same as connectionType so existing setups behave identically
     var wakewordConnectionType: String
@@ -308,7 +303,6 @@ class SettingsRepository(context: Context) {
         private const val KEY_DEFAULT_AGENT_ID = "default_agent_id"
         private const val KEY_USE_NODE_CHAT = "use_node_chat"
         private const val KEY_CONNECTION_TYPE = "connection_type"
-        private const val KEY_HTTP_IGNORE_SSL_ERRORS = "http_ignore_ssl_errors"
         private const val KEY_WAKEWORD_CONNECTION_TYPE = "wakeword_connection_type"
         private const val KEY_SPEECH_SILENCE_TIMEOUT = "speech_silence_timeout"
         private const val KEY_THINKING_SOUND_ENABLED = "thinking_sound_enabled"

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
@@ -74,7 +74,7 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
     }
 
     private val settings = SettingsRepository.getInstance(context)
-    private val apiClient = OpenClawClient(ignoreSslErrors = settings.httpIgnoreSslErrors)
+    private val apiClient = OpenClawClient()
     private lateinit var speechManager: SpeechRecognizerManager
     private lateinit var ttsManager: TTSManager
     

--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatViewModel.kt
@@ -73,7 +73,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
 
     private val settings = SettingsRepository.getInstance(application)
     private val chatRepository = com.openclaw.assistant.data.repository.ChatRepository.getInstance(application)
-    private val apiClient = OpenClawClient(ignoreSslErrors = settings.httpIgnoreSslErrors)
+    private val apiClient = OpenClawClient()
     private val nodeRuntime = (application as OpenClawApplication).nodeRuntime
     private val speechManager = SpeechRecognizerManager(application)
     private val toneGenerator = android.media.ToneGenerator(android.media.AudioManager.STREAM_MUSIC, 100)


### PR DESCRIPTION
Removed the `ignoreSslErrors` HTTP connection setting and the underlying OkHttp TrustAll X509TrustManager implementation to prevent Man-in-the-Middle (MitM) attacks caused by blindly trusting all SSL certificates. For self-signed certificates, the standard TOFU (Trust On First Use) / fingerprinting mechanism provided by GatewayTls should be used instead.

---
*PR created automatically by Jules for task [404061787362476308](https://jules.google.com/task/404061787362476308) started by @yuga-hashimoto*