### PR TITLE
🔄 Upstream Parity: fix: make Android current-location callback cancellation-safe (#52318)

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/LocationCaptureManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/LocationCaptureManager.kt
@@ -13,8 +13,6 @@ import androidx.core.os.CancellationSignal as CoreCancellationSignal
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.suspendCancellableCoroutine
 
 class LocationCaptureManager(private val context: Context) {
@@ -131,8 +129,8 @@ class LocationCaptureManager(private val context: Context) {
     val resolved =
       providers.firstOrNull { manager.isProviderEnabled(it) }
         ?: throw IllegalStateException("LOCATION_UNAVAILABLE: no providers available")
-    return withTimeout(timeoutMs.coerceAtLeast(1)) {
-      suspendCancellableCoroutine { cont ->
+    val location = withTimeout(timeoutMs.coerceAtLeast(1)) {
+      suspendCancellableCoroutine<Location?> { cont ->
         val signal = CoreCancellationSignal()
         cont.invokeOnCancellation { signal.cancel() }
         LocationManagerCompat.getCurrentLocation(
@@ -141,13 +139,10 @@ class LocationCaptureManager(private val context: Context) {
             signal,
             ContextCompat.getMainExecutor(context)
         ) { location ->
-          if (location != null) {
-            cont.resume(location)
-          } else {
-            cont.resumeWithException(IllegalStateException("LOCATION_UNAVAILABLE: no fix"))
-          }
+          cont.resume(location) { _ -> }
         }
       }
     }
+    return location ?: throw IllegalStateException("LOCATION_UNAVAILABLE: no fix")
   }
 }


### PR DESCRIPTION
- Source: https://github.com/openclaw/openclaw/commit/d551d8b8f7e49482647263316300b3d42db52a37
- Why: Prevent crash `Already resumed` caused by a race condition where the location callback fires after the coroutine was already cancelled by a timeout.
- Adaptation: Adapted the coroutine signature from `suspendCancellableCoroutine<Location>` to `suspendCancellableCoroutine<Location?>` to safely propagate `null` upon timeout cancellation.
- Excluded upstream behavior: N/A - applied the core coroutine logic fix fully.
- Verification: Compiled successfully using `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug`. No regressions introduced to LocationManager wrapping.

---
*PR created automatically by Jules for task [9771206520887970185](https://jules.google.com/task/9771206520887970185) started by @yuga-hashimoto*