### PR TITLE
🔄 Upstream Parity: Require TLS for remote gateway endpoints

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewayHostSecurity.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewayHostSecurity.kt
@@ -1,0 +1,80 @@
+package com.openclaw.assistant.gateway
+
+import android.os.Build
+import java.net.InetAddress
+import java.util.Locale
+
+internal fun isLoopbackGatewayHost(
+  rawHost: String?,
+  allowEmulatorBridgeAlias: Boolean = isAndroidEmulatorRuntime(),
+): Boolean {
+  var host =
+    rawHost
+      ?.trim()
+      ?.lowercase(Locale.US)
+      ?.trim('[', ']')
+      .orEmpty()
+  if (host.endsWith(".")) {
+    host = host.dropLast(1)
+  }
+  val zoneIndex = host.indexOf('%')
+  if (zoneIndex >= 0) {
+    host = host.substring(0, zoneIndex)
+  }
+  if (host.isEmpty()) return false
+  if (host == "localhost") return true
+  if (allowEmulatorBridgeAlias && host == "10.0.2.2") return true
+
+  parseIpv4Address(host)?.let { ipv4 ->
+    return ipv4.first() == 127.toByte()
+  }
+  if (!host.contains(':') || !host.all(::isIpv6LiteralChar)) return false
+
+  val address = runCatching { InetAddress.getByName(host) }.getOrNull()?.address ?: return false
+  if (address.size == 4) {
+    return address[0] == 127.toByte()
+  }
+  if (address.size != 16) return false
+  // `::1` is 15 zero bytes followed by `0x01`.
+  val isIpv6Loopback = address.copyOfRange(0, 15).all { it == 0.toByte() } && address[15] == 1.toByte()
+  if (isIpv6Loopback) return true
+
+  val isMappedIpv4 =
+    address.copyOfRange(0, 10).all { it == 0.toByte() } &&
+      address[10] == 0xFF.toByte() &&
+      address[11] == 0xFF.toByte()
+  return isMappedIpv4 && address[12] == 127.toByte()
+}
+
+private fun isAndroidEmulatorRuntime(): Boolean {
+  val fingerprint = Build.FINGERPRINT?.lowercase(Locale.US).orEmpty()
+  val model = Build.MODEL?.lowercase(Locale.US).orEmpty()
+  val manufacturer = Build.MANUFACTURER?.lowercase(Locale.US).orEmpty()
+  val brand = Build.BRAND?.lowercase(Locale.US).orEmpty()
+  val device = Build.DEVICE?.lowercase(Locale.US).orEmpty()
+  val product = Build.PRODUCT?.lowercase(Locale.US).orEmpty()
+
+  return fingerprint.contains("generic") ||
+    fingerprint.contains("robolectric") ||
+    model.contains("emulator") ||
+    model.contains("sdk_gphone") ||
+    manufacturer.contains("genymotion") ||
+    (brand.contains("generic") && device.contains("generic")) ||
+    product.contains("sdk_gphone") ||
+    product.contains("emulator") ||
+    product.contains("simulator")
+}
+
+private fun parseIpv4Address(host: String): ByteArray? {
+  val parts = host.split('.')
+  if (parts.size != 4) return null
+  val bytes = ByteArray(4)
+  for ((index, part) in parts.withIndex()) {
+    val value = part.toIntOrNull() ?: return null
+    if (value !in 0..255) return null
+    bytes[index] = value.toByte()
+  }
+  return bytes
+}
+
+private fun isIpv6LiteralChar(char: Char): Boolean = char in '0'..'9' || char in 'a'..'f' || char == ':' || char == '.'

--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
@@ -1,6 +1,7 @@
 package com.openclaw.assistant.gateway
 
 import android.util.Log
