### PR TITLE
🔄 Upstream Parity: Align SMS permission UI state

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -116,7 +116,7 @@ class MainActivity : ComponentActivity(), TextToSpeech.OnInitListener {
         val cameraGranted = permissions[Manifest.permission.CAMERA] ?: false
         val coarseGranted = permissions[Manifest.permission.ACCESS_COARSE_LOCATION] ?: false
         val fineGranted = permissions[Manifest.permission.ACCESS_FINE_LOCATION] ?: false
-        val smsGranted = permissions[Manifest.permission.SEND_SMS] ?: false
+        val smsGranted = (permissions[Manifest.permission.SEND_SMS] ?: false) || (permissions[Manifest.permission.READ_SMS] ?: false)
 
         // Auto-enable capabilities when permission is newly granted
         val runtime = (applicationContext as OpenClawApplication).nodeRuntime
@@ -800,11 +800,13 @@ fun MainScreen(
                             } else {
                                 val granted = ContextCompat.checkSelfPermission(
                                     context, Manifest.permission.SEND_SMS
+                                ) == PackageManager.PERMISSION_GRANTED || ContextCompat.checkSelfPermission(
+                                    context, Manifest.permission.READ_SMS
                                 ) == PackageManager.PERMISSION_GRANTED
                                 if (granted) {
                                     runtime.setSmsEnabled(true)
                                 } else {
-                                    onRequestPermissions(listOf(Manifest.permission.SEND_SMS))
+                                    onRequestPermissions(listOf(Manifest.permission.SEND_SMS, Manifest.permission.READ_SMS))
                                 }
                             }
                         },

--- a/app/src/main/java/com/openclaw/assistant/PermissionRequester.kt
+++ b/app/src/main/java/com/openclaw/assistant/PermissionRequester.kt
@@ -147,6 +147,7 @@ class PermissionRequester(private val activity: ComponentActivity) {
       Manifest.permission.CAMERA -> "Camera"
       Manifest.permission.RECORD_AUDIO -> "Microphone"
       Manifest.permission.SEND_SMS -> "SMS"
+      Manifest.permission.READ_SMS -> "SMS (read)"
       Manifest.permission.READ_CONTACTS -> "Contacts (read)"
       Manifest.permission.WRITE_CONTACTS -> "Contacts (write)"
       Manifest.permission.READ_CALENDAR -> "Calendar (read)"

--- a/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
@@ -150,7 +150,7 @@ private enum class PermissionToggle(
         R.string.capability_sms,
         R.string.permission_send_sms_desc,
         Icons.Default.Sms,
-        listOf(Manifest.permission.SEND_SMS)
+        listOf(Manifest.permission.SEND_SMS, Manifest.permission.READ_SMS)
     )
 }
 


### PR DESCRIPTION
- Source: openclaw/openclaw commit `88716f02de1e2b661fd654220d9e8a73da1ed72f`
- Why: Allowing UI configuration and toggling of the SMS capability even if only `READ_SMS` is granted is necessary. Currently, only `SEND_SMS` activates the capability toggle UI state, but users who wish only to read text messages shouldn't be blocked.
- Adaptation: Adapted the capability toggle UI checks in `MainActivity.kt` and `SetupGuideScreen.kt` to allow SMS capability to be active if *either* `SEND_SMS` or `READ_SMS` is active. Additionally modified `PermissionRequester.kt` to provide clarity when specifically requesting the read permission.
- Excluded upstream behavior: Upstream modified `SettingsSheet.kt` directly, but in this repository's layout architecture, the equivalent capability logic lives in `MainActivity.kt` and `SetupGuideScreen.kt`. I mapped the exact logical changes accordingly.
- Verification: Compiled and validated natively with `./gradlew app:lintStandardDebug` and `./gradlew app:testStandardDebugUnitTest`.

---
*PR created automatically by Jules for task [5510729103247054175](https://jules.google.com/task/5510729103247054175) started by @yuga-hashimoto*