### PR TITLE
🎨 Palette: Improve accessibility of StatusIndicator

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,6 @@
 ## 2025-03-27 - Expand/Collapse Accessibility Pattern for MissingScopeCard
 **Learning:** Using `Card(onClick=)` without an `onClickLabel` leads to generic, unhelpful screen reader announcements. Expandable cards require explicit labels that change based on state (e.g. Expand / Collapse).
 **Action:** When converting `Card(onClick=)` to use `Modifier.clickable()`, use `onClickLabel = stringResource(if (expanded) R.string.action_collapse else R.string.action_expand)` and assign `role = Role.Button` so the action changes dynamically for screen readers.
+## 2025-02-24 - Improve Icon + Text Grouping in Status Indicators
+**Learning:** When pairing an icon (or shape) with text in a `Row` to convey a single state (like a connection status), adding `contentDescription` piecemeal to the inner elements causes screen readers to announce them individually or ignore the text entirely if the icon is focused first.
+**Action:** Apply `Modifier.semantics(mergeDescendants = true) {}` to the parent `Row`. *Crucially*, if the `Row` contains a child `Text` element displaying the label, do NOT also set `contentDescription = label` on the parent, as TalkBack will concatenate and read the string twice. Only apply `contentDescription` on the parent if the child text is absent (e.g., when showing an icon only).

--- a/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
@@ -70,7 +70,11 @@ fun StatusIndicator(
     )
 
     Row(
-        modifier = modifier,
+        modifier = modifier.semantics(mergeDescendants = true) {
+            if (label == null) {
+                contentDescription = stateDesc
+            }
+        },
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp)
     ) {
@@ -79,15 +83,6 @@ fun StatusIndicator(
                 .size(dotSize)
                 .alpha(alpha)
                 .background(dotColor, CircleShape)
-                .then(
-                    if (label == null) {
-                        Modifier.semantics {
-                            contentDescription = stateDesc
-                        }
-                    } else {
-                        Modifier
-                    }
-                )
         )
         if (label != null) {
             Text(


### PR DESCRIPTION
💡 **What:** Grouped the animated dot and text label within `StatusIndicator` using `semantics(mergeDescendants = true)`. Explicitly omitted the parent `contentDescription` when a text label is present to avoid duplicate TalkBack announcements.

🎯 **Why:** Previously, the screen reader would either read the components piecemeal or the `contentDescription` was conditionally applied only to the dot. This update ensures that TalkBack focuses on the entire connection indicator as a single, unified element and reads its state exactly once.

📸 **Before/After:** No visual changes. This is purely a semantic tree accessibility update.

♿ **Accessibility:** Prevents duplicate text reading and groups visually adjacent connection status elements into a single logical TalkBack target.

---
*PR created automatically by Jules for task [11907293781839752203](https://jules.google.com/task/11907293781839752203) started by @yuga-hashimoto*