+import com.openclaw.assistant.gateway.isLoopbackGatewayHost
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -77,7 +78,7 @@ class GatewaySession(
     }
 
     internal fun buildCanvasUrl(scheme: String, host: String, port: Int, suffix: String): String {
-      val formattedHost = if (host.contains(":")) "[$host]" else host
+      val formattedHost = formatGatewayAuthorityHost(host)
       val portSuffix =
         when {
           (scheme == "https" && port == 443) || (scheme == "http" && port == 80) -> ""
@@ -90,15 +91,6 @@ class GatewaySession(
     internal fun resolveInvokeResultAckTimeoutMs(invokeTimeoutMs: Long?): Long {
       if (invokeTimeoutMs == null) return 15_000L
       return minOf(maxOf(invokeTimeoutMs + 5_000L, 15_000L), 120_000L)
-    }
-
-    internal fun isLoopbackHost(raw: String?): Boolean {
-      val host = raw?.trim()?.lowercase().orEmpty()
-      if (host.isEmpty()) return false
-      if (host == "localhost") return true
-      if (host == "::1") return true
-      if (host == "0.0.0.0" || host == "::") return true
-      return host.startsWith("127.")
     }
 
     internal fun normalizeCanvasHostUrl(
@@ -116,7 +108,7 @@ class GatewaySession(
 
       val tls = isTlsConnection || endpoint.port == 443 || endpoint.host.contains(".")
 
-      if (trimmed.isNotBlank() && !isLoopbackHost(host)) {
+      if (trimmed.isNotBlank() && !isLoopbackGatewayHost(host)) {
         if (tls && port > 0 && port != 443) {
           return buildCanvasUrl("https", host, 443, suffix)
         }
@@ -279,18 +271,12 @@ class GatewaySession(
     private var socket: WebSocket? = null
     private val loggerTag = "OpenClawGateway"
 
-    val remoteAddress: String =
-      if (endpoint.host.contains(":")) {
-        "[${endpoint.host}]:${endpoint.port}"
-      } else {
-        "${endpoint.host}:${endpoint.port}"
-      }
+    val remoteAddress: String = formatGatewayAuthority(endpoint.host, endpoint.port)
 
     suspend fun connect() {
-      val scheme = if (tls != null) "wss" else "ws"
-      val url = "$scheme://${endpoint.host}:${endpoint.port}"
+      val url = buildGatewayWebSocketUrl(endpoint.host, endpoint.port, tls != null)
       val httpScheme = if (tls != null) "https" else "http"
-      val origin = "$httpScheme://${endpoint.host}:${endpoint.port}"
+      val origin = "$httpScheme://${formatGatewayAuthority(endpoint.host, endpoint.port)}"
       val request = Request.Builder()
         .url(url)
         .header("Origin", origin)
@@ -676,7 +662,7 @@ class GatewaySession(
     }
 
     private suspend fun awaitConnectNonce(): String? {
-      if (isLoopbackHost(endpoint.host)) return null
+      if (isLoopbackGatewayHost(endpoint.host)) return null
       return try {
         withTimeout(2_000) { connectNonceDeferred.await() }
       } catch (_: Throwable) {
@@ -834,6 +820,21 @@ class GatewaySession(
     return parts.joinToString("|")
   }
 
+}
+
+
+internal fun buildGatewayWebSocketUrl(host: String, port: Int, useTls: Boolean): String {
+  val scheme = if (useTls) "wss" else "ws"
+  return "$scheme://${formatGatewayAuthority(host, port)}"
+}
+
+internal fun formatGatewayAuthority(host: String, port: Int): String {
+  return "${formatGatewayAuthorityHost(host)}:$port"
+}
+
+private fun formatGatewayAuthorityHost(host: String): String {
+  val normalizedHost = host.trim().trim('[', ']')
+  return if (normalizedHost.contains(":")) "[${normalizedHost}]" else normalizedHost
 }
 
 private fun JsonElement?.asObjectOrNull(): JsonObject? = this as? JsonObject

--- a/app/src/main/java/com/openclaw/assistant/node/ConnectionManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/ConnectionManager.kt
@@ -11,6 +11,7 @@ import com.openclaw.assistant.gateway.GatewayClientInfo
 import com.openclaw.assistant.gateway.GatewayConnectOptions
 import com.openclaw.assistant.gateway.GatewayEndpoint
 import com.openclaw.assistant.gateway.GatewayTlsParams
+import com.openclaw.assistant.gateway.isLoopbackGatewayHost
 import com.openclaw.assistant.protocol.OpenClawCanvasA2UICommand
 import com.openclaw.assistant.protocol.OpenClawCanvasCommand
 import com.openclaw.assistant.protocol.OpenClawCameraCommand
@@ -49,9 +50,10 @@ class ConnectionManager(
       val stableId = endpoint.stableId
       val stored = storedFingerprint?.trim().takeIf { !it.isNullOrEmpty() }
       val isManual = stableId.startsWith("manual|")
+      val isLoopback = isLoopbackGatewayHost(endpoint.host)
 
       if (isManual) {
-        if (!manualTlsEnabled) return null
+        if (!manualTlsEnabled && isLoopback) return null
         if (!stored.isNullOrBlank()) {
           return GatewayTlsParams(
             required = true,
@@ -81,6 +83,15 @@ class ConnectionManager(
       val hinted = endpoint.tlsEnabled || !endpoint.tlsFingerprintSha256.isNullOrBlank()
       if (hinted) {
         // TXT is unauthenticated. Do not treat the advertised fingerprint as authoritative.
+        return GatewayTlsParams(
+          required = true,
+          expectedFingerprint = null,
+          allowTOFU = false,
+          stableId = stableId,
+        )
+      }
+
+      if (!isLoopback) {
         return GatewayTlsParams(
           required = true,
           expectedFingerprint = null,

--- a/app/src/main/java/com/openclaw/assistant/utils/GatewayConfigUtils.kt
+++ b/app/src/main/java/com/openclaw/assistant/utils/GatewayConfigUtils.kt
@@ -4,6 +4,7 @@ import android.util.Base64
 import android.util.Log
 import androidx.core.net.toUri
 import com.openclaw.assistant.shared.utils.NetworkUtils
+import com.openclaw.assistant.gateway.isLoopbackGatewayHost
 import java.util.Locale
 import org.json.JSONObject
 
@@ -29,7 +30,7 @@ object GatewayConfigUtils {
 
         val normalized = if (raw.contains("://")) raw else "https://$raw"
         val uri = normalized.toUri()
-        val host = uri.host?.trim().orEmpty()
+        val host = uri.host?.trim()?.trim('[', ']').orEmpty()
         if (host.isEmpty()) return null
 
         val scheme = uri.scheme?.trim()?.lowercase(Locale.US).orEmpty()
@@ -38,11 +39,16 @@ object GatewayConfigUtils {
             "wss", "https" -> true
             else -> true
         }
-        val port = uri.port.takeIf { it in 1..65535 } ?: if (tls) 443 else 18789
-        val displayUrl = "${if (tls) "https" else "http"}://$host:$port"
+        if (!tls && !isLoopbackGatewayHost(host)) return null
 
-        if (!tls && !NetworkUtils.isUrlSecure(displayUrl)) {
-            return null
+        val defaultPort = if (tls) 443 else 18789
+        val port = uri.port.takeIf { it in 1..65535 } ?: defaultPort
+
+        val displayHost = if (host.contains(":")) "[$host]" else host
+        val displayUrl = if (port == defaultPort) {
+            "${if (tls) "https" else "http"}://$displayHost"
+        } else {
+            "${if (tls) "https" else "http"}://$displayHost:$port"
         }
 
         return GatewayEndpointConfig(host = host, port = port, tls = tls, displayUrl = displayUrl)
@@ -68,7 +74,7 @@ object GatewayConfigUtils {
                 Log.w("GatewayConfigUtils", "Setup code missing 'url' field")
                 return null
             }
-            if (!NetworkUtils.isUrlSecure(url)) {
+            if (parseGatewayEndpoint(url) == null) {
                 Log.w("GatewayConfigUtils", "Setup code URL is not secure: $url")
                 return null
             }
@@ -92,7 +98,7 @@ object GatewayConfigUtils {
         val scheme = if (tls) "https" else "http"
         val url = "$scheme://$host:$port"
 
-        if (!tls && !NetworkUtils.isUrlSecure(url)) {
+        if (!tls && !isLoopbackGatewayHost(host)) {
             return null
         }
 

--- a/app/src/test/java/com/openclaw/assistant/gateway/GatewaySessionUrlTest.kt
+++ b/app/src/test/java/com/openclaw/assistant/gateway/GatewaySessionUrlTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
  * Covers:
  *  - [GatewaySession.buildUrlSuffix]
  *  - [GatewaySession.buildCanvasUrl]
- *  - [GatewaySession.isLoopbackHost]
+ *  - [com.openclaw.assistant.gateway.isLoopbackGatewayHost]
  *  - [GatewaySession.resolveInvokeResultAckTimeoutMs]
  *  - [GatewaySession.normalizeCanvasHostUrl]
  */
@@ -108,25 +108,25 @@ class GatewaySessionUrlTest {
     // ---------------------------------------------------------------------------
 
     @Test
-    fun `isLoopbackHost - localhost`() = assertTrue(GatewaySession.isLoopbackHost("localhost"))
+    fun `isLoopbackHost - localhost`() = assertTrue(com.openclaw.assistant.gateway.isLoopbackGatewayHost("localhost"))
 
     @Test
-    fun `isLoopbackHost - 127_0_0_1`() = assertTrue(GatewaySession.isLoopbackHost("127.0.0.1"))
+    fun `isLoopbackHost - 127_0_0_1`() = assertTrue(com.openclaw.assistant.gateway.isLoopbackGatewayHost("127.0.0.1"))
 
     @Test
-    fun `isLoopbackHost - IPv6 loopback`() = assertTrue(GatewaySession.isLoopbackHost("::1"))
+    fun `isLoopbackHost - IPv6 loopback`() = assertTrue(com.openclaw.assistant.gateway.isLoopbackGatewayHost("::1"))
 
     @Test
-    fun `isLoopbackHost - 0_0_0_0`() = assertTrue(GatewaySession.isLoopbackHost("0.0.0.0"))
+    fun `isLoopbackHost - 0_0_0_0`() = assertFalse(com.openclaw.assistant.gateway.isLoopbackGatewayHost("0.0.0.0"))
 
     @Test
-    fun `isLoopbackHost - public domain`() = assertFalse(GatewaySession.isLoopbackHost("example.com"))
+    fun `isLoopbackHost - public domain`() = assertFalse(com.openclaw.assistant.gateway.isLoopbackGatewayHost("example.com"))
 
     @Test
-    fun `isLoopbackHost - null returns false`() = assertFalse(GatewaySession.isLoopbackHost(null))
+    fun `isLoopbackHost - null returns false`() = assertFalse(com.openclaw.assistant.gateway.isLoopbackGatewayHost(null))
 
     @Test
-    fun `isLoopbackHost - empty string returns false`() = assertFalse(GatewaySession.isLoopbackHost(""))
+    fun `isLoopbackHost - empty string returns false`() = assertFalse(com.openclaw.assistant.gateway.isLoopbackGatewayHost(""))
 
     // ---------------------------------------------------------------------------
     // resolveInvokeResultAckTimeoutMs

--- a/app/src/test/java/com/openclaw/assistant/utils/GatewayConfigUtilsTest.kt
+++ b/app/src/test/java/com/openclaw/assistant/utils/GatewayConfigUtilsTest.kt
@@ -52,12 +52,9 @@ class GatewayConfigUtilsTest {
     }
 
     @Test
-    fun `decodeGatewaySetupCode extracts password from local WS setup code`() {
+    fun `decodeGatewaySetupCode fails on non-loopback WS setup code`() {
         val result = GatewayConfigUtils.decodeGatewaySetupCode(codeLocalWsPassword)
-        assertNotNull("Local WS setup code should decode successfully", result)
-        assertEquals("localpass", result!!.password)
-        assertNull("Token should be null when not present", result.token)
-        assertEquals("ws://192.168.1.100:18789", result.url)
+        assertNull(result)
     }
 
     @Test
@@ -98,11 +95,9 @@ class GatewayConfigUtilsTest {
     }
 
     @Test
-    fun `parseGatewayEndpoint defaults to port 18789 for WS`() {
+    fun `parseGatewayEndpoint returns null for non-loopback WS`() {
         val result = GatewayConfigUtils.parseGatewayEndpoint("ws://192.168.1.100")
-        assertNotNull(result)
-        assertEquals(18789, result!!.port)
-        assertEquals(false, result.tls)
+        assertNull(result)
     }
 
     @Test


### PR DESCRIPTION
- **Source**: Upstream PR #58475 `fix(android): require TLS for remote gateway endpoints`
- **Why**: Cleartext WebSockets (`ws://`) over LAN/WAN expose device auth tokens, microphone chunks, and chat data. Remote endpoints must be fully secured using TLS, while local emulator bridges and `127.0.0.1` should still permit debug cleartext.
- **Adaptation**: Reimplemented the upstream `isLoopbackGatewayHost` checks, refactored `ConnectionManager` to respect these bounds, and integrated it into our `GatewayConfigUtils` so that malicious `ws://` setup QR codes are cleanly rejected before dialing. Re-implemented upstream's formatting logic into `GatewaySession`. Corrected our own `GatewaySessionUrlTest` and `GatewayConfigUtilsTest` so they properly reject LAN IPs as "loopback".
- **Excluded upstream behavior**: Kept our native UI and error toasts instead of porting upstream's full dialog styling.
- **Verification**: Ran `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug` and confirmed all assertions pass. Tested against valid `127.0.0.1` and invalid `192.168.1.1` hosts natively in tests.

---
*PR created automatically by Jules for task [1730344439082817846](https://jules.google.com/task/1730344439082817846) started by @yuga-hashimoto*