### PR TITLE
🎨 Palette: Prevent duplicate screen reader announcements on semantic icons

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
@@ -1078,7 +1078,7 @@ private fun FinalCheckStep(
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(Icons.Default.Shield, contentDescription = stringResource(R.string.permission_summary_title), tint = OnboardingGradientMid)
+            Icon(Icons.Default.Shield, contentDescription = null, tint = OnboardingGradientMid)
             Spacer(modifier = Modifier.width(12.dp))
             Column {
                 Text(

--- a/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
@@ -46,7 +46,7 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(Icons.Default.Devices, contentDescription = stringResource(R.string.pairing_required_title), tint = MaterialTheme.colorScheme.error)
+                Icon(Icons.Default.Devices, contentDescription = null, tint = MaterialTheme.colorScheme.error)
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = stringResource(R.string.pairing_required_title),


### PR DESCRIPTION
💡 **What:** Set `contentDescription = null` for the "Shield" icon in `SetupGuideScreen` and the "Devices" icon in `PairingRequiredCard`.

🎯 **Why:** TalkBack was reading the same text twice because both the icon and the adjacent text had identical semantic values ("Device Pairing Required" and "Permissions Summary"). Setting the icon's description to null removes this redundancy.

♿ **Accessibility:** Purely decorative icons or icons providing duplicate information should not be independently focusable or described by screen readers. This streamlines the auditory experience.

---
*PR created automatically by Jules for task [745039496897907745](https://jules.google.com/task/745039496897907745) started by @yuga-hashimoto*