### PR TITLE
🎨 Palette: Improve accessibility of inline images in chat markdown

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatMarkdown.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatMarkdown.kt
@@ -25,11 +25,13 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import com.openclaw.assistant.R
 import com.openclaw.assistant.chat.ChatMarkdownPreprocessor
 
 private val BASE64_IMAGE_REGEX = Regex("data:image/([a-zA-Z0-9+.-]+);base64,([A-Za-z0-9+/=\\n\\r]+)")
@@ -202,7 +204,7 @@ private fun InlineBase64Image(base64: String, mimeType: String?) {
   if (image != null) {
     Image(
       bitmap = image!!,
-      contentDescription = mimeType ?: "image",
+      contentDescription = mimeType ?: stringResource(R.string.image_attachment),
       contentScale = ContentScale.Fit,
       modifier = Modifier.fillMaxWidth(),
     )


### PR DESCRIPTION
💡 **What:** Replaced the hardcoded `"image"` string in the `contentDescription` of the `InlineBase64Image` component with a localized `stringResource(R.string.image_attachment)`.
🎯 **Why:** To improve accessibility for screen reader users and to allow the application's strings to be easily localized and managed. Screen readers will now read out "Image attachment" in the user's preferred language instead of the hardcoded "image" string.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** This directly impacts TalkBack and other screen readers to properly read a localized label for chat image attachments rather than a hardcoded string.

---
*PR created automatically by Jules for task [12608617280097079622](https://jules.google.com/task/12608617280097079622) started by @yuga-hashimoto*