### PR TITLE
fix: resolve ANR in chat and receiver-not-registered crash

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -58,7 +58,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.openclaw.assistant.speech.TTSUtils
-import com.openclaw.assistant.ui.components.MarkdownText
+import com.openclaw.assistant.ui.chat.ChatMarkdown
 import androidx.compose.foundation.Image
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
@@ -597,9 +597,9 @@ fun MessageBubble(message: ChatMessage) {
                             lineHeight = 24.sp
                         )
                     } else {
-                        MarkdownText(
-                            markdown = message.text,
-                            color = contentColor
+                        ChatMarkdown(
+                            text = message.text,
+                            textColor = contentColor
                         )
                     }
                     if (message.attachments.isNotEmpty()) {

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
@@ -120,6 +120,6 @@ class OpenClawAssistantService : VoiceInteractionService() {
         isServiceReady = false
         pendingShowSession = false
         handler.removeCallbacks(pendingSessionTimeoutRunnable)
-        unregisterReceiver(debugReceiver)
+        try { unregisterReceiver(debugReceiver) } catch (_: Exception) {}
     }
 }


### PR DESCRIPTION
## Summary / 概要

Firebase Crashlytics のログを調査した結果、現行バージョン (v2.4.7) で発生している 2 件の問題を修正します。

| Issue | Type | Users | Version |
|---|---|---|---|
| ANR in `MarkdownText` — main thread blocked by IntelliJ Markdown parser | ANR | 1 (SIGNAL_FRESH) | v2.4.7 |
| `Receiver not registered` crash in `OpenClawAssistantService.onShutdown` | FATAL | 4 | up to v2.4.4 |

---

## Changes / 変更内容

### 1. ChatActivity: Replace `MarkdownText` → `ChatMarkdown` for AI messages

**Root cause / 原因:**
`MarkdownText` は `mikepenz/multiplatform-markdown-renderer` を使用しており、内部で `MarkdownParser.buildMarkdownTreeFromString()` を Compose のコンポジション中にメインスレッドで同期実行します。AI の長い返答には `[...]` パターンが多く含まれるため、`ReferenceLinkParser` がトークンを大量に走査して ANR を引き起こしていました。

**Fix / 修正:**
Chat 画面の AI メッセージレンダリングを、同プロジェクト内に既存の `ChatMarkdown`（軽量な手書きレンダラー）に置き換えます。`ChatMarkdown` はボールド・イタリック・インラインコード・コードブロック・Base64 画像を扱い、メインスレッドをブロックしません。

### 2. OpenClawAssistantService: Guard `unregisterReceiver` in `onShutdown`

**Root cause / 原因:**
`onShutdown()` が `onCreate()` より前に呼ばれるケース（一部 Android 15 端末のプロセス再利用など）で `debugReceiver` が未登録のまま `unregisterReceiver` が呼ばれ FATAL クラッシュしていました。

**Fix / 修正:**
`unregisterReceiver(debugReceiver)` を `try/catch` で保護します（同プロジェクト内の `HotwordService.onDestroy` と同じパターン）。

---

## Crashlytics Issues Addressed / 対応した Crashlytics Issue

- `25d390c` — ANR `MarkdownText-FNF3uiM` (v2.4.7, SIGNAL_FRESH, 2 events)
- `d73d9f7` — FATAL `OpenClawAssistantService.onShutdown` Receiver not registered (v1.4.2–v2.4.4, 4 users)

---

## Test Plan / テスト計画

- [ ] Chat 画面で長い AI 返答（コードブロック・箇条書き・リンクを含む）を表示して ANR が出ないことを確認
- [ ] Bold / Italic / inline code が正しくレンダリングされることを確認
- [ ] アシスタントサービスを複数回起動/終了しても `onShutdown` でクラッシュしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)