### PR TITLE
🎨 Palette: Improve accessibility of info buttons in MainActivity

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,6 @@
 ## 2024-11-20 - Expand/Collapse Accessibility Pattern
 **Learning:** Adding a `contentDescription` to an expand/collapse `Icon` inside a clickable row that already has adjacent descriptive text causes duplicate/confusing screen reader announcements.
 **Action:** Always set the `onClickLabel` of the `Modifier.clickable` parent `Row` to describe the action (e.g. "Expand" or "Collapse") dynamically based on state, assign a semantic `role = Role.Button`, and set the child `Icon`'s `contentDescription = null` to ensure a single, clear semantic interaction.
+## 2024-05-15 - Android String Formatting in strings.xml
+**Learning:** Using `%s` for string arguments in Android `strings.xml` can cause compilation errors (`Found item String/[name] more than one time` or `malformed patch`) during resource merging, and is discouraged for localization.
+**Action:** Always use positional format specifiers like `%1$s` instead of `%s` when defining formatted string resources, ensuring compatibility with `stringResource` in Jetpack Compose and enabling translators to safely reorder words based on language grammar.

--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1146,7 +1146,7 @@ fun CapabilityCard(
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                        contentDescription = "More info about $label",
+                        contentDescription = stringResource(R.string.more_info_description, label),
                         tint = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(16.dp)
                     )
@@ -1249,7 +1249,7 @@ fun CompactActionCard(modifier: Modifier = Modifier, icon: ImageVector, title: S
             Column(modifier = Modifier.weight(1f).fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
                 Row(modifier = Modifier.fillMaxWidth().height(32.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                     Icon(imageVector = icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(28.dp))
-                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = "More information about $title", tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable { onInfoClick?.invoke() })
+                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = stringResource(R.string.more_info_description, title), tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable { onInfoClick?.invoke() })
                     if (showSwitch) Switch(checked = switchValue, onCheckedChange = onSwitchChange, modifier = Modifier.scale(0.8f).offset(y = (-8).dp))
                 }
                 Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,6 +348,7 @@
     <string name="gateway_manual_desc">Connect to specific host/port</string>
     <string name="gateway_host">Host</string>
     <string name="gateway_port">Port</string>
+    <string name="more_info_description">More information about %1$s</string>
     <string name="gateway_port_error">Invalid port</string>
     <string name="gateway_token">Token</string>
     <string name="gateway_password">Password</string>


### PR DESCRIPTION
💡 **What**: Replaced hardcoded english "More info about..." strings with a localized `stringResource` named `more_info_description` in `CapabilityCard` and `CompactActionCard`.
🎯 **Why**: Hardcoded strings are not localized when the language is changed, confusing non-English screen reader users.
📸 **Before/After**: Visually identical, but affects text-to-speech output when accessibility is enabled.
♿ **Accessibility**: Improved screen reader announcements for the information and help buttons by making them translatable.

---
*PR created automatically by Jules for task [13212098672837285521](https://jules.google.com/task/13212098672837285521) started by @yuga-hashimoto*