### PR TITLE
🔄 Upstream Parity: Android fix Bitmap memory leaks in CanvasController snapshots

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
@@ -236,39 +236,53 @@ class CanvasController {
     withContext(Dispatchers.Main) {
       val wv = webView ?: throw IllegalStateException("no webview")
       val bmp = wv.captureBitmap()
-      val scaled =
-        if (maxWidth != null && maxWidth > 0 && bmp.width > maxWidth) {
-          val h = (bmp.height.toDouble() * (maxWidth.toDouble() / bmp.width.toDouble())).toInt().coerceAtLeast(1)
-          bmp.scale(maxWidth, h)
-        } else {
-          bmp
+      try {
+        val scaled =
+          if (maxWidth != null && maxWidth > 0 && bmp.width > maxWidth) {
+            val h = (bmp.height.toDouble() * (maxWidth.toDouble() / bmp.width.toDouble())).toInt().coerceAtLeast(1)
+            bmp.scale(maxWidth, h)
+          } else {
+            bmp
+          }
+        try {
+          val out = ByteArrayOutputStream()
+          scaled.compress(Bitmap.CompressFormat.PNG, 100, out)
+          Base64.encodeToString(out.toByteArray(), Base64.NO_WRAP)
+        } finally {
+          if (scaled !== bmp) scaled.recycle()
         }
-
-      val out = ByteArrayOutputStream()
-      scaled.compress(Bitmap.CompressFormat.PNG, 100, out)
-      Base64.encodeToString(out.toByteArray(), Base64.NO_WRAP)
+      } finally {
+        bmp.recycle()
+      }
     }
 
   suspend fun snapshotBase64(format: SnapshotFormat, quality: Double?, maxWidth: Int?): String =
     withContext(Dispatchers.Main) {
       val wv = webView ?: throw IllegalStateException("no webview")
       val bmp = wv.captureBitmap()
-      val scaled =
-        if (maxWidth != null && maxWidth > 0 && bmp.width > maxWidth) {
-          val h = (bmp.height.toDouble() * (maxWidth.toDouble() / bmp.width.toDouble())).toInt().coerceAtLeast(1)
-          bmp.scale(maxWidth, h)
-        } else {
-          bmp
+      try {
+        val scaled =
+          if (maxWidth != null && maxWidth > 0 && bmp.width > maxWidth) {
+            val h = (bmp.height.toDouble() * (maxWidth.toDouble() / bmp.width.toDouble())).toInt().coerceAtLeast(1)
+            bmp.scale(maxWidth, h)
+          } else {
+            bmp
+          }
+        try {
+          val out = ByteArrayOutputStream()
+          val (compressFormat, compressQuality) =
+            when (format) {
+              SnapshotFormat.Png -> Bitmap.CompressFormat.PNG to 100
+              SnapshotFormat.Jpeg -> Bitmap.CompressFormat.JPEG to clampJpegQuality(quality)
+            }
+          scaled.compress(compressFormat, compressQuality, out)
+          Base64.encodeToString(out.toByteArray(), Base64.NO_WRAP)
+        } finally {
+          if (scaled !== bmp) scaled.recycle()
         }
-
-      val out = ByteArrayOutputStream()
-      val (compressFormat, compressQuality) =
-        when (format) {
-          SnapshotFormat.Png -> Bitmap.CompressFormat.PNG to 100
-          SnapshotFormat.Jpeg -> Bitmap.CompressFormat.JPEG to clampJpegQuality(quality)
-        }
-      scaled.compress(compressFormat, compressQuality, out)
-      Base64.encodeToString(out.toByteArray(), Base64.NO_WRAP)
+      } finally {
+        bmp.recycle()
+      }
     }
 
   private suspend fun WebView.captureBitmap(): Bitmap =


### PR DESCRIPTION
- **Source**: Upstream commit `2909d8cd12` (`Android: fix Bitmap memory leaks in CanvasController snapshots (#41889)`)
- **Why**: Repeated snapshots of the canvas WebView for image parsing would leak un-recycled memory for each bitmap allocation, eventually leading to `OutOfMemoryError` crashes during sustained usage.
- **Adaptation**: Wrapped both `snapshotPngBase64` and `snapshotBase64` processing flows in nested `try/finally` blocks in `CanvasController.kt`. The outer block guarantees the initially captured bitmap (`bmp`) is recycled, while the inner block guarantees any subsequent scaled version (`scaled`) is recycled if a new instance was generated (`scaled !== bmp`).
- **Excluded upstream behavior**: N/A; all necessary memory management aspects of the fix were cleanly mapped to the existing repository structure.
- **Verification**: Ran `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug` ensuring tests pass and no lint regressions were introduced.

---
*PR created automatically by Jules for task [2224018653723097266](https://jules.google.com/task/2224018653723097266) started by @yuga-hashimoto*