### PR TITLE
fix: stop speech recognition loop when user explicitly dismisses overlay

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
@@ -191,7 +191,10 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
                     partialText = partialText.value,
                     errorMessage = errorMessage.value,
                     audioLevel = audioLevel.value,
-                    onClose = { finish() },
+                    onClose = {
+                        isUserDismissed = true
+                        finish()
+                    },
                     onRetry = { startListening() },
                     onInterrupt = { interruptAndListen() }
                 )
@@ -289,6 +292,13 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
     override fun onHide() {
         super.onHide()
 
+        // ユーザーが明示的に Close ボタンを押した場合は、音声状態に関わらず必ずクリーンアップ
+        if (isUserDismissed) {
+            isUserDismissed = false
+            cleanupSession()
+            return
+        }
+
         // If a voice session is active (listening, thinking, or speaking),
         // keep resources alive so conversation continues with screen off.
         val state = currentState.value
@@ -367,6 +377,7 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
 
     private var listeningJob: Job? = null
     private var speakingJob: Job? = null
+    private var isUserDismissed = false
 
     private fun startListening(initialDelayMs: Long = 50L) {
         Log.d(TAG, "startListening() called, currentState=${currentState.value}, listeningJob=${listeningJob}, speakingJob=${speakingJob}")


### PR DESCRIPTION
## Summary / 概要

Fixes #371

| | EN | JA |
|---|---|---|
| **Problem** | When the user opened the assistant and immediately pressed Close, the speech recognition loop continued running indefinitely in the background | アシスタントを開いてすぐ Close ボタンを押すと、音声認識ループがバックグラウンドで無限に続く |
| **Root cause** | `onHide()` has a "screen-off conversation" feature that keeps resources alive when state is `LISTENING`. It could not distinguish explicit user dismissal from a screen-off event | `onHide()` の「画面オフ中も会話継続」機能が `LISTENING` 状態ではリソースを維持する。Close 操作と画面オフを区別できなかった |
| **Fix** | Add `isUserDismissed` flag set by the `onClose` lambda. `onHide()` checks the flag first and always calls `cleanupSession()` for explicit dismissals | `onClose` ラムダで `isUserDismissed` フラグをセット。`onHide()` がフラグを確認し、明示的な閉じ操作では必ず `cleanupSession()` を呼ぶ |

## Changes / 変更内容

- `OpenClawSession.kt`
  - Add `private var isUserDismissed = false` field
  - Set flag in `onClose` lambda before calling `finish()`
  - Check flag at the top of `onHide()` → force cleanup if true

The existing screen-off conversation feature is fully preserved.  
既存の「画面オフ中の会話継続」機能は維持されます。

## Test plan / テスト手順

- [ ] アシスタントを起動してすぐ Close ボタンを押す → オーバーレイが閉じてマイクが解放されること
- [ ] 会話中に画面をオフにする → 応答が引き続き聞こえること（screen-off 機能が壊れていないこと）
- [ ] continuous mode ON の状態で同じシナリオを再現 → ループが止まること

🤖 Generated with [Claude Code](https://claude.com/claude-code)