### PR TITLE
🎨 Palette: Improve MissingScopeCard keyboard & screen reader accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-11-20 - Expand/Collapse Accessibility Pattern
 **Learning:** Adding a `contentDescription` to an expand/collapse `Icon` inside a clickable row that already has adjacent descriptive text causes duplicate/confusing screen reader announcements.
 **Action:** Always set the `onClickLabel` of the `Modifier.clickable` parent `Row` to describe the action (e.g. "Expand" or "Collapse") dynamically based on state, assign a semantic `role = Role.Button`, and set the child `Icon`'s `contentDescription = null` to ensure a single, clear semantic interaction.
+
+## $(date +%Y-%m-%d) - Expand/Collapse State Accessibility in Jetpack Compose
+**Learning:** In Jetpack Compose, when building custom expandable components (like error or warning cards), default Material `Card` components with an `onClick` parameter do not automatically announce their state (expanded vs collapsed) to screen readers (TalkBack). Furthermore, purely decorative state icons (like chevrons) are often left with `contentDescription = null`, causing screen reader users to completely miss the interaction paradigm.
+**Action:** When creating custom expandable interactive containers, always apply an `onClickLabel` (e.g., via `Modifier.clickable(onClickLabel = ...)`) that dynamically switches between "Expand" and "Collapse" string resources based on the current state, and ensure accompanying state icons either share this description or are explicitly marked `null` if the container's label already covers the interaction semantics adequately.

--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1264,17 +1264,17 @@ fun CompactActionCard(modifier: Modifier = Modifier, icon: ImageVector, title: S
 fun MissingScopeCard(error: String, onClick: () -> Unit) {
     var expanded by rememberSaveable { mutableStateOf(false) }
     val context = LocalContext.current
+    val actionLabel = if (expanded) stringResource(R.string.action_collapse) else stringResource(R.string.action_expand)
 
     Card(
-        modifier = Modifier.fillMaxWidth(), 
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer), 
-        onClick = { expanded = !expanded }
+        modifier = Modifier.fillMaxWidth().clickable(onClickLabel = actionLabel) { expanded = !expanded },
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer)
     ) {
         Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
                     imageVector = Icons.Default.Error, 
-                    contentDescription = null, 
+                    contentDescription = stringResource(R.string.permission_error_title),
                     tint = MaterialTheme.colorScheme.error, 
                     modifier = Modifier.size(32.dp)
                 )
@@ -1302,7 +1302,7 @@ fun MissingScopeCard(error: String, onClick: () -> Unit) {
                 }
                 Icon(
                     imageVector = if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown, 
-                    contentDescription = null, 
+                    contentDescription = actionLabel,
                     tint = MaterialTheme.colorScheme.error
                 )
             }


### PR DESCRIPTION
💡 What: Added screen reader (TalkBack) accessibility properties (`onClickLabel` and `contentDescription`) to the interactive `MissingScopeCard`.
🎯 Why: The original error card expanded/collapsed when clicked, but screen readers only announced it as a generic clickable button without conveying its current state (expanded/collapsed) or the purpose of its decorative state icons.
📸 Before/After: Visuals remain unchanged, but screen readers now accurately read "Collapse" or "Expand" depending on state.
♿ Accessibility: Improved TalkBack semantic readouts by assigning specific string resources (`action_collapse`, `action_expand`, and `permission_error_title`) to components previously left as `null` or missing labels.

---
*PR created automatically by Jules for task [2233231152097826414](https://jules.google.com/task/2233231152097826414) started by @yuga-hashimoto*