### PR TITLE
fix: upgrade Kotlin 2.0.21 + Compose BOM 2025.04.01 to fix OEM font weight crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("kotlin-kapt")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("com.google.gms.google-services")
@@ -128,9 +129,6 @@ android {
         compose = true
         buildConfig = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.8"
-    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -174,7 +172,7 @@ dependencies {
     implementation("androidx.webkit:webkit:1.10.0")
 
     // Compose
-    implementation(platform("androidx.compose:compose-bom:2024.12.01"))
+    implementation(platform("androidx.compose:compose-bom:2025.04.01"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
@@ -189,7 +187,7 @@ dependencies {
     implementation("com.google.code.gson:gson:2.10.1")
 
     // Serialization
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1")
 
     // Encrypted SharedPreferences
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
@@ -213,7 +211,7 @@ dependencies {
     implementation("com.mikepenz:multiplatform-markdown-renderer-m3:0.14.0")
 
     // Coroutines
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
 
     // CameraX
     val cameraXVersion = "1.5.2"
@@ -236,13 +234,13 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("io.mockk:mockk:1.13.8")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.10.2")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
     testImplementation("io.kotest:kotest-runner-junit5-jvm:5.8.0")
     testImplementation("io.kotest:kotest-assertions-core-jvm:5.8.0")
     testImplementation("org.robolectric:robolectric:4.16")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2024.12.01"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2025.04.01"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
@@ -254,7 +252,7 @@ dependencies {
     kapt("androidx.room:room-compiler:$roomVersion")
 
     // Firebase
-    implementation(platform("com.google.firebase:firebase-bom:32.7.4"))
+    implementation(platform("com.google.firebase:firebase-bom:33.7.0"))
     implementation("com.google.firebase:firebase-crashlytics")
     implementation("com.google.firebase:firebase-analytics")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
     id("com.android.application") version "8.13.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.22" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
     id("com.google.gms.google-services") version "4.4.4" apply false
     id("com.google.firebase.crashlytics") version "3.0.2" apply false
 }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {
@@ -35,9 +36,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.8"
-    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -69,5 +67,5 @@ dependencies {
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
     // Coroutines
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
 }


### PR DESCRIPTION
## Summary / 概要

Fixes a FATAL crash (Crashlytics issue `5c3f7672`) that has affected **14 users** and occurred 27 times between March–April 2026. The crash is a `NoSuchFieldError` thrown by Jetpack Compose's `FontWeightAdjustmentHelperApi31` on OEM devices that have removed `Configuration.fontWeightAdjustment` from their customized Android framework. Compose 1.8.x (included in BOM 2025.04.01) resolves this via a proper reflection-based accessor.

Firebaseのクラッシュログ分析により特定された重大なFATALクラッシュ（Crashlytics issue `5c3f7672`）の修正です。OEMデバイスで`Configuration.fontWeightAdjustment`フィールドが存在しない場合に`NoSuchFieldError`が発生する問題をCompose 1.8.xのリフレクションベース実装で解消します。2026年3月〜4月の間に14ユーザー・27回発生しています。

---

## Changes / 変更内容

| | Before | After |
|---|---|---|
| Kotlin | 1.9.22 | 2.0.21 |
| Compose BOM | 2024.12.01 | 2025.04.01 |
| Compose compiler | `composeOptions { KCE = "1.5.8" }` | `org.jetbrains.kotlin.plugin.compose` |
| Firebase BOM | 32.7.4 | 33.7.0 |
| kotlinx-coroutines | 1.7.3 | 1.8.1 |
| kotlinx-serialization | 1.6.2 | 1.7.1 |

---

## Crashlytics Log Summary / Crashlyticsログ分析結果

Analysis of the production app (March 1 – April 3, 2026):

| Issue | Type | Events | Users | Status |
|---|---|---|---|---|
| `5c3f7672` Compose `NoSuchFieldError` fontWeightAdjustment | FATAL | 27 | **14** | ✅ Fixed by this PR |
| `dc6ae48e` ToneGenerator after release() | FATAL | 80 | 3 | ✅ Already fixed (try-catch in current code) |
| `458e1539` NodeForegroundService SecurityException | FATAL | 37 | 9 | ✅ Already fixed (try-catch in current code) |
| `0b7b7a84` HotwordService ForegroundServiceStartNotAllowed | FATAL | 13 | 5 | ✅ Already fixed (try-catch in current code) |
| `140f9a10` GatewaySession JSON parse error | FATAL | 13 | 1 | ✅ Already fixed (handleMessage try-catch) |
| `422524366f` DNS failure (okhttp) | NON_FATAL | 72 | 8 | ⚠️ Network issue (no code fix possible) |
| `17127a98` / `06e7f454` UpdateChecker network errors | NON_FATAL | 30 | 27 | ✅ Already fixed (IOException catch) |

---

## Migration Notes / 移行メモ

- **kapt** is still used for Room. Kotlin 2.0 supports kapt with a deprecation warning; KSP migration is a future follow-up.
  Roomはkapt継続使用（Kotlin 2.0でdeprecation警告が出るが動作する）。KSP移行は今後の対応。
- The `composeOptions { kotlinCompilerExtensionVersion }` block is replaced by the `org.jetbrains.kotlin.plugin.compose` Gradle plugin (standard for Kotlin 2.0+).
  `composeOptions.kotlinCompilerExtensionVersion`は`org.jetbrains.kotlin.plugin.compose`プラグインに置き換え。
- **Note:** BOM/library versions were chosen based on knowledge as of August 2025. Please verify the latest stable versions and adjust if CI reports resolution failures.
  **注意:** バージョンはAugust 2025時点の知識に基づいています。CI失敗時は最新バージョンに調整してください。

---

## Test plan / テスト計画

- [ ] Build succeeds on both `debug` and `release` variants
- [ ] `./gradlew :app:testStandardDebugUnitTest` passes
- [ ] Smoke test on a device with a standard Android ROM (font weight should render normally)
- [ ] Smoke test on a Xiaomi/INFINIX device if available (verify no `NoSuchFieldError` crash)
- [ ] Verify Crashlytics issue `5c3f7672` stops generating new events after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)