### PR TITLE
🎨 Palette: Merge semantics for StatusIndicator

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@
 ## 2025-03-27 - Expand/Collapse Accessibility Pattern for MissingScopeCard
 **Learning:** Using `Card(onClick=)` without an `onClickLabel` leads to generic, unhelpful screen reader announcements. Expandable cards require explicit labels that change based on state (e.g. Expand / Collapse).
 **Action:** When converting `Card(onClick=)` to use `Modifier.clickable()`, use `onClickLabel = stringResource(if (expanded) R.string.action_collapse else R.string.action_expand)` and assign `role = Role.Button` so the action changes dynamically for screen readers.
+
+## 2025-04-01 - Semantics Grouping in Status Indicator
+**Learning:** In Compose, an animated `Box` acting as a "dot" next to a `Text` label creates disjointed screen reader announcements if the `Row` wrapper doesn't use `Modifier.semantics(mergeDescendants = true)`. Without merging, users navigating by swipe hear the dot's state separate from the adjacent text label. Adding `mergeDescendants = true` ensures the entire status block is read cohesively as a single node.
+**Action:** Always group visual indicators (like dots, spinners, or icons) and their corresponding text descriptions in a `Row` or `Column` using `Modifier.semantics(mergeDescendants = true) {}`.

--- a/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
@@ -70,7 +70,7 @@ fun StatusIndicator(
     )
 
     Row(
-        modifier = modifier,
+        modifier = modifier.semantics(mergeDescendants = true) {},
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp)
     ) {


### PR DESCRIPTION
💡 What: Added `Modifier.semantics(mergeDescendants = true) {}` to the `Row` wrapper in `StatusIndicator`.
🎯 Why: Without merging, screen readers reading by swipe announce the visual dot's accessibility description ("Connected") and the accompanying `Text` separately, creating disjointed feedback.
♿ Accessibility: Ensures that users navigating with screen readers like TalkBack hear the full cohesive state of the connection status block at once.

---
*PR created automatically by Jules for task [7322844923087286030](https://jules.google.com/task/7322844923087286030) started by @yuga-hashimoto*