### PR TITLE
🧪 Regression Guard: Fix service lifecycle exceptions

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1538,7 +1538,17 @@ fun TroubleshootingDialog(onDismiss: () -> Unit) {
                 BulletPoint(stringResource(titleId), stringResource(descId)) 
             }
             Spacer(modifier = Modifier.height(8.dp)); HorizontalDivider(); Spacer(modifier = Modifier.height(8.dp))
-            Button(onClick = { context.startService(Intent(context, OpenClawAssistantService::class.java).apply { action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT }) }, modifier = Modifier.fillMaxWidth(), colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiary)) { Text(stringResource(R.string.debug_force_start)) }
+            Button(
+                onClick = {
+                    try {
+                        context.startService(Intent(context, OpenClawAssistantService::class.java).apply { action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT })
+                    } catch (e: Exception) {
+                        Log.e("MainActivity", "Failed to start OpenClawAssistantService", e)
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiary)
+            ) { Text(stringResource(R.string.debug_force_start)) }
         }
     }, confirmButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.got_it)) } })
 }

--- a/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
+++ b/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
@@ -44,7 +44,11 @@ class MediaButtonReceiver : BroadcastReceiver() {
                 val serviceIntent = Intent(context, OpenClawAssistantService::class.java).apply {
                     action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT
                 }
-                context.startService(serviceIntent)
+                try {
+                    context.startService(serviceIntent)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to start OpenClawAssistantService", e)
+                }
                 // Absorb the event so it doesn't reach the media player
                 abortBroadcast()
             }

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -58,7 +58,11 @@ class HotwordService : Service(), VoskRecognitionListener {
         }
 
         fun stop(context: Context) {
-            context.stopService(Intent(context, HotwordService::class.java))
+            try {
+                context.stopService(Intent(context, HotwordService::class.java))
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to stop HotwordService", e)
+            }
         }
 
         fun shouldCopyModel(currentVersion: Int, savedVersion: Int, targetDirExists: Boolean, targetDirNotEmpty: Boolean): Boolean {
@@ -647,8 +651,12 @@ class HotwordService : Service(), VoskRecognitionListener {
             val intent = Intent(this@HotwordService, OpenClawAssistantService::class.java).apply {
                 action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT
             }
-            startService(intent)
-            Log.e(TAG, "startService ACTION_SHOW_ASSISTANT called")
+            try {
+                startService(intent)
+                Log.d(TAG, "startService ACTION_SHOW_ASSISTANT called")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start OpenClawAssistantService", e)
+            }
         }
     }
 

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -281,7 +281,11 @@ class NodeForegroundService : Service() {
 
     fun stop(context: Context) {
       val intent = Intent(context, NodeForegroundService::class.java).setAction(ACTION_STOP)
-      context.startService(intent)
+      try {
+        context.startService(intent)
+      } catch (e: Exception) {
+        android.util.Log.e(TAG, "Failed to startService for stop", e)
+      }
     }
 
     /**

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -44,7 +44,11 @@ class SessionForegroundService : Service() {
         }
 
         fun stop(context: Context) {
-            context.stopService(Intent(context, SessionForegroundService::class.java))
+            try {
+                context.stopService(Intent(context, SessionForegroundService::class.java))
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to stop SessionForegroundService", e)
+            }
         }
     }
 


### PR DESCRIPTION
### What
Added defensive `try-catch` blocks around multiple `startService` and `stopService` calls across the app.

### Why
On Android 8+ (API 26+) and especially Android 12+ (API 31+), the OS strictly regulates when an app can launch background services or foreground services. Calling `startService()` while the app is in the background often throws an `IllegalStateException` or `ForegroundServiceStartNotAllowedException`. Similarly, stopping services improperly can occasionally lead to exceptions depending on timing and permissions. By catching these exceptions, we prevent the entire application from crashing silently or visibly when these OS-level enforcement limits are hit.

### Impact
- **Crash Prevention:** Users will no longer experience application crashes when background components (like `MediaButtonReceiver`) attempt to wake up the assistant service.
- **Stability:** Ensures components like `HotwordService`, `SessionForegroundService`, and `NodeForegroundService` handle state transitions defensively.

### Testing
- Ran `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug` successfully.
- Verified compilation and lack of regressions.

---
*PR created automatically by Jules for task [10761921942871813118](https://jules.google.com/task/10761921942871813118) started by @yuga-hashimoto*