### PR TITLE
🔄 Upstream Parity: Make current-location callback cancellation-safe

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/LocationCaptureManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/LocationCaptureManager.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.suspendCancellableCoroutine
 
 class LocationCaptureManager(private val context: Context) {
@@ -131,8 +130,8 @@ class LocationCaptureManager(private val context: Context) {
     val resolved =
       providers.firstOrNull { manager.isProviderEnabled(it) }
         ?: throw IllegalStateException("LOCATION_UNAVAILABLE: no providers available")
-    return withTimeout(timeoutMs.coerceAtLeast(1)) {
-      suspendCancellableCoroutine { cont ->
+    val location = withTimeout(timeoutMs.coerceAtLeast(1)) {
+      suspendCancellableCoroutine<Location?> { cont ->
         val signal = CoreCancellationSignal()
         cont.invokeOnCancellation { signal.cancel() }
         LocationManagerCompat.getCurrentLocation(
@@ -141,13 +140,10 @@ class LocationCaptureManager(private val context: Context) {
             signal,
             ContextCompat.getMainExecutor(context)
         ) { location ->
-          if (location != null) {
-            cont.resume(location)
-          } else {
-            cont.resumeWithException(IllegalStateException("LOCATION_UNAVAILABLE: no fix"))
-          }
+          cont.resume(location) { _ -> }
         }
       }
     }
+    return location ?: throw IllegalStateException("LOCATION_UNAVAILABLE: no fix")
   }
 }


### PR DESCRIPTION
- **Source:** Upstream `openclaw/openclaw` commit `d551d8b8f7e49482647263316300b3d42db52a37`
- **Why:** To prevent a global app crash caused by an "undeliverable exception" that gets thrown when `withTimeout` expires, canceling the internal `suspendCancellableCoroutine` just before the callback tries to `resumeWithException`.
- **Adaptation:** Ported exactly as implemented upstream. Changed the coroutine signature from `suspendCancellableCoroutine` to `suspendCancellableCoroutine<Location?>`. It now uses `cont.resume(location) { _ -> }` allowing any internal exceptions (like timeout-induced cancellation) to be handled seamlessly. Extracted `location ?: throw IllegalStateException("LOCATION_UNAVAILABLE: no fix")` to the `return` statement outside the `withTimeout` block, where it can be correctly caught and handled by the system.
- **Excluded upstream behavior:** None. The fix perfectly maps to the local application logic.
- **Verification:** Built and verified locally against `app:testStandardDebugUnitTest` and `app:lintStandardDebug`. Checked the changes via the `request_code_review` tool.

---
*PR created automatically by Jules for task [8932583684124237116](https://jules.google.com/task/8932583684124237116) started by @yuga-hashimoto*