### PR TITLE
🧪 Regression Guard: Fix Wear Session lifecycle regression

### DIFF
--- a/wear/src/main/java/com/openclaw/assistant/wear/service/WearSession.kt
+++ b/wear/src/main/java/com/openclaw/assistant/wear/service/WearSession.kt
@@ -177,12 +177,14 @@ class WearSession(context: Context) : VoiceInteractionSession(context),
     override fun onShow(args: Bundle?, showFlags: Int) {
         super.onShow(args, showFlags)
         lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+        WearSessionForegroundService.start(context)
         startListening()
     }
 
     override fun onHide() {
         super.onHide()
         lifecycleRegistry.currentState = Lifecycle.State.CREATED
+        WearSessionForegroundService.stop(context)
     }
 
     override fun onDestroy() {
@@ -190,6 +192,7 @@ class WearSession(context: Context) : VoiceInteractionSession(context),
         scope.cancel()
         speechRecognizer?.destroy()
         tts?.shutdown()
+        WearSessionForegroundService.stop(context)
         super.onDestroy()
     }
 

--- a/wear/src/main/java/com/openclaw/assistant/wear/service/WearSessionForegroundService.kt
+++ b/wear/src/main/java/com/openclaw/assistant/wear/service/WearSessionForegroundService.kt
@@ -3,7 +3,9 @@ package com.openclaw.assistant.wear.service
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
+import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import com.openclaw.assistant.wear.R
@@ -61,5 +63,22 @@ class WearSessionForegroundService : Service() {
     companion object {
         private const val CHANNEL_ID = "wear_session"
         private const val NOTIFICATION_ID = 1001
+
+        fun start(context: Context) {
+            val intent = Intent(context, WearSessionForegroundService::class.java)
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(intent)
+                } else {
+                    context.startService(intent)
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("WearSessionFGS", "Failed to start WearSessionForegroundService: ${e.message}", e)
+            }
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, WearSessionForegroundService::class.java))
+        }
     }
 }


### PR DESCRIPTION
**What changed?**
Explicitly invokes `WearSessionForegroundService.start(context)` during the Wear OS voice session's `onShow` lifecycle, and `.stop(context)` during its `onHide` and `onDestroy` phases. Also introduces static control helper methods in `WearSessionForegroundService.kt`.

**Why?**
The `WearSessionForegroundService` is intended to prevent the OS from freezing the process mid-conversation while using the Wear Assistant, keeping the microphone warm and processing stable. However, the service was previously declared in the manifest but never actually started in the code. This resolves the regression by explicitly wiring it to the active UI/voice session state.

**Testing**
Verified changes natively via the `wear` module:
- `./gradlew wear:testDebugUnitTest --offline`
- `./gradlew wear:lintDebug --offline`

**Safety**
Wrapped the new service invocation intent in `try/catch` to gracefully prevent `ForegroundServiceStartNotAllowedException` crashes on recent Android versions if the context attempts startup while ineligible.

---
*PR created automatically by Jules for task [16041039096892466964](https://jules.google.com/task/16041039096892466964) started by @yuga-hashimoto*