### PR TITLE
🛡️ Sentinel: Remove global cleartext traffic permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,7 +89,6 @@
         android:name="com.openclaw.assistant.OpenClawApplication"
         android:allowBackup="false"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Removed the globally permissive `usesCleartextTraffic="true"` from the Android manifest. The app already explicitly defines cleartext network policies per domain/IP in its `network_security_config.xml` (which defaults `cleartextTrafficPermitted="true"` on the base config for local network operations), rendering the manifest attribute unnecessary and potentially overly broad. Removing it from the manifest is a security best practice that prevents inadvertently allowing unencrypted traffic where it isn't strictly required by the local gateway logic.

---
*PR created automatically by Jules for task [14227439866238231594](https://jules.google.com/task/14227439866238231594) started by @yuga-hashimoto*