### PR TITLE
🎨 Polish: Improve empty chat hint

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatMessageListCard.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatMessageListCard.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import com.openclaw.assistant.R
 import com.openclaw.assistant.chat.ChatMessage
 import com.openclaw.assistant.chat.ChatPendingToolCall
 
@@ -111,7 +113,7 @@ private fun EmptyChatHint(modifier: Modifier = Modifier) {
       tint = MaterialTheme.colorScheme.onSurfaceVariant,
     )
     Text(
-      text = "Message OpenClaw…",
+      text = stringResource(R.string.ask_hint),
       style = MaterialTheme.typography.bodyMedium,
       color = MaterialTheme.colorScheme.onSurfaceVariant,
     )


### PR DESCRIPTION
This PR replaces the hardcoded "Message OpenClaw…" text in the empty chat state of `ChatMessageListCard.kt` with the existing `stringResource(R.string.ask_hint)` ("Ask OpenClaw…").

**Why:**
The previous string was hardcoded in English, preventing it from being translated for international users. Using `R.string.ask_hint` leverages existing translation resources, ensuring a consistent and localized experience across all supported languages (e.g., "OpenClawに質問…" in Japanese, "Pregunte a OpenClaw…" in Spanish).

**Impact:**
Improves UI consistency and fully localizes the empty chat state. No changes were made to the visual layout or spacing.

---
*PR created automatically by Jules for task [9814977620905380417](https://jules.google.com/task/9814977620905380417) started by @yuga-hashimoto*