### PR TITLE
🧪 Regression Guard: Fix WearSession FGS crash

### DIFF
--- a/wear/src/main/java/com/openclaw/assistant/wear/service/WearSession.kt
+++ b/wear/src/main/java/com/openclaw/assistant/wear/service/WearSession.kt
@@ -176,16 +176,30 @@ class WearSession(context: Context) : VoiceInteractionSession(context),
 
     override fun onShow(args: Bundle?, showFlags: Int) {
         super.onShow(args, showFlags)
+        val intent = Intent(context, WearSessionForegroundService::class.java)
+        try {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start WearSessionForegroundService", e)
+        }
         lifecycleRegistry.currentState = Lifecycle.State.RESUMED
         startListening()
     }
 
     override fun onHide() {
+        val intent = Intent(context, WearSessionForegroundService::class.java)
+        context.stopService(intent)
         super.onHide()
         lifecycleRegistry.currentState = Lifecycle.State.CREATED
     }
 
     override fun onDestroy() {
+        val intent = Intent(context, WearSessionForegroundService::class.java)
+        context.stopService(intent)
         lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
         scope.cancel()
         speechRecognizer?.destroy()


### PR DESCRIPTION
Fixes a regression on Android 12+ (specifically 14+) where starting WearSessionForegroundService from the background throws a ForegroundServiceStartNotAllowedException by wrapping it in a try-catch block.

---
*PR created automatically by Jules for task [12445350344638616959](https://jules.google.com/task/12445350344638616959) started by @yuga-hashimoto*