### PR TITLE
fix: resolve Crashlytics ANR and Receiver-not-registered crashes

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -58,7 +58,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.openclaw.assistant.speech.TTSUtils
-import com.openclaw.assistant.ui.components.MarkdownText
+import com.openclaw.assistant.ui.chat.ChatMarkdown
 import androidx.compose.foundation.Image
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
@@ -597,9 +597,9 @@ fun MessageBubble(message: ChatMessage) {
                             lineHeight = 24.sp
                         )
                     } else {
-                        MarkdownText(
-                            markdown = message.text,
-                            color = contentColor
+                        ChatMarkdown(
+                            text = message.text,
+                            textColor = contentColor
                         )
                     }
                     if (message.attachments.isNotEmpty()) {

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
@@ -120,6 +120,10 @@ class OpenClawAssistantService : VoiceInteractionService() {
         isServiceReady = false
         pendingShowSession = false
         handler.removeCallbacks(pendingSessionTimeoutRunnable)
-        unregisterReceiver(debugReceiver)
+        try {
+            unregisterReceiver(debugReceiver)
+        } catch (e: Exception) {
+            Log.w(TAG, "debugReceiver already unregistered", e)
+        }
     }
 }


### PR DESCRIPTION
## Summary / 概要

Firebase Crashlytics の過去7日間のログ(2026-03-25〜2026-04-01)を分析し、修正可能な2件のバグを修正します。

| Issue ID | Type | Affected Users | Versions | Fix |
|---|---|---|---|---|
| `d73d9f7a` | FATAL | 4 users | 1.4.2–2.4.4 | `unregisterReceiver` を try-catch で保護 |
| `25d390c5` | ANR | 2 users (FRESH) | 2.4.7 | `MarkdownText` → `ChatMarkdown` に置き換え |

---

### Fix 1: `OpenClawAssistantService.onShutdown` — Receiver not registered

**EN:** `onShutdown()` called `unregisterReceiver(debugReceiver)` unconditionally. If `onCreate()` was never reached (e.g. service killed before initialization) or if `onShutdown` fires more than once, the receiver is not registered and Android throws `IllegalArgumentException`, crashing the app. Wrapped in try-catch.

**JA:** `onShutdown()` で `unregisterReceiver(debugReceiver)` を無条件に呼び出していた。`onCreate()` が完了する前にシャットダウンされた場合などレシーバー未登録状態でクラッシュしていた。try-catch で保護。

### Fix 2: `ChatActivity` ANR — synchronous Markdown parsing on main thread

**EN:** The AI message bubbles in `ChatActivity` used `MarkdownText` which wraps the `mikepenz` Markdown library. That library calls `MarkdownParser.buildMarkdownTreeFromString()` synchronously on the main thread, which ANRed on a Redmi Note 9 Pro with a long AI response. Replaced with the project's own `ChatMarkdown` composable, which uses `remember(text)` to cache parsed blocks and avoids any heavy library traversal. `ChatMessageViews.kt` already uses `ChatMarkdown` for the same purpose.

**JA:** `ChatActivity` のAI返答バブルに `MarkdownText`（mikepenzライブラリのラッパー）を使用していた。このライブラリはメインスレッドでMarkdown構文解析を同期実行するため、長い返答でANRが発生していた。プロジェクト独自の `ChatMarkdown`（`remember(text)` でキャッシュ済み）に置き換えた。`ChatMessageViews.kt` では既に同じ理由で `ChatMarkdown` を使用している。

## Test plan / テスト計画

- [ ] Send a long AI response in ChatActivity — no ANR (Redmi Note 9 Pro or similar low-end device)
- [ ] Markdown formatting (bold, italic, inline code, code blocks) renders correctly in chat bubbles
- [ ] Trigger assistant session and interrupt/dismiss rapidly — no crash on `onShutdown`
- [ ] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)