### PR TITLE
🔄 Upstream Parity: Fix Bitmap memory leaks in CameraCaptureManager.snap

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
@@ -121,42 +121,48 @@ class CameraCaptureManager(private val context: Context) {
             (rotated.height.toDouble() * (maxWidth.toDouble() / rotated.width.toDouble()))
               .toInt()
               .coerceAtLeast(1)
-          rotated.scale(maxWidth, h)
+          val s = rotated.scale(maxWidth, h)
+          if (s !== rotated) rotated.recycle()
+          s
         } else {
           rotated
         }
 
-      val maxPayloadBytes = 5 * 1024 * 1024
-      // Base64 inflates payloads by ~4/3; cap encoded bytes so the payload stays under 5MB (API limit).
-      val maxEncodedBytes = (maxPayloadBytes / 4) * 3
-      val result =
-        JpegSizeLimiter.compressToLimit(
-          initialWidth = scaled.width,
-          initialHeight = scaled.height,
-          startQuality = (quality * 100.0).roundToInt().coerceIn(10, 100),
-          maxBytes = maxEncodedBytes,
-          encode = { width, height, q ->
-            val bitmap =
-              if (width == scaled.width && height == scaled.height) {
-                scaled
-              } else {
-                scaled.scale(width, height)
+      try {
+        val maxPayloadBytes = 5 * 1024 * 1024
+        // Base64 inflates payloads by ~4/3; cap encoded bytes so the payload stays under 5MB (API limit).
+        val maxEncodedBytes = (maxPayloadBytes / 4) * 3
+        val result =
+          JpegSizeLimiter.compressToLimit(
+            initialWidth = scaled.width,
+            initialHeight = scaled.height,
+            startQuality = (quality * 100.0).roundToInt().coerceIn(10, 100),
+            maxBytes = maxEncodedBytes,
+            encode = { width, height, q ->
+              val bitmap =
+                if (width == scaled.width && height == scaled.height) {
+                  scaled
+                } else {
+                  scaled.scale(width, height)
+                }
+              val out = ByteArrayOutputStream()
+              if (!bitmap.compress(Bitmap.CompressFormat.JPEG, q, out)) {
+                if (bitmap !== scaled) bitmap.recycle()
+                throw IllegalStateException("UNAVAILABLE: failed to encode JPEG")
               }
-            val out = ByteArrayOutputStream()
-            if (!bitmap.compress(Bitmap.CompressFormat.JPEG, q, out)) {
-              if (bitmap !== scaled) bitmap.recycle()
-              throw IllegalStateException("UNAVAILABLE: failed to encode JPEG")
-            }
-            if (bitmap !== scaled) {
-              bitmap.recycle()
-            }
-            out.toByteArray()
-          },
+              if (bitmap !== scaled) {
+                bitmap.recycle()
+              }
+              out.toByteArray()
+            },
+          )
+        val base64 = Base64.encodeToString(result.bytes, Base64.NO_WRAP)
+        Payload(
+          """{"format":"jpg","base64":"$base64","width":${result.width},"height":${result.height}}""",
         )
-      val base64 = Base64.encodeToString(result.bytes, Base64.NO_WRAP)
-      Payload(
-        """{"format":"jpg","base64":"$base64","width":${result.width},"height":${result.height}}""",
-      )
+      } finally {
+        scaled.recycle()
+      }
     }
 
   @SuppressLint("MissingPermission")


### PR DESCRIPTION
- Source: upstream commit `d38561acbefa66af58f838d34b20fd7ad8e74cdc`
- Why: Fixes `OutOfMemoryError` (OOM) memory leaks by ensuring that intermediate scaled and rotated Bitmaps created during camera capture snapshot encoding are properly recycled.
- Adaptation: Applied the `try...finally` resource handling and exact recycle matching (`if (s !== rotated)`) directly to the local `CameraCaptureManager` equivalent.
- Excluded upstream behavior: N/A (applied as-is to local copy).
- Verification: Code successfully linted (`./gradlew app:lintStandardDebug`) and tests passed (`./gradlew app:testStandardDebugUnitTest`).

---
*PR created automatically by Jules for task [128827975073521390](https://jules.google.com/task/128827975073521390) started by @yuga-hashimoto*