### PR TITLE
🧪 Regression Guard: Fix location coroutine crash

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/LocationCaptureManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/LocationCaptureManager.kt
@@ -132,7 +132,7 @@ class LocationCaptureManager(private val context: Context) {
       providers.firstOrNull { manager.isProviderEnabled(it) }
         ?: throw IllegalStateException("LOCATION_UNAVAILABLE: no providers available")
     return withTimeout(timeoutMs.coerceAtLeast(1)) {
-      suspendCancellableCoroutine { cont ->
+      suspendCancellableCoroutine<Location?> { cont ->
         val signal = CoreCancellationSignal()
         cont.invokeOnCancellation { signal.cancel() }
         LocationManagerCompat.getCurrentLocation(
@@ -141,13 +141,9 @@ class LocationCaptureManager(private val context: Context) {
             signal,
             ContextCompat.getMainExecutor(context)
         ) { location ->
-          if (location != null) {
-            cont.resume(location)
-          } else {
-            cont.resumeWithException(IllegalStateException("LOCATION_UNAVAILABLE: no fix"))
-          }
+          cont.resume(location) { _ -> }
         }
-      }
+      } ?: throw IllegalStateException("LOCATION_UNAVAILABLE: no fix")
     }
   }
 }


### PR DESCRIPTION
This PR fixes a critical crash in `LocationCaptureManager.kt` caused by an improper usage of `suspendCancellableCoroutine`.

**Issue:**
If `withTimeout` cancelled the `suspendCancellableCoroutine`, but the `LocationManagerCompat.getCurrentLocation` callback was later invoked with a `null` location, the callback would execute `cont.resumeWithException(...)`. In Kotlin coroutines, calling `resumeWithException` on an already-cancelled continuation causes the exception to be treated as unhandled, immediately crashing the app.

**Fix:**
* Modified `suspendCancellableCoroutine` to return a nullable `Location?`.
* Changed the callback logic to safely resume with the location using `cont.resume(location) { _ -> }`.
* Shifted the `IllegalStateException` throwing logic outside the continuation block using the Elvis operator (`?: throw`).

If the coroutine is cancelled via timeout, the `null` resumption is safely ignored by the standard coroutine mechanisms, and the crash is completely prevented. The original timeout and exception behaviors are preserved identically.

Tested locally with `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug`.

---
*PR created automatically by Jules for task [11631572841600764053](https://jules.google.com/task/11631572841600764053) started by @yuga-hashimoto*