### PR TITLE
fix: prevent onShutdown crash and MarkdownText ANR (from Crashlytics)

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
@@ -120,6 +120,10 @@ class OpenClawAssistantService : VoiceInteractionService() {
         isServiceReady = false
         pendingShowSession = false
         handler.removeCallbacks(pendingSessionTimeoutRunnable)
-        unregisterReceiver(debugReceiver)
+        try {
+            unregisterReceiver(debugReceiver)
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "debugReceiver was not registered at shutdown", e)
+        }
     }
 }

--- a/app/src/main/java/com/openclaw/assistant/ui/components/MarkdownText.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/MarkdownText.kt
@@ -11,14 +11,20 @@ import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
 
+private const val MAX_MARKDOWN_LENGTH = 20_000
+
 @Composable
 fun MarkdownText(
     markdown: String,
     modifier: Modifier = Modifier,
     color: Color = MaterialTheme.colorScheme.onSurface
 ) {
+    val content = remember(markdown) {
+        if (markdown.length > MAX_MARKDOWN_LENGTH) markdown.take(MAX_MARKDOWN_LENGTH) + "\n\n[...]"
+        else markdown
+    }
     Markdown(
-        content = markdown,
+        content = content,
         modifier = modifier,
         colors = markdownColor(
             text = color,


### PR DESCRIPTION
## Summary / 概要

Fixes two issues detected via Firebase Crashlytics:

| Issue | Type | Users | Crashlytics ID |
|-------|------|-------|---------------|
| `OpenClawAssistantService.onShutdown` — `IllegalArgumentException: Receiver not registered` | FATAL | 4 | d73d9f7a |
| `MarkdownText` — ANR (main thread blocked by markdown parser) | ANR | 1 | 25d390c5 |

---

Crashlyticsで検出された2件の不具合を修正します:

| 問題 | 種別 | ユーザー数 | Crashlytics ID |
|------|------|-----------|---------------|
| `OpenClawAssistantService.onShutdown` — `IllegalArgumentException: Receiver not registered` | FATAL クラッシュ | 4 | d73d9f7a |
| `MarkdownText` — ANR (マークダウンパーサーがメインスレッドをブロック) | ANR | 1 | 25d390c5 |

## Changes / 変更内容

### 1. `OpenClawAssistantService.kt` — Receiver not registered crash

**Root cause / 原因:** `onShutdown()` calls `unregisterReceiver(debugReceiver)` unconditionally. If `onCreate()` was skipped or the receiver was never registered (e.g. system-managed service lifecycle edge case), this throws `IllegalArgumentException` and crashes the app.

**Fix / 修正:** Wrap in `try-catch(IllegalArgumentException)` and log a warning instead.

### 2. `MarkdownText.kt` — ANR on long content

**Root cause / 原因:** `mikepenz/multiplatform-markdown-renderer` parses markdown synchronously on the main thread during Compose recomposition. For very long AI responses (e.g. code dumps), the `ReferenceLinkParser` can loop in near-quadratic time, blocking the main thread >5 seconds → ANR.

**Fix / 修正:** Cap content at `MAX_MARKDOWN_LENGTH = 20,000` characters using `remember {}` before passing to the parser. Content beyond the limit is truncated with `[...]`. This prevents the parser from running on pathologically long inputs.

## Test plan / テスト計画

- [ ] Verify app starts/stops without crash in normal use
- [ ] Verify assistant service shuts down cleanly (no crash in logcat)
- [ ] Simulate `onShutdown` without `onCreate` (e.g. force-stop) — confirm no crash
- [ ] Open a chat session with a very long AI response (>20,000 chars) — confirm no ANR
- [ ] Confirm short markdown renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)