### PR TITLE
🧪 Regression Guard: Fix background startService crashes

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1538,7 +1538,13 @@ fun TroubleshootingDialog(onDismiss: () -> Unit) {
                 BulletPoint(stringResource(titleId), stringResource(descId)) 
             }
             Spacer(modifier = Modifier.height(8.dp)); HorizontalDivider(); Spacer(modifier = Modifier.height(8.dp))
-            Button(onClick = { context.startService(Intent(context, OpenClawAssistantService::class.java).apply { action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT }) }, modifier = Modifier.fillMaxWidth(), colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiary)) { Text(stringResource(R.string.debug_force_start)) }
+            Button(onClick = {
+                try {
+                    context.startService(Intent(context, OpenClawAssistantService::class.java).apply { action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT })
+                } catch (e: Exception) {
+                    android.util.Log.e("MainActivity", "Failed to force start assistant", e)
+                }
+            }, modifier = Modifier.fillMaxWidth(), colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiary)) { Text(stringResource(R.string.debug_force_start)) }
         }
     }, confirmButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.got_it)) } })
 }

--- a/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
+++ b/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
@@ -44,7 +44,11 @@ class MediaButtonReceiver : BroadcastReceiver() {
                 val serviceIntent = Intent(context, OpenClawAssistantService::class.java).apply {
                     action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT
                 }
-                context.startService(serviceIntent)
+                try {
+                    context.startService(serviceIntent)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to start OpenClawAssistantService via media button: ${e.message}", e)
+                }
                 // Absorb the event so it doesn't reach the media player
                 abortBroadcast()
             }

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -647,7 +647,11 @@ class HotwordService : Service(), VoskRecognitionListener {
             val intent = Intent(this@HotwordService, OpenClawAssistantService::class.java).apply {
                 action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT
             }
-            startService(intent)
+            try {
+                startService(intent)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start OpenClawAssistantService: ${e.message}", e)
+            }
             Log.e(TAG, "startService ACTION_SHOW_ASSISTANT called")
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -281,7 +281,11 @@ class NodeForegroundService : Service() {
 
     fun stop(context: Context) {
       val intent = Intent(context, NodeForegroundService::class.java).setAction(ACTION_STOP)
-      context.startService(intent)
+      try {
+        context.startService(intent)
+      } catch (e: Exception) {
+        android.util.Log.e(TAG, "Failed to stop NodeForegroundService: ${e.message}", e)
+      }
     }
 
     /**


### PR DESCRIPTION
Wrapped multiple `context.startService` calls with `try-catch` blocks to catch `Exception`.

### Why
Android 8.0 (API level 26) imposes strict limits on running background services. If an app attempts to start a background service (`startService()`) while not in the foreground, the system throws an `IllegalStateException`.
On Android 12 (API level 31) and higher, similar limits apply to foreground services (`startForegroundService()`), throwing a `ForegroundServiceStartNotAllowedException` if called from the background without a valid exemption.

Wrapping these background triggers (like the media button listener, hotword background restarts, and the manual start button) prevents the app from hard-crashing when the OS rejects the service launch.

### Areas Modified
- `MediaButtonReceiver.kt`
- `HotwordService.kt`
- `NodeForegroundService.kt`
- `MainActivity.kt` (Debug force start button)

---
*PR created automatically by Jules for task [9557702401335276301](https://jules.google.com/task/9557702401335276301) started by @yuga-hashimoto*