### PR TITLE
🎨 Palette: Improve accessibility of typing and tool indicator bubbles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@
 ## 2025-03-27 - Expand/Collapse Accessibility Pattern for MissingScopeCard
 **Learning:** Using `Card(onClick=)` without an `onClickLabel` leads to generic, unhelpful screen reader announcements. Expandable cards require explicit labels that change based on state (e.g. Expand / Collapse).
 **Action:** When converting `Card(onClick=)` to use `Modifier.clickable()`, use `onClickLabel = stringResource(if (expanded) R.string.action_collapse else R.string.action_expand)` and assign `role = Role.Button` so the action changes dynamically for screen readers.
+
+## 2025-03-30 - Add mergeDescendants semantics to Chat Bubbles
+**Learning:** In Jetpack Compose, container rows with loading animations and text labels (like typing indicators and tool running bubbles) are read as separate, disjointed elements by TalkBack.
+**Action:** Always add `Modifier.semantics(mergeDescendants = true)` to parent containers of loading indicators and their descriptive text to group them into a single, cohesive accessibility announcement.

--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatMessageViews.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatMessageViews.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.StartOffset
 import androidx.compose.animation.core.animateFloat
@@ -106,7 +107,7 @@ fun ChatTypingIndicatorBubble() {
       color = MaterialTheme.colorScheme.surfaceContainer,
     ) {
       Row(
-        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp).semantics(mergeDescendants = true) {},
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
       ) {
@@ -133,6 +134,7 @@ fun ChatPendingToolsBubble(toolCalls: List<ChatPendingToolCall>) {
         Row(
           verticalAlignment = Alignment.CenterVertically,
           horizontalArrangement = Arrangement.spacedBy(8.dp),
+          modifier = Modifier.semantics(mergeDescendants = true) {}
         ) {
           DotPulse()
           Text(stringResource(R.string.running_tools), style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onSurface)


### PR DESCRIPTION
💡 **What:** Added `Modifier.semantics(mergeDescendants = true)` to the `Row` containers of `ChatTypingIndicatorBubble` ("Thinking...") and `ChatPendingToolsBubble` ("Running tools") in `ChatMessageViews.kt`.
🎯 **Why:** To group the animated pulsing dots and the text label into a single semantic node.
📸 **Before/After:** No visual change.
♿ **Accessibility:** Prevents screen readers (like TalkBack) from awkwardly splitting focus between the visual indicator and the text, providing a cleaner, single auditory announcement when the AI is processing or running tools.

---
*PR created automatically by Jules for task [2904883511008844137](https://jules.google.com/task/2904883511008844137) started by @yuga-hashimoto*