### PR TITLE
🛡️ Sentinel: Remove cleartext traffic allowance

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,7 +89,6 @@
         android:name="com.openclaw.assistant.OpenClawApplication"
         android:allowBackup="false"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config>
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>

--- a/wear/src/main/res/xml/network_security_config.xml
+++ b/wear/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config>
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>


### PR DESCRIPTION
## What
This PR removes the insecure `usesCleartextTraffic` and `cleartextTrafficPermitted` directives from the application's manifests and network security configurations across both the `app` and `wear` modules.

## Why
Allowing cleartext traffic globally is a security risk (Man-in-the-Middle vulnerabilities) and goes against modern Android security best practices (default is `false` starting API 28). This forces the application to use secure transports (HTTPS/WSS) or local/debug connections defined explicitly, adhering to the Sentinel priority of preventing insecure transport.

## Impact
Network traffic that relies on unencrypted HTTP to non-local endpoints will now be blocked by the OS, securing user data in transit.

## Verification
- Verified changes using `app:testStandardDebugUnitTest` and `app:lintStandardDebug`.
- Wear module lint fails due to a pre-existing known issue, but app module checks pass.

---
*PR created automatically by Jules for task [17821625625680270968](https://jules.google.com/task/17821625625680270968) started by @yuga-hashimoto*