### PR TITLE
🎨 Palette: Fix redundant screen reader announcement for QR scanner icon

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-11-20 - Expand/Collapse Accessibility Pattern
 **Learning:** Adding a `contentDescription` to an expand/collapse `Icon` inside a clickable row that already has adjacent descriptive text causes duplicate/confusing screen reader announcements.
 **Action:** Always set the `onClickLabel` of the `Modifier.clickable` parent `Row` to describe the action (e.g. "Expand" or "Collapse") dynamically based on state, assign a semantic `role = Role.Button`, and set the child `Icon`'s `contentDescription = null` to ensure a single, clear semantic interaction.
+
+## 2025-02-13 - Redundant Screen Reader Announcements on Icons
+**Learning:** Adding a `contentDescription` to an `Icon` when the adjacent `Text` provides the exact same descriptive string causes screen readers (like TalkBack) to announce the action twice (e.g., "Scan QR Code, Scan QR Code").
+**Action:** When an `Icon` is used alongside descriptive text within a clickable area, set the `Icon`'s `contentDescription` to `null` so the screen reader only reads the text once.

--- a/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
@@ -579,7 +579,7 @@ private fun ConnectionStep(
                 ),
                 border = androidx.compose.foundation.BorderStroke(1.dp, OnboardingGradientMid)
             ) {
-                Icon(Icons.Default.QrCodeScanner, contentDescription = stringResource(R.string.qr_scan_prompt))
+                Icon(Icons.Default.QrCodeScanner, contentDescription = null)
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(stringResource(R.string.qr_scan_prompt), fontSize = 16.sp)
             }


### PR DESCRIPTION
💡 What: Set the `contentDescription` of the `QrCodeScanner` icon to `null`.
🎯 Why: It was previously set to the same string resource as the adjacent `Text` element, causing TalkBack and other screen readers to announce "Scan QR Code, Scan QR Code".
📸 Before/After: Visuals are identical, but TalkBack will now only read the string once.
♿ Accessibility: Eliminates a redundant announcement, making the UI less annoying to navigate for visually impaired users.

---
*PR created automatically by Jules for task [1247996058134259488](https://jules.google.com/task/1247996058134259488) started by @yuga-hashimoto*