### PR TITLE
🎨 Polish: Improve attachment error clarity

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatMessageViews.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatMessageViews.kt
@@ -216,7 +216,7 @@ private fun ChatBase64Image(base64: String, mimeType: String?) {
       modifier = Modifier.fillMaxWidth(),
     )
   } else if (state.failed) {
-    Text("Unsupported attachment", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    Text(stringResource(R.string.unsupported_attachment), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
   }
 }
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -432,6 +432,7 @@
 <string name="setup_code_applied">設定を適用しました！</string>
 <string name="setup_code_invalid_code">セットアップコードが無効または不完全です。</string>
 <string name="setup_code_credential_copy_button">コマンドをコピー</string>
+    <string name="unsupported_attachment">サポートされていない添付ファイル</string>
     <string name="setup_code_credential_hint_title">ゲートウェイのパスワードまたはトークンを入力してください</string>
 <string name="setup_code_credential_hint_desc">セットアップコードでサーバーURLを設定しました。オペレーターセッションを接続するには、ゲートウェイのパスワードまたはトークンを入力してください。\n\nOpenClawを起動しているホストで以下のコマンドを実行して取得できます：</string>
 <string name="permission_camera_desc">AIがカメラ映像を確認するために必要です</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -314,6 +314,7 @@
     <string name="reject_command_format">openclaw devices reject $(openclaw devices list --json | tr \'{\' \'\\n\' | grep \'\"deviceId\":\"%s\"\' | grep -o \'\"requestId\":\"[^\"]*\"\' | cut -d\'\"\' -f4)</string>
     <string name="pairing_approve_command">Approve Command (Copy)</string>
     <string name="pairing_reject_command">Reject Command (Copy)</string>
+    <string name="unsupported_attachment">Unsupported attachment</string>
     <string name="pairing_refresh_status">Refresh Status</string>
     <string name="pairing_guide_title">How to approve this device:</string>
     <string name="pairing_guide_step_1">1. Access your OpenClaw server terminal.</string>


### PR DESCRIPTION
**What**
Extracts the hardcoded "Unsupported attachment" string in ChatMessageViews.kt into Android string resources and adds a Japanese translation.

**Why**
To improve localization and error message clarity for non-English users when an unsupported attachment is encountered in chat.

**Before/After**
* Before: `Unsupported attachment` hardcoded in `ChatMessageViews.kt`
* After: References `stringResource(R.string.unsupported_attachment)` with both default (English) and Japanese translations available.

**Accessibility Details**
Improves accessibility by ensuring users properly receive localized text on screen rather than falling back to an English-only literal string.

---
*PR created automatically by Jules for task [4597236443263041178](https://jules.google.com/task/4597236443263041178) started by @yuga-hashimoto*