### PR TITLE
🧪 Regression Guard: Fix LocationManager callback crash

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/LocationCaptureManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/LocationCaptureManager.kt
@@ -132,7 +132,7 @@ class LocationCaptureManager(private val context: Context) {
       providers.firstOrNull { manager.isProviderEnabled(it) }
         ?: throw IllegalStateException("LOCATION_UNAVAILABLE: no providers available")
     return withTimeout(timeoutMs.coerceAtLeast(1)) {
-      suspendCancellableCoroutine { cont ->
+      val loc = suspendCancellableCoroutine<Location?> { cont ->
         val signal = CoreCancellationSignal()
         cont.invokeOnCancellation { signal.cancel() }
         LocationManagerCompat.getCurrentLocation(
@@ -142,12 +142,13 @@ class LocationCaptureManager(private val context: Context) {
             ContextCompat.getMainExecutor(context)
         ) { location ->
           if (location != null) {
-            cont.resume(location)
+            cont.resume(location) { _ -> }
           } else {
-            cont.resumeWithException(IllegalStateException("LOCATION_UNAVAILABLE: no fix"))
+            cont.resume(null) { _ -> }
           }
         }
       }
+      loc ?: throw IllegalStateException("LOCATION_UNAVAILABLE: no fix")
     }
   }
 }


### PR DESCRIPTION
Fixes a stability issue in `LocationCaptureManager.kt` where an unhandled exception inside a cancelled coroutine callback causes the app to crash. Changing the coroutine to explicitly return `Location?` allows handling the exception gracefully outside the continuation block.

---
*PR created automatically by Jules for task [16277318853549620347](https://jules.google.com/task/16277318853549620347) started by @yuga-hashimoto*