### PR TITLE
🛡️ Sentinel: Add KeyboardType.Password to secure text fields

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -718,7 +718,8 @@ fun SettingsScreen(
                                     },
                                     visualTransformation = if (showNodeToken) VisualTransformation.None else PasswordVisualTransformation(),
                                     modifier = Modifier.fillMaxWidth(),
-                                    singleLine = true
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
                                 )
                             } else {
                                 OutlinedTextField(
@@ -792,7 +793,8 @@ fun SettingsScreen(
                                 },
                                 visualTransformation = if (showNodeToken) VisualTransformation.None else PasswordVisualTransformation(),
                                 modifier = Modifier.fillMaxWidth(),
-                                singleLine = true
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
                             )
                         }
 
@@ -1909,7 +1911,8 @@ fun ElevenLabsSettingsCard(
                 },
                 visualTransformation = if (showApiKey) VisualTransformation.None else PasswordVisualTransformation(),
                 modifier = Modifier.fillMaxWidth(),
-                singleLine = true
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
             )
             
             // API Key link button
@@ -2103,7 +2106,8 @@ fun OpenAISettingsCard(
                 },
                 visualTransformation = if (showApiKey) VisualTransformation.None else PasswordVisualTransformation(),
                 modifier = Modifier.fillMaxWidth(),
-                singleLine = true
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
             )
             
             // API Key link button


### PR DESCRIPTION
This PR adds `KeyboardOptions(keyboardType = KeyboardType.Password)` to sensitive `OutlinedTextField` inputs in `SettingsActivity.kt` that handle API keys and tokens. 

By default, the Android software keyboard may cache input into its predictive text dictionary or clipboard history. While `PasswordVisualTransformation` obscures the text visually on screen, explicitly specifying the password keyboard type ensures the keyboard itself treats the input securely and does not record the strings. This is a targeted security hardening measure to prevent inadvertent credential leakage via the keyboard.

All native lint checks and unit tests pass.

---
*PR created automatically by Jules for task [12284827145707236433](https://jules.google.com/task/12284827145707236433) started by @yuga-hashimoto*