### PR TITLE
🔄 Upstream Parity: Harden permission dialogs across activity teardown

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/PermissionRequester.kt
+++ b/app/src/main/java/com/openclaw/assistant/PermissionRequester.kt
@@ -4,6 +4,8 @@ import android.content.pm.PackageManager
 import android.content.Intent
 import android.Manifest
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.provider.Settings
 import androidx.appcompat.app.AlertDialog
 import androidx.activity.ComponentActivity
@@ -11,17 +13,21 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.app.ActivityCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.resume
 
 class PermissionRequester(private val activity: ComponentActivity) {
   private val mutex = Mutex()
   private var pending: CompletableDeferred<Map<String, Boolean>>? = null
+  private val mainHandler = Handler(Looper.getMainLooper())
 
   private val launcher: ActivityResultLauncher<Array<String>> =
     activity.registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
@@ -86,14 +92,46 @@ class PermissionRequester(private val activity: ComponentActivity) {
 
   private suspend fun showRationaleDialog(permissions: List<String>): Boolean =
     withContext(Dispatchers.Main) {
+      if (activity.isFinishing || activity.isDestroyed) {
+        return@withContext false
+      }
       suspendCancellableCoroutine { cont ->
-        AlertDialog.Builder(activity)
-          .setTitle("Permission required")
-          .setMessage(buildRationaleMessage(permissions))
-          .setPositiveButton("Continue") { _, _ -> cont.resume(true) }
-          .setNegativeButton("Not now") { _, _ -> cont.resume(false) }
-          .setOnCancelListener { cont.resume(false) }
-          .show()
+        val lifecycle = activity.lifecycle
+        var dialog: AlertDialog? = null
+        var observer: LifecycleEventObserver? = null
+        val finished = AtomicBoolean(false)
+        val removeObserver = {
+          observer?.let(lifecycle::removeObserver)
+          observer = null
+        }
+        fun finish(result: Boolean?) {
+          if (!finished.compareAndSet(false, true)) return
+          removeObserver()
+          dialog?.dismiss()
+          if (result != null) {
+            cont.resume(result)
+          }
+        }
+        val actualObserver =
+          LifecycleEventObserver { _, event ->
+            if (event != Lifecycle.Event.ON_DESTROY) return@LifecycleEventObserver
+            finish(false)
+          }
+        observer = actualObserver
+        lifecycle.addObserver(actualObserver)
+        cont.invokeOnCancellation {
+          mainHandler.post {
+            finish(null)
+          }
+        }
+        dialog =
+          AlertDialog.Builder(activity)
+            .setTitle("Permission required")
+            .setMessage(buildRationaleMessage(permissions))
+            .setPositiveButton("Continue") { _, _ -> finish(true) }
+            .setNegativeButton("Not now") { _, _ -> finish(false) }
+            .setOnCancelListener { finish(false) }
+            .show()
       }
     }
 
@@ -116,21 +154,41 @@ class PermissionRequester(private val activity: ComponentActivity) {
       }
     }
 
-  private fun showSettingsDialog(permissions: List<String>) {
-    AlertDialog.Builder(activity)
-      .setTitle("Enable permission in Settings")
-      .setMessage(buildSettingsMessage(permissions))
-      .setPositiveButton("Open Settings") { _, _ ->
-        val intent =
-          Intent(
-            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-            Uri.fromParts("package", activity.packageName, null),
-          )
-        activity.startActivity(intent)
+  private suspend fun showSettingsDialog(permissions: List<String>) =
+    withContext(Dispatchers.Main) {
+      if (activity.isFinishing || activity.isDestroyed) return@withContext
+      val lifecycle = activity.lifecycle
+      var dialog: AlertDialog? = null
+      var observer: LifecycleEventObserver? = null
+      val removeObserver = {
+        observer?.let(lifecycle::removeObserver)
+        observer = null
       }
-      .setNegativeButton("Cancel", null)
-      .show()
-  }
+      val actualObserver =
+        LifecycleEventObserver { _, event ->
+          if (event != Lifecycle.Event.ON_DESTROY) return@LifecycleEventObserver
+          removeObserver()
+          dialog?.dismiss()
+        }
+      observer = actualObserver
+      lifecycle.addObserver(actualObserver)
+      dialog =
+        AlertDialog.Builder(activity)
+          .setTitle("Enable permission in Settings")
+          .setMessage(buildSettingsMessage(permissions))
+          .setPositiveButton("Open Settings") { _, _ ->
+            if (activity.isFinishing || activity.isDestroyed) return@setPositiveButton
+            val intent =
+              Intent(
+                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                Uri.fromParts("package", activity.packageName, null),
+              )
+            activity.startActivity(intent)
+          }
+          .setNegativeButton("Cancel", null)
+          .setOnDismissListener { removeObserver() }
+          .show()
+    }
 
   private fun buildRationaleMessage(permissions: List<String>): String {
     val labels = permissions.map { permissionLabel(it) }


### PR DESCRIPTION
- Source: Ported from `openclaw/openclaw` android app
  - `b67baae1f61d2b45ee6dcf785c1090518fcb8ead` fix: make permission rationale completion single-shot
  - `6db72746fb5411a3fce62c49bd2a56eb065bc573` Android: keep permission dialog cleanup on the main thread
  - `518d2dd6a9920db3d5492aabab4b55a963efe604` Android: harden permission dialogs across activity teardown
- Why: Showing `AlertDialog`s via `suspendCancellableCoroutine` while an `Activity` is finishing or destroyed causes `WindowLeaked`, `BadTokenException`, or `IllegalStateException`. This makes the permission dialogs cancellation/lifecycle-safe.
- Adaptation: Applied equivalent `AtomicBoolean` + `LifecycleEventObserver` patterns to `PermissionRequester` dialogs.
- Excluded upstream behavior: N/A
- Verification: Compiled and passed unit tests via `./gradlew`.

---
*PR created automatically by Jules for task [15317735646863939160](https://jules.google.com/task/15317735646863939160) started by @yuga-hashimoto*