### PR TITLE
🛡️ Sentinel: Remove global cleartext traffic allowance from Manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,7 +89,6 @@
         android:name="com.openclaw.assistant.OpenClawApplication"
         android:allowBackup="false"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
**What:**
Removed the `android:usesCleartextTraffic="true"` directive from the app module's `AndroidManifest.xml`.

**Why:**
Globally permitting cleartext (HTTP) traffic across all application components and libraries increases the risk of inadvertent data leaks over unencrypted channels. The application already defines a precise `@xml/network_security_config` and relies on `NetworkUtils.isUrlSecure` to evaluate runtime endpoints (allowing HTTP for private IP ranges / localhost but mandating HTTPS for public IPs). Therefore, a global cleartext override is unnecessary and introduces a broad security risk.

**Verification:**
Ran `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug` successfully to verify no regressions were introduced.

---
*PR created automatically by Jules for task [7019821615871864339](https://jules.google.com/task/7019821615871864339) started by @yuga-hashimoto*