### PR TITLE
i18n: add missing accessibility string translations to all 8 locales

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -51,6 +51,8 @@
 <string name="ask_hint">Fragen Sie OpenClaw…</string>
 <string name="send_description">Schicken</string>
 <string name="stop_description">Stoppen</string>
+    <string name="start_listening_description">Zuhören starten</string>
+    <string name="interrupt_description">Unterbrechen und zuhören</string>
 <string name="listening">Hören…</string>
 <string name="thinking">Denken…</string>
 <string name="speaking">Spricht…</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -51,6 +51,8 @@
 <string name="ask_hint">Pregunte a OpenClaw…</string>
 <string name="send_description">Enviar</string>
 <string name="stop_description">Detener</string>
+    <string name="start_listening_description">Empezar a escuchar</string>
+    <string name="interrupt_description">Interrumpir y escuchar</string>
 <string name="listening">Escuchando…</string>
 <string name="thinking">Pensando…</string>
 <string name="speaking">Hablando…</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -51,6 +51,8 @@
 <string name="ask_hint">Demandez à OpenClaw…</string>
 <string name="send_description">Envoyer</string>
 <string name="stop_description">Arrêter</string>
+    <string name="start_listening_description">Commencer à écouter</string>
+    <string name="interrupt_description">Interrompre et écouter</string>
 <string name="listening">Écoute…</string>
 <string name="thinking">Réflexion…</string>
 <string name="speaking">Parlant…</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -51,6 +51,8 @@
 <string name="ask_hint">ओपनक्लॉ से पूछें...</string>
 <string name="send_description">भेजना</string>
 <string name="stop_description">रुकना</string>
+    <string name="start_listening_description">सुनना शुरू करें</string>
+    <string name="interrupt_description">बाधित करें और सुनें</string>
 <string name="listening">सुनना…</string>
 <string name="thinking">सोच…</string>
 <string name="speaking">बोला जा रहा है…</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -51,6 +51,8 @@
 <string name="ask_hint">OpenClawに質問…</string>
 <string name="send_description">送信</string>
 <string name="stop_description">停止</string>
+    <string name="start_listening_description">聴き始める</string>
+    <string name="interrupt_description">割り込んで聴く</string>
 <string name="listening">聞いています…</string>
 <string name="thinking">考え中…</string>
 <string name="speaking">読み上げ中…</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -51,6 +51,8 @@
 <string name="ask_hint">Спросите OpenClaw…</string>
 <string name="send_description">Отправить</string>
 <string name="stop_description">Стоп</string>
+    <string name="start_listening_description">Начать прослушивание</string>
+    <string name="interrupt_description">Прервать и слушать</string>
 <string name="listening">Слушаю…</string>
 <string name="thinking">Думая…</string>
 <string name="speaking">Говорю…</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -51,6 +51,8 @@
 <string name="ask_hint">询问 OpenClaw...</string>
 <string name="send_description">发送</string>
 <string name="stop_description">停止</string>
+    <string name="start_listening_description">开始聆听</string>
+    <string name="interrupt_description">打断并聆听</string>
 <string name="listening">聆听…</string>
 <string name="thinking">思考…</string>
 <string name="speaking">说话…</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -51,6 +51,8 @@
 <string name="ask_hint">詢問 OpenClaw...</string>
 <string name="send_description">傳送</string>
 <string name="stop_description">停止</string>
+    <string name="start_listening_description">開始聆聽</string>
+    <string name="interrupt_description">打斷並聆聽</string>
 <string name="listening">正在聽…</string>
 <string name="thinking">思維…</string>
 <string name="speaking">請講…</string>


### PR DESCRIPTION
## Summary / 概要

PR #384 added two new accessibility strings to `values/strings.xml` but did not propagate them to the other 8 locale files.

PR #384 で追加されたアクセシビリティ文字列2件が、英語(values/)以外の8言語に追加されていなかったため修正。

| String | EN |
|--------|-----|
| `start_listening_description` | Start listening |
| `interrupt_description` | Interrupt and listen |

**Affected locales / 対象言語:** ja, de, es, fr, hi, ru, zh-rCN, zh-rTW

These strings are used as accessibility `contentDescription` / `onClickLabel` in `OpenClawSession.kt`. The app does not crash without them (Android falls back to English), but they should be localized per project convention.

アクセシビリティ用途のみのため、欠落してもクラッシュはしないが、プロジェクトルール（全9言語への追加）を満たすため修正。

## Test plan / テスト計画

- [ ] Build succeeds with no lint errors
- [ ] On a non-English device, TalkBack reads the localized string for the interrupt/listen button