### PR TITLE
🛡️ Sentinel: Disable cleartext traffic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,7 +89,7 @@
         android:name="com.openclaw.assistant.OpenClawApplication"
         android:allowBackup="false"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>


### PR DESCRIPTION
This PR hardens the app's security by disabling cleartext traffic globally.

## What
Disabled cleartext traffic via the Android manifest and network security config file.
- Changed `android:usesCleartextTraffic="true"` to `"false"` in `AndroidManifest.xml`
- Changed `cleartextTrafficPermitted="true"` to `"false"` in `app/src/main/res/xml/network_security_config.xml`

## Why
Allowing cleartext traffic exposes the app to Man-in-the-Middle (MITM) attacks and data interception. Disabling this ensures that all network communication is forced over HTTPS or WSS, preventing the transmission of unencrypted sensitive data (like API tokens, passwords, and user inputs) over insecure networks.

## Verification
- Verified natively by running `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug` (0 regressions, successful compilation).

---
*PR created automatically by Jules for task [260881196714230432](https://jules.google.com/task/260881196714230432) started by @yuga-hashimoto*