### PR TITLE
🛡️ Sentinel: Enforce secure transport by disabling global cleartext traffic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,7 +89,6 @@
         android:name="com.openclaw.assistant.OpenClawApplication"
         android:allowBackup="false"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>


### PR DESCRIPTION
**What:**
Removed the `android:usesCleartextTraffic="true"` flag from the `AndroidManifest.xml` and modified `network_security_config.xml` to explicitly set `cleartextTrafficPermitted="false"` on the base configuration.

**Why:**
To enforce HTTPS by default across the application, addressing the top security priority (insecure transport / cleartext traffic). Allowing cleartext traffic globally is a security risk because it exposes data to man-in-the-middle (MITM) attacks when communicating with non-HTTPS APIs. The app logic already appropriately gates cleartext connections (like HTTP or WS) to strictly local or loopback IPs via `NetworkUtils.isUrlSecure()`.

**Verification:**
- Ran `./gradlew app:lintStandardDebug app:testStandardDebugUnitTest` natively to verify no compilation or testing regressions were introduced by removing the attribute.

---
*PR created automatically by Jules for task [6778920640289529762](https://jules.google.com/task/6778920640289529762) started by @yuga-hashimoto*