### PR TITLE
🛡️ Sentinel: Fix unsafe parsing in NetworkUtils IP validation

### DIFF
--- a/shared/src/main/java/com/openclaw/assistant/shared/utils/NetworkUtils.kt
+++ b/shared/src/main/java/com/openclaw/assistant/shared/utils/NetworkUtils.kt
@@ -34,6 +34,10 @@ object NetworkUtils {
         if (ipv4Parts.size == 4) {
             val p1 = ipv4Parts[0].toIntOrNull() ?: return false
             val p2 = ipv4Parts[1].toIntOrNull() ?: return false
+            val p3 = ipv4Parts[2].toIntOrNull() ?: return false
+            val p4 = ipv4Parts[3].toIntOrNull() ?: return false
+
+            if (p1 !in 0..255 || p2 !in 0..255 || p3 !in 0..255 || p4 !in 0..255) return false
 
             if (p1 == 127) return true // Loopback: 127.x.x.x
             if (p1 == 10) return true  // Class A Private: 10.x.x.x


### PR DESCRIPTION
## What
This PR addresses an insecure input parsing vulnerability within the `NetworkUtils.isUrlSecure` logic.

## Why
Previously, the `isLocalHost` check in `NetworkUtils.kt` split hoststrings by `.` but only validated the first two segments. 
Because of this oversight, it was possible for malicious or invalid inputs (like `192.168.evil.com` or `10.0.999.999`) to bypass the check, potentially enabling Server-Side Request Forgery (SSRF) vulnerabilities where the app would inadvertently trust a public domain or an invalid IP format over cleartext HTTP.

## How
The `isLocalHost` method has been hardened. It now validates that the IP address exactly consists of 4 parts and that every part is a valid integer within the bounds of `0` to `255` inclusive.

---
*PR created automatically by Jules for task [13754855714311747937](https://jules.google.com/task/13754855714311747937) started by @yuga-hashimoto*