### PR TITLE
🔄 Upstream Parity: Fix temp file leak in CameraHandler.handleClip

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CameraHandler.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CameraHandler.kt
@@ -145,9 +145,11 @@ class CameraHandler(
         clipLog("upload failed: ${err.message}, falling back to base64")
         // Fallback to base64 if upload fails
         val bytes = withContext(Dispatchers.IO) {
-          val b = filePayload.file.readBytes()
-          filePayload.file.delete()
-          b
+          try {
+            filePayload.file.readBytes()
+          } finally {
+            filePayload.file.delete()
+          }
         }
         val base64 = android.util.Base64.encodeToString(bytes, android.util.Base64.NO_WRAP)
         showCameraHud("Clip captured", CameraHudKind.Success, 1800)


### PR DESCRIPTION
- Source: upstream commit `88da51d91b`
- Why: When `readBytes()` throws (e.g., IOException, OOM), the recorded clip file was never deleted because `delete()` only ran on the success path. This leaked native storage.
- Adaptation: Wrapped `filePayload.file.readBytes()` in a `try/finally` block where `delete()` is executed in the `finally` block.
- Excluded upstream behavior: None.
- Verification: Ran `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug` natively successfully.

---
*PR created automatically by Jules for task [7193552564517227257](https://jules.google.com/task/7193552564517227257) started by @yuga-hashimoto*