### PR TITLE
🛡️ Sentinel: Fix JSON injection vulnerabilities in node handlers

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/ClipboardHandler.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/ClipboardHandler.kt
@@ -5,8 +5,10 @@ import android.content.ClipboardManager
 import android.content.Context
 import com.openclaw.assistant.gateway.GatewaySession
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.JsonPrimitive
 
 class ClipboardHandler(
   private val context: Context,
@@ -31,8 +33,10 @@ class ClipboardHandler(
         ""
       }
 
-      val escapedText = text.replace("\"", "\\\"").replace("\n", "\\n")
-      GatewaySession.InvokeResult.ok("""{"text":"$escapedText"}""")
+      val payload = buildJsonObject {
+          put("text", JsonPrimitive(text))
+      }.toString()
+      GatewaySession.InvokeResult.ok(payload)
     } catch (e: Throwable) {
       val (code, msg) = invokeErrorFromThrowable(e)
       GatewaySession.InvokeResult.error(code, msg)

--- a/app/src/main/java/com/openclaw/assistant/node/NodeUtils.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/NodeUtils.kt
@@ -11,12 +11,7 @@ data class Quad<A, B, C, D>(val first: A, val second: B, val third: C, val fourt
 data class Quint<A, B, C, D, E>(val first: A, val second: B, val third: C, val fourth: D, val fifth: E)
 
 fun String.toJsonString(): String {
-    val escaped =
-        this.replace("\\", "\\\\")
-            .replace("\"", "\\\"")
-            .replace("\n", "\\n")
-            .replace("\r", "\\r")
-    return "\"$escaped\""
+    return JsonPrimitive(this).toString()
 }
 
 fun JsonElement?.asObjectOrNull(): JsonObject? = this as? JsonObject

--- a/app/src/main/java/com/openclaw/assistant/node/SmsManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/SmsManager.kt
@@ -11,6 +11,8 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.encodeToString
 import com.openclaw.assistant.PermissionRequester
@@ -284,12 +286,18 @@ class SmsManager(private val context: Context) {
                 }
             }
 
-            val messagesJson = messages.joinToString(",") { msg ->
-                val escapedBody = msg.body.replace("\"", "\\\"").replace("\n", "\\n")
-                val escapedAddress = msg.address.replace("\"", "\\\"").replace("\n", "\\n")
-                """{"address":"$escapedAddress","body":"$escapedBody","date":${msg.date},"isRead":${msg.isRead}}"""
-            }
-            val payload = """{"messages":[$messagesJson]}"""
+            val payload = buildJsonObject {
+                put("messages", buildJsonArray {
+                    messages.forEach { msg ->
+                        add(buildJsonObject {
+                            put("address", JsonPrimitive(msg.address))
+                            put("body", JsonPrimitive(msg.body))
+                            put("date", JsonPrimitive(msg.date))
+                            put("isRead", JsonPrimitive(msg.isRead))
+                        })
+                    }
+                })
+            }.toString()
             return ReadResult(ok = true, messages = messages, payloadJson = payload)
         } catch (e: SecurityException) {
             return errorReadResult("SMS_PERMISSION_REQUIRED: ${e.message}")


### PR DESCRIPTION
This PR remediates a JSON injection vulnerability across several node handlers (`SmsManager.kt`, `ClipboardHandler.kt`, and `NodeUtils.kt`).

**Issue:**
Previously, JSON payloads were manually constructed using string interpolation and `String.replace()`. This manual escaping mechanism failed to properly escape control characters (e.g., `\b`, `\t`, `\f`, or unescaped backslashes `\`), which can lead to malformed JSON, parse errors (Denial of Service), or potential JSON injection attacks when processing user-controlled input (e.g., from the clipboard or incoming SMS messages).

**Fix:**
Replaced the vulnerable manual string concatenation with robust JSON encoding mechanisms using `kotlinx.serialization.json` functions (`buildJsonObject`, `buildJsonArray`, and `JsonPrimitive`). These native serialization APIs guarantee that all values are safely encoded and properly escaped, adhering exactly to the JSON specification.

---
*PR created automatically by Jules for task [3689410461612651249](https://jules.google.com/task/3689410461612651249) started by @yuga-hashimoto*