### PR TITLE
🧪 Regression Guard: Fix background service start/stop crashes

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1538,7 +1538,13 @@ fun TroubleshootingDialog(onDismiss: () -> Unit) {
                 BulletPoint(stringResource(titleId), stringResource(descId)) 
             }
             Spacer(modifier = Modifier.height(8.dp)); HorizontalDivider(); Spacer(modifier = Modifier.height(8.dp))
-            Button(onClick = { context.startService(Intent(context, OpenClawAssistantService::class.java).apply { action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT }) }, modifier = Modifier.fillMaxWidth(), colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiary)) { Text(stringResource(R.string.debug_force_start)) }
+            Button(onClick = {
+                try {
+                    context.startService(Intent(context, OpenClawAssistantService::class.java).apply { action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT })
+                } catch (e: Exception) {
+                    android.util.Log.e("MainActivity", "Failed to start OpenClawAssistantService: ${e.message}", e)
+                }
+            }, modifier = Modifier.fillMaxWidth(), colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiary)) { Text(stringResource(R.string.debug_force_start)) }
         }
     }, confirmButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.got_it)) } })
 }

--- a/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
+++ b/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
@@ -44,7 +44,11 @@ class MediaButtonReceiver : BroadcastReceiver() {
                 val serviceIntent = Intent(context, OpenClawAssistantService::class.java).apply {
                     action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT
                 }
-                context.startService(serviceIntent)
+                try {
+                    context.startService(serviceIntent)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to start OpenClawAssistantService: ${e.message}", e)
+                }
                 // Absorb the event so it doesn't reach the media player
                 abortBroadcast()
             }

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -58,7 +58,11 @@ class HotwordService : Service(), VoskRecognitionListener {
         }
 
         fun stop(context: Context) {
-            context.stopService(Intent(context, HotwordService::class.java))
+            try {
+                context.stopService(Intent(context, HotwordService::class.java))
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to stop HotwordService: ${e.message}", e)
+            }
         }
 
         fun shouldCopyModel(currentVersion: Int, savedVersion: Int, targetDirExists: Boolean, targetDirNotEmpty: Boolean): Boolean {

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -281,7 +281,11 @@ class NodeForegroundService : Service() {
 
     fun stop(context: Context) {
       val intent = Intent(context, NodeForegroundService::class.java).setAction(ACTION_STOP)
-      context.startService(intent)
+      try {
+        context.startService(intent)
+      } catch (e: Exception) {
+        android.util.Log.e(TAG, "Failed to stop NodeForegroundService: ${e.message}", e)
+      }
     }
 
     /**

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -44,7 +44,11 @@ class SessionForegroundService : Service() {
         }
 
         fun stop(context: Context) {
-            context.stopService(Intent(context, SessionForegroundService::class.java))
+            try {
+                context.stopService(Intent(context, SessionForegroundService::class.java))
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to stop SessionForegroundService: ${e.message}", e)
+            }
         }
     }
 


### PR DESCRIPTION
Fixes crash prevention and stability around background service lifecycle events.

**What was done:**
Wrapped `context.startService` and `context.stopService` invocations across multiple critical app components (`MediaButtonReceiver`, `MainActivity`, `NodeForegroundService`, `HotwordService`, and `SessionForegroundService`) with broad `try-catch` blocks catching generic `Exception`.

**Why:**
Android 8.0 (API 26) introduced strict limits on starting background services. Attempting to start a service when the application is not in the foreground throws an `IllegalStateException`. Android 12 further restricted this. Components like `MediaButtonReceiver` execute in the background and trigger service starts, making them highly susceptible to these crashes. Failing to handle these exceptions leads to a hard crash of the application. 

By catching these errors gracefully, we ensure stability and prevent abrupt process terminations, prioritizing reliability over executing the task immediately when the OS denies background execution rights.

---
*PR created automatically by Jules for task [5077319925557313430](https://jules.google.com/task/5077319925557313430) started by @yuga-hashimoto*