### PR TITLE
🧪 Regression Guard: Fix background service start crashes

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1538,7 +1538,13 @@ fun TroubleshootingDialog(onDismiss: () -> Unit) {
                 BulletPoint(stringResource(titleId), stringResource(descId)) 
             }
             Spacer(modifier = Modifier.height(8.dp)); HorizontalDivider(); Spacer(modifier = Modifier.height(8.dp))
-            Button(onClick = { context.startService(Intent(context, OpenClawAssistantService::class.java).apply { action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT }) }, modifier = Modifier.fillMaxWidth(), colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiary)) { Text(stringResource(R.string.debug_force_start)) }
+            Button(onClick = {
+                try {
+                    context.startService(Intent(context, OpenClawAssistantService::class.java).apply { action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT })
+                } catch (e: Exception) {
+                    android.util.Log.e("TroubleshootingDialog", "Failed to start service: ${e.message}")
+                }
+            }, modifier = Modifier.fillMaxWidth(), colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiary)) { Text(stringResource(R.string.debug_force_start)) }
         }
     }, confirmButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.got_it)) } })
 }

--- a/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
+++ b/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
@@ -44,7 +44,11 @@ class MediaButtonReceiver : BroadcastReceiver() {
                 val serviceIntent = Intent(context, OpenClawAssistantService::class.java).apply {
                     action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT
                 }
-                context.startService(serviceIntent)
+                try {
+                    context.startService(serviceIntent)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to start OpenClawAssistantService: ${e.message}")
+                }
                 // Absorb the event so it doesn't reach the media player
                 abortBroadcast()
             }

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -58,7 +58,11 @@ class HotwordService : Service(), VoskRecognitionListener {
         }
 
         fun stop(context: Context) {
-            context.stopService(Intent(context, HotwordService::class.java))
+            try {
+                context.stopService(Intent(context, HotwordService::class.java))
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to stop HotwordService: ${e.message}", e)
+            }
         }
 
         fun shouldCopyModel(currentVersion: Int, savedVersion: Int, targetDirExists: Boolean, targetDirNotEmpty: Boolean): Boolean {
@@ -647,8 +651,12 @@ class HotwordService : Service(), VoskRecognitionListener {
             val intent = Intent(this@HotwordService, OpenClawAssistantService::class.java).apply {
                 action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT
             }
-            startService(intent)
-            Log.e(TAG, "startService ACTION_SHOW_ASSISTANT called")
+            try {
+                startService(intent)
+                Log.e(TAG, "startService ACTION_SHOW_ASSISTANT called")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start OpenClawAssistantService: ${e.message}", e)
+            }
         }
     }
 

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -281,7 +281,11 @@ class NodeForegroundService : Service() {
 
     fun stop(context: Context) {
       val intent = Intent(context, NodeForegroundService::class.java).setAction(ACTION_STOP)
-      context.startService(intent)
+      try {
+        context.startService(intent)
+      } catch (e: Exception) {
+        android.util.Log.e(TAG, "Failed to stop NodeForegroundService: ${e.message}", e)
+      }
     }
 
     /**

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -44,7 +44,11 @@ class SessionForegroundService : Service() {
         }
 
         fun stop(context: Context) {
-            context.stopService(Intent(context, SessionForegroundService::class.java))
+            try {
+                context.stopService(Intent(context, SessionForegroundService::class.java))
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to stop SessionForegroundService: ${e.message}", e)
+            }
         }
     }
 


### PR DESCRIPTION
Wrapped `startService` and `stopService` calls across multiple background components (like `MediaButtonReceiver`, `HotwordService`, `NodeForegroundService`, and `SessionForegroundService`) in `try-catch` blocks. This prevents `IllegalStateException` crashes on Android 8.0+ when the OS restricts background apps from starting services.

---
*PR created automatically by Jules for task [15623102037094565651](https://jules.google.com/task/15623102037094565651) started by @yuga-hashimoto*