### PR TITLE
fix: guard against Receiver-not-registered and ActivityNotFoundException crashes

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
@@ -120,6 +120,10 @@ class OpenClawAssistantService : VoiceInteractionService() {
         isServiceReady = false
         pendingShowSession = false
         handler.removeCallbacks(pendingSessionTimeoutRunnable)
-        unregisterReceiver(debugReceiver)
+        try {
+            unregisterReceiver(debugReceiver)
+        } catch (_: IllegalArgumentException) {
+            // Receiver was never registered or already unregistered
+        }
     }
 }

--- a/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
@@ -858,8 +858,12 @@ private fun PermissionsStep(onNext: () -> Unit) {
                 onClick = {
                     when (toggle) {
                         SpecialAccessToggle.NotificationListener -> {
-                            val intent = Intent("android.settings.ACTION_NOTIFICATION_LISTENER_SETTINGS")
-                            context.startActivity(intent)
+                            try {
+                                val intent = Intent("android.settings.ACTION_NOTIFICATION_LISTENER_SETTINGS")
+                                context.startActivity(intent)
+                            } catch (_: android.content.ActivityNotFoundException) {
+                                // Some devices (e.g. TV, custom Android) don't have this settings screen
+                            }
                         }
                         SpecialAccessToggle.AppUpdates -> {
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
## Summary / 概要

Fixes two FATAL crashes identified in Crashlytics for the past 7 days.

Crashlytics経由で検出された直近7日間のFATALクラッシュ2件を修正します。

| Issue ID | Error | Events | Impacted Users |
|---|---|---|---|
| d73d9f7a | `Receiver not registered` in `OpenClawAssistantService.onShutdown` | 4 | 4 |
| ae6ebef8 | `ActivityNotFoundException` for `ACTION_NOTIFICATION_LISTENER_SETTINGS` in `SetupGuideScreen` | 1 (FRESH) | 1 |

## Changes / 変更内容

### `OpenClawAssistantService.kt`
`onShutdown()` was calling `unregisterReceiver(debugReceiver)` unconditionally. If `onShutdown` fires before `onCreate` completes (or is called a second time), this throws `IllegalArgumentException: Receiver not registered`.

The fix wraps the call in `try/catch(IllegalArgumentException)`, consistent with how `OpenClawSession.onDestroy` already handles `interruptReceiver`.

`onShutdown()`が`unregisterReceiver(debugReceiver)`を無条件に呼び出していました。`onCreate`完了前に`onShutdown`が呼ばれる、または2回呼ばれた場合に`IllegalArgumentException: Receiver not registered`がスローされます。`try/catch(IllegalArgumentException)`で囲むことで修正します（`OpenClawSession.onDestroy`での`interruptReceiver`の処理と統一）。

### `SetupGuideScreen.kt`
`startActivity(Intent("android.settings.ACTION_NOTIFICATION_LISTENER_SETTINGS"))` crashes on devices that don't have this settings screen (confirmed on a Skyworth Android TV: `SWTV-25CN-P`).

The fix wraps the call in `try/catch(ActivityNotFoundException)`.

一部のデバイス（Android TVなど）では`ACTION_NOTIFICATION_LISTENER_SETTINGS`の設定画面が存在しないため、`ActivityNotFoundException`でクラッシュします（Skyworth SWTV-25CN-Pで確認）。`try/catch(ActivityNotFoundException)`で囲むことで修正します。

## Test Plan / テスト計画

- [ ] Build succeeds
- [ ] Install on a standard Android phone and verify notification listener settings button navigates correctly
- [ ] Verify no regression in `OpenClawAssistantService` voice interaction flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)