### PR TITLE
🎨 Polish: Improve missing scope UI feedback

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1275,9 +1275,10 @@ fun MissingScopeCard(error: String, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .semantics(mergeDescendants = true) {
-                onClick(label = onClickLabel, action = null)
+                this.onClick(label = onClickLabel, action = null)
                 role = Role.Button
             },
+        shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer), 
         onClick = { expanded = !expanded }
     ) {


### PR DESCRIPTION
This PR makes a small UX improvement to the `MissingScopeCard` component:

1. Adds a 12dp rounded corner shape to align with the rest of the application's card styles (Material 3).
2. Fixes an issue where the `onClick` lambda parameter shadowed the semantics property receiver. Now the `action_expand` or `action_collapse` label works correctly for screen readers by explicitly scoping `this.onClick()` inside the semantics modifier.

---
*PR created automatically by Jules for task [2728658729841335709](https://jules.google.com/task/2728658729841335709) started by @yuga-hashimoto*