### PR TITLE
🛡️ Sentinel: Fix incomplete IPv4 validation in NetworkUtils

### DIFF
--- a/shared/src/main/java/com/openclaw/assistant/shared/utils/NetworkUtils.kt
+++ b/shared/src/main/java/com/openclaw/assistant/shared/utils/NetworkUtils.kt
@@ -34,6 +34,10 @@ object NetworkUtils {
         if (ipv4Parts.size == 4) {
             val p1 = ipv4Parts[0].toIntOrNull() ?: return false
             val p2 = ipv4Parts[1].toIntOrNull() ?: return false
+            val p3 = ipv4Parts[2].toIntOrNull() ?: return false
+            val p4 = ipv4Parts[3].toIntOrNull() ?: return false
+
+            if (p1 !in 0..255 || p2 !in 0..255 || p3 !in 0..255 || p4 !in 0..255) return false
 
             if (p1 == 127) return true // Loopback: 127.x.x.x
             if (p1 == 10) return true  // Class A Private: 10.x.x.x


### PR DESCRIPTION
This PR implements a security hardening improvement for IPv4 parsing.

**What was fixed:**
In `NetworkUtils.kt`, the `isLocalHost` method only parsed the first two octets of a given IPv4 address. It failed to parse the third and fourth octets, and also failed to validate that any of the parsed integer components fell within the valid `0..255` range for an IP address.

**Why it matters:**
If this method is used to restrict outbound connections or bypass proxy checks (e.g., SSRF protection), an incomplete validation could allow malicious domains or IP segments (like `192.168.evil.com`) to bypass the filter since the parser stopped verifying after the first two segments.

**Verification:**
Verified through local execution and `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug`. Cleaned up all scratchpad testing scripts.

---
*PR created automatically by Jules for task [10804754528019402694](https://jules.google.com/task/10804754528019402694) started by @yuga-hashimoto*