### PR TITLE
🎨 Polish: Improve command copy feedback

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
@@ -104,6 +104,8 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
                     modifier = Modifier.weight(1f),
                     contentPadding = PaddingValues(horizontal = 8.dp)
                 ) {
+                    Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(16.dp))
+                    Spacer(modifier = Modifier.width(4.dp))
                     Text(stringResource(R.string.pairing_reject_command), fontSize = 12.sp)
                 }
             }


### PR DESCRIPTION
**What**
Added the `ContentCopy` icon and a spacer to the "Reject" command button in `PairingRequiredCard.kt`.

**Why**
The "Approve" button had a visual cue (the `ContentCopy` icon) indicating that clicking it copies a command to the clipboard, but the "Reject" button lacked this icon despite performing a similar clipboard copy action. Adding the icon makes the interface consistent and clarifies the button's function.

**Before/After**
- Before: The "Reject" button contained only text.
- After: The "Reject" button now displays the `ContentCopy` icon alongside the text, matching the "Approve" button.

**Accessibility**
The new icon has `contentDescription = null` to prevent duplicate screen reader announcements, since the button's purpose is clearly conveyed by the text.

---
*PR created automatically by Jules for task [2241509954840934099](https://jules.google.com/task/2241509954840934099) started by @yuga-hashimoto*