### PR TITLE
🧪 Regression Guard: Fix Wear OS foreground service crash

### DIFF
--- a/wear/src/main/java/com/openclaw/assistant/wear/service/WearSessionForegroundService.kt
+++ b/wear/src/main/java/com/openclaw/assistant/wear/service/WearSessionForegroundService.kt
@@ -22,7 +22,28 @@ class WearSessionForegroundService : Service() {
             .setSmallIcon(android.R.drawable.ic_btn_speak_now)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()
-        startForeground(NOTIFICATION_ID, notification)
+        try {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                val hasMicPermission = androidx.core.content.ContextCompat.checkSelfPermission(
+                    this, android.Manifest.permission.RECORD_AUDIO
+                ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+                if (hasMicPermission) {
+                    startForeground(
+                        NOTIFICATION_ID,
+                        notification,
+                        android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                    )
+                } else {
+                    startForeground(NOTIFICATION_ID, notification)
+                }
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("WearSessionFGS", "Failed to start foreground service", e)
+            stopSelf()
+            return START_NOT_STICKY
+        }
         return START_NOT_STICKY
     }
 


### PR DESCRIPTION
Fixes a potential crash on Android 14+ when starting the WearSessionForegroundService by handling \`ForegroundServiceStartNotAllowedException\` and providing the required microphone foreground service type.

The microphone foreground service type is required for apps running on Android 11+ (API level 30), and failing to provide it on newer Android versions when starting a foreground service for mic access will cause a crash.

---
*PR created automatically by Jules for task [3514171508074286382](https://jules.google.com/task/3514171508074286382) started by @yuga-hashimoto*