### PR TITLE
🛡️ Sentinel: Disable cleartext traffic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,7 +89,6 @@
         android:name="com.openclaw.assistant.OpenClawApplication"
         android:allowBackup="false"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>

--- a/wear/src/main/res/xml/network_security_config.xml
+++ b/wear/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>


### PR DESCRIPTION
This PR implements a critical security hardening improvement by disabling cleartext traffic across the application.

**Changes:**
1. Removed `android:usesCleartextTraffic="true"` from `app/src/main/AndroidManifest.xml`.
2. Changed `cleartextTrafficPermitted="true"` to `"false"` in `app/src/main/res/xml/network_security_config.xml`.
3. Changed `cleartextTrafficPermitted="true"` to `"false"` in `wear/src/main/res/xml/network_security_config.xml`.

**Why:**
Allowing cleartext traffic exposes user data and tokens to Man-in-the-Middle (MITM) vulnerabilities. By enforcing HTTPS/WSS, we ensure that all communication between the app and the gateway/nodes remains encrypted and secure.

**Verification:**
Verified via native build and unit testing (`./gradlew app:testStandardDebugUnitTest app:lintStandardDebug wear:testDebugUnitTest wear:lintDebug`).

---
*PR created automatically by Jules for task [9289845159339211599](https://jules.google.com/task/9289845159339211599) started by @yuga-hashimoto*