### PR TITLE
🎨 Polish: Improve connection status accessibility

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.text.font.FontFamily
@@ -1031,25 +1032,33 @@ fun SystemStatusCard(
     ) {
         Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 14.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                val state = when {
-                    connected -> ConnectionState.Connected
-                    isConnecting -> ConnectionState.Connecting
-                    else -> ConnectionState.Disconnected
+                Row(
+                    modifier = Modifier
+                        .weight(1f)
+                        .semantics(mergeDescendants = true) {},
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    val state = when {
+                        connected -> ConnectionState.Connected
+                        isConnecting -> ConnectionState.Connecting
+                        else -> ConnectionState.Disconnected
+                    }
+                    Box(modifier = Modifier.clearAndSetSemantics {}) {
+                        StatusIndicator(state = state)
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(R.string.app_name),
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = statusText,
+                        fontSize = 13.sp,
+                        color = contentColor.copy(alpha = 0.8f)
+                    )
                 }
-                StatusIndicator(state = state)
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = stringResource(R.string.app_name),
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.Bold
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = statusText,
-                    fontSize = 13.sp,
-                    color = contentColor.copy(alpha = 0.8f),
-                    modifier = Modifier.weight(1f)
-                )
                 IconButton(onClick = onOpenSettings, modifier = Modifier.size(24.dp)) {
                     Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.settings_title), tint = contentColor.copy(alpha = 0.6f))
                 }

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,6 @@
+1. Modify `app/src/main/java/com/openclaw/assistant/MainActivity.kt` to import `androidx.compose.ui.semantics.clearAndSetSemantics`.
+2. In `SystemStatusCard`, wrap `StatusIndicator` and the two `Text` views inside a `Row` with `Modifier.weight(1f).semantics(mergeDescendants = true) {}`. This groups the "OpenClaw Assistant" and "Connected" texts into a single, clean announcement for TalkBack.
+3. Wrap `StatusIndicator` itself in a `Box(modifier = Modifier.clearAndSetSemantics {})` to prevent its internal "Connected!" `contentDescription` from redundantly being read alongside the visible "Connected" text in the row.
+4. Run native build/lint checks via Gradle.
+5. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+6. Submit a PR titled `🎨 Polish: Improve connection status accessibility`.


### PR DESCRIPTION
**What:** Groups the connection status UI components in the main system status card into a single semantic element, and suppresses the redundant inner accessibility label on the status dot.

**Why:** Previously, screen readers like TalkBack would focus the dot and announce "Connected!", then separately focus the adjacent label and announce "Connected", resulting in repetitive feedback.

**Before/After:**
- **Before:** TalkBack read "Connected!" (dot), then "OpenClaw Assistant", then "Connected" (text).
- **After:** TalkBack reads "OpenClaw Assistant Connected" as a single, coherent statement without repeating the connection status twice.

**Accessibility:** This change utilizes `Modifier.semantics(mergeDescendants = true)` on the parent `Row` to group the relevant status information, and cleanly isolates the `StatusIndicator` dot from emitting a redundant `contentDescription` inside the newly unified block using `Modifier.clearAndSetSemantics {}`.

---
*PR created automatically by Jules for task [16025610190267406685](https://jules.google.com/task/16025610190267406685) started by @yuga-hashimoto*