### PR TITLE
⚡ Bolt: Optimize ChatMessage fingerprinting performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 ## 2026-03-26 - Kotlin `ByteArray.joinToString("") { "%02x".format(it) }` Performance Bottleneck
 **Learning:** Formatting byte arrays to hex strings using Kotlin's `joinToString` with `"%02x".format(it)` is extremely slow and memory inefficient because it allocates a new string and lambda invocation for every single byte, creating immense garbage collector pressure during heavy data processing (like image encoding or cryptographic hashing). A benchmark showed `joinToString` taking ~691ms for 1000 iterations vs a manual `CharArray` bit-shift approach taking only ~26ms (a 26x speedup).
 **Action:** When converting large byte arrays to hex strings (e.g., in `ChatImageCodec` for MD5 caching or `DeviceIdentity` for signature generation), replace `joinToString` formatting with a fast manual `CharArray` bitwise approach.
+
+## 2025-03-30 - StringBuilder over joinToString with lambda
+**Learning:** `joinToString` combined with string templates creates intermediate string instances for each loop iteration and has significant overhead compared to direct string building inside hot paths.
+**Action:** Use manual `StringBuilder` approaches combined with standard loops (instead of `.joinToString`) to optimize string concatenation in hot paths.

--- a/app/src/main/java/com/openclaw/assistant/chat/ChatController.kt
+++ b/app/src/main/java/com/openclaw/assistant/chat/ChatController.kt
@@ -589,15 +589,31 @@ internal fun messageIdentityKey(message: ChatMessage): String? {
   if (role.isEmpty()) return null
 
   val timestamp = message.timestampMs?.toString().orEmpty()
-  val contentFingerprint =
-    message.content.joinToString(separator = "\u001E") { part ->
-      val type = part.type.trim().lowercase()
-      val text = part.text?.trim().orEmpty()
-      val mime = part.mimeType?.trim()?.lowercase().orEmpty()
-      val name = part.fileName?.trim().orEmpty()
-      val base64Hash = part.base64?.hashCode()?.toString().orEmpty()
-      "$type\u001F$text\u001F$mime\u001F$name\u001F$base64Hash"
-    }
+
+  // ⚡ Bolt Optimization: Replaced `joinToString(separator = "\u001E") { "$type\u001F$text..." }`
+  // with direct StringBuilder appends. This prevents the allocation of an intermediate
+  // String instance (and its own internal StringBuilder) for every message part during
+  // hot-path UI reconciliation, reducing GC pressure and improving rendering speed for long histories.
+  val contentFingerprint = if (message.content.isEmpty()) {
+      ""
+  } else {
+      val sb = java.lang.StringBuilder()
+      for (i in message.content.indices) {
+          if (i > 0) sb.append("\u001E")
+          val part = message.content[i]
+          val type = part.type.trim().lowercase()
+          val text = part.text?.trim().orEmpty()
+          val mime = part.mimeType?.trim()?.lowercase().orEmpty()
+          val name = part.fileName?.trim().orEmpty()
+          val base64Hash = part.base64?.hashCode()?.toString().orEmpty()
+          sb.append(type).append("\u001F")
+            .append(text).append("\u001F")
+            .append(mime).append("\u001F")
+            .append(name).append("\u001F")
+            .append(base64Hash)
+      }
+      sb.toString()
+  }
 
   if (timestamp.isEmpty() && contentFingerprint.isEmpty()) return null
   return "$role|$timestamp|$contentFingerprint"


### PR DESCRIPTION
💡 **What**: Replaced `message.content.joinToString` with direct `StringBuilder` appends inside `ChatController.messageIdentityKey()`. Added a comment documenting the optimization.

🎯 **Why**: `joinToString` with a lambda that returns an interpolated string creates an intermediate `String` (and its own internal `StringBuilder`) for every element in the collection before appending it to `joinToString`'s internal `StringBuilder`. Since `messageIdentityKey()` is called on every message during chat history reconciliation (`reconcileMessageIds`), eliminating these intermediate string allocations reduces garbage collection pressure on the UI thread, particularly for long chat histories.

📊 **Impact**: Reduces object allocation overhead on the UI thread during chat message reconciliation, improving scrolling and rendering performance for long chat histories.

🔬 **Measurement**: Verify by inspecting heap allocations during fast scrolling in a long chat history, noting fewer short-lived string instances created during `reconcileMessageIds`.

---
*PR created automatically by Jules for task [14243332309555569138](https://jules.google.com/task/14243332309555569138) started by @yuga-hashimoto*