### PR TITLE
🧪 Regression Guard: Fix background service crash in MediaButtonReceiver

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
+++ b/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
@@ -44,7 +44,11 @@ class MediaButtonReceiver : BroadcastReceiver() {
                 val serviceIntent = Intent(context, OpenClawAssistantService::class.java).apply {
                     action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT
                 }
-                context.startService(serviceIntent)
+                try {
+                    context.startService(serviceIntent)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to start OpenClawAssistantService: ${e.message}", e)
+                }
                 // Absorb the event so it doesn't reach the media player
                 abortBroadcast()
             }


### PR DESCRIPTION
**What**
Wraps the `context.startService(serviceIntent)` call in `MediaButtonReceiver.kt` inside a `try-catch` block.

**Why**
On Android 8.0 (API level 26) and above, starting a service from the background throws an `IllegalStateException`. Since `MediaButtonReceiver` is triggered by a broadcast, it's very likely to run while the app is in the background. Without this fix, pressing a media button when the app is not in the foreground crashes the application.

**Impact**
This prevents an app crash. The user's media button event is still correctly intercepted and absorbed so it doesn't accidentally pause/play other media apps when they were trying to trigger the assistant, even if the service couldn't be launched.

**Verification**
- Verified the code changes.
- Ran `./gradlew app:lintStandardDebug --offline` and `./gradlew app:testStandardDebugUnitTest --offline` successfully.

---
*PR created automatically by Jules for task [2043871966959216276](https://jules.google.com/task/2043871966959216276) started by @yuga-hashimoto*