### PR TITLE
🎨 Polish: Improve connection status text contrast

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
@@ -93,7 +93,7 @@ fun StatusIndicator(
             Text(
                 text = label,
                 style = MaterialTheme.typography.bodySmall,
-                color = dotColor
+                color = MaterialTheme.colorScheme.onSurface
             )
         }
     }


### PR DESCRIPTION
Changed the `StatusIndicator` label text color to `MaterialTheme.colorScheme.onSurface` instead of using the raw status color (`dotColor`). This improves contrast and legibility, especially on light themes where bright green or yellow text can be difficult to read.

---
*PR created automatically by Jules for task [8989944713292345674](https://jules.google.com/task/8989944713292345674) started by @yuga-hashimoto*