### PR TITLE
🎨 Palette: Improve accessibility of StatusIndicator

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
@@ -70,7 +70,11 @@ fun StatusIndicator(
     )
 
     Row(
-        modifier = modifier,
+        modifier = modifier.semantics(mergeDescendants = true) {
+            if (label == null) {
+                contentDescription = stateDesc
+            }
+        },
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp)
     ) {
@@ -79,15 +83,7 @@ fun StatusIndicator(
                 .size(dotSize)
                 .alpha(alpha)
                 .background(dotColor, CircleShape)
-                .then(
-                    if (label == null) {
-                        Modifier.semantics {
-                            contentDescription = stateDesc
-                        }
-                    } else {
-                        Modifier
-                    }
-                )
+
         )
         if (label != null) {
             Text(


### PR DESCRIPTION
💡 What: Applied `Modifier.semantics(mergeDescendants = true)` to the `StatusIndicator`'s parent `Row`.
🎯 Why: Screen readers (like TalkBack) previously read the color dot and the text label as separate elements, which creates a fragmented experience. By merging them, the status is announced as a single cohesive update.
♿ Accessibility: Groups the semantic nodes of the color dot and text label together to prevent redundant or split reading by TalkBack.

---
*PR created automatically by Jules for task [17529573523776375188](https://jules.google.com/task/17529573523776375188) started by @yuga-hashimoto*