### PR TITLE
fix: prevent FATAL crash when GMS barcode module is unavailable

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
@@ -13,6 +13,7 @@ import android.provider.Settings
 import com.google.mlkit.vision.barcode.common.Barcode
 import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
 import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
+import com.google.android.gms.common.moduleinstall.ModuleInstall
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -535,22 +536,41 @@ private fun ConnectionStep(
                     val options = GmsBarcodeScannerOptions.Builder()
                         .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
                         .build()
-                    GmsBarcodeScanning.getClient(context, options)
-                        .startScan()
-                        .addOnSuccessListener { barcode ->
-                            barcode.rawValue?.let { rawValue ->
-                                // openclaw qr generates {"setupCode":"base64..."} JSON; extract the inner code
-                                val code = try {
-                                    org.json.JSONObject(rawValue.trim())
-                                        .optString("setupCode")
-                                        .takeIf { it.isNotBlank() } ?: rawValue
-                                } catch (_: Exception) {
-                                    rawValue
-                                }
-                                onSetupCodeChange(code)
+                    val scanner = GmsBarcodeScanning.getClient(context, options)
+                    ModuleInstall.getClient(context)
+                        .areModulesAvailable(scanner)
+                        .addOnSuccessListener { response ->
+                            if (response.areModulesAvailable()) {
+                                scanner.startScan()
+                                    .addOnSuccessListener { barcode ->
+                                        barcode.rawValue?.let { rawValue ->
+                                            // openclaw qr generates {"setupCode":"base64..."} JSON; extract the inner code
+                                            val code = try {
+                                                org.json.JSONObject(rawValue.trim())
+                                                    .optString("setupCode")
+                                                    .takeIf { it.isNotBlank() } ?: rawValue
+                                            } catch (_: Exception) {
+                                                rawValue
+                                            }
+                                            onSetupCodeChange(code)
+                                        }
+                                    }
+                                    .addOnFailureListener { /* scan cancelled or failed — no action needed */ }
+                            } else {
+                                android.widget.Toast.makeText(
+                                    context,
+                                    context.getString(R.string.qr_scan_unavailable),
+                                    android.widget.Toast.LENGTH_LONG
+                                ).show()
                             }
                         }
-                        .addOnFailureListener { /* scan cancelled or failed — no action needed */ }
+                        .addOnFailureListener {
+                            android.widget.Toast.makeText(
+                                context,
+                                context.getString(R.string.qr_scan_unavailable),
+                                android.widget.Toast.LENGTH_LONG
+                            ).show()
+                        }
                 },
                 modifier = Modifier.fillMaxWidth().height(56.dp),
                 shape = RoundedCornerShape(16.dp),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -508,6 +508,7 @@ Weitere Informationen finden Sie auf der offiziellen Website von VOICEVOX.</stri
     <string name="operator_offline_command">openclaw devices approve $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
+    <string name="qr_scan_unavailable">QR-Scan ist nicht verfügbar. Bitte aktualisieren Sie die Google Play-Dienste.</string>
     <string name="reject_command_format">openclaw devices reject $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="setup_guide_qr_scan_title">Option 1: QR-Code scannen</string>
     <string name="setup_guide_qr_scan_cmd_label">Führen Sie dies auf dem Gateway-Host aus, um einen QR-Code anzuzeigen:</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -509,6 +509,7 @@ Para más detalles, consulta el sitio oficial de VOICEVOX.</string>
     <string name="operator_offline_command">openclaw devices approve $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
+    <string name="qr_scan_unavailable">El escaneo de QR no está disponible. Actualice los servicios de Google Play.</string>
     <string name="reject_command_format">openclaw devices reject $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="setup_guide_qr_scan_title">Opción 1: Escanear código QR</string>
     <string name="setup_guide_qr_scan_cmd_label">Ejecuta esto en el host del gateway para mostrar un código QR:</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -509,6 +509,7 @@ Pour plus de détails, consultez le site officiel de VOICEVOX.</string>
     <string name="operator_offline_command">openclaw devices approve $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
+    <string name="qr_scan_unavailable">La numérisation QR n\'est pas disponible. Veuillez mettre à jour les services Google Play.</string>
     <string name="reject_command_format">openclaw devices reject $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="setup_guide_qr_scan_title">Option 1 : Scanner le QR code</string>
     <string name="setup_guide_qr_scan_cmd_label">Exécutez ceci sur l\'hôte de la passerelle pour afficher un QR code :</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -509,6 +509,7 @@
     <string name="operator_offline_command">openclaw devices approve $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
+    <string name="qr_scan_unavailable">QR स्कैनिंग उपलब्ध नहीं है। कृपया Google Play Services अपडेट करें।</string>
     <string name="reject_command_format">openclaw devices reject $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="setup_guide_qr_scan_title">विकल्प 1: QR कोड स्कैन करें</string>
     <string name="setup_guide_qr_scan_cmd_label">QR कोड दिखाने के लिए गेटवे होस्ट पर यह चलाएं:</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -507,6 +507,7 @@
     <string name="setup_guide_qr_scan_cmd_label">QRコードを表示するには、ゲートウェイホストでこれを実行してください:</string>
     <string name="setup_guide_code_input_title">方法2：セットアップコードを入力</string>
     <string name="qr_scan_desc">QRスキャン</string>
+    <string name="qr_scan_unavailable">QRスキャンが利用できません。Google Play開発者サービスを更新してください。</string>
 
     <!-- Missing translations -->
     <string name="approve_command_format">openclaw devices approve $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -509,6 +509,7 @@
     <string name="operator_offline_command">openclaw devices approve $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
+    <string name="qr_scan_unavailable">Сканирование QR недоступно. Пожалуйста, обновите сервисы Google Play.</string>
     <string name="reject_command_format">openclaw devices reject $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="setup_guide_qr_scan_title">Вариант 1: Сканировать QR-код</string>
     <string name="setup_guide_qr_scan_cmd_label">Запустите это на хосте шлюза для отображения QR-кода:</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -509,6 +509,7 @@
     <string name="operator_offline_command">openclaw devices approve $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
+    <string name="qr_scan_unavailable">QR 扫描不可用。请更新 Google Play 服务。</string>
     <string name="reject_command_format">openclaw devices reject $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="setup_guide_qr_scan_title">方式 1：扫描 QR 码</string>
     <string name="setup_guide_qr_scan_cmd_label">在网关主机上运行以下命令以显示 QR 码：</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -508,6 +508,7 @@
     <string name="operator_offline_command">openclaw devices approve $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
+    <string name="qr_scan_unavailable">QR 掃描無法使用。請更新 Google Play 服務。</string>
     <string name="reject_command_format">openclaw devices reject $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="setup_guide_qr_scan_title">方式 1：掃描 QR 碼</string>
     <string name="setup_guide_qr_scan_cmd_label">在閘道主機上執行以下命令以顯示 QR 碼：</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -599,6 +599,7 @@
 
     <string name="qr_scan_prompt">Scan QR Code</string>
 <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
+    <string name="qr_scan_unavailable">QR scanning is unavailable. Please update Google Play Services.</string>
     <string name="setup_guide_qr_scan_title">Option 1: Scan QR Code</string>
     <string name="setup_guide_qr_scan_cmd_label">Run this on the gateway host to display a QR code:</string>
     <string name="setup_guide_code_input_title">Option 2: Enter Setup Code</string>


### PR DESCRIPTION
## Summary / 概要

| | |
|---|---|
| **Issue** | Crashlytics FATAL crash `563ca2af` (first seen v2.4.5) |
| **Root cause** | `GmsBarcodeScanningDelegateActivity.onCreate` throws `ActivityNotFoundException` on devices with outdated Google Play Services |
| **Fix** | Check GMS module availability via `ModuleInstallClient` before launching scanner |

**EN**: On devices with outdated GMS (e.g. Nexus 5X / Android 13), the GMS barcode module may not be installed. `GmsBarcodeScanningDelegateActivity` crashes with `ActivityNotFoundException` inside its `onCreate`, which is unrecoverable by `addOnFailureListener`. Now we check availability first and show a user-friendly Toast if the module is missing.

**JA**: 古いGoogle Play Services端末（Nexus 5X / Android 13等）では、GMSバーコードモジュールが未インストールの場合がある。`GmsBarcodeScanningDelegateActivity.onCreate`内で`ActivityNotFoundException`が発生し、`addOnFailureListener`では捕捉できないFATALクラッシュになっていた。`ModuleInstallClient`で事前チェックし、未インストール時はToastでエラーを表示するよう修正。

## Changes / 変更内容

- `SetupGuideScreen.kt`: Wrap `startScan()` with `ModuleInstall.getClient().areModulesAvailable()` check
- All 9 language `strings.xml`: Add `qr_scan_unavailable` error string

## Test plan / テスト計画

- [ ] QR scan works normally on a device with up-to-date GMS
- [ ] On a device/emulator without the GMS barcode module, a Toast is shown instead of crashing
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)