### PR TITLE
🛡️ Sentinel: Restrict cleartext traffic to local networks

### DIFF
--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,7 +89,7 @@
         android:name="com.openclaw.assistant.OpenClawApplication"
         android:allowBackup="false"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
     </base-config>
-    <debug-overrides>
-        <trust-anchors>
-            <certificates src="user" />
-        </trust-anchors>
-    </debug-overrides>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
🛡️ Sentinel: Restrict cleartext traffic to localhost

**What:** 
Removed the globally permissive cleartext traffic flag and enforced a strict HTTPS-only policy by default, with a narrow exception for `localhost`.

**Why:** 
Hardening transport security. Permitting global cleartext traffic allows potential unintentional transmission of sensitive data over unencrypted connections, leaving the app vulnerable to interception and MITM attacks on insecure networks.

**Impact:** 
Release builds will now actively block cleartext HTTP traffic to external destinations. A `debug` variant configuration has been provided to ensure local development and proxying are unaffected.

---
*PR created automatically by Jules for task [13633914148736092033](https://jules.google.com/task/13633914148736092033) started by @yuga-hashimoto*