### PR TITLE
🧪 Regression Guard: Fix IllegalStateException crashes from background start/stopService calls

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1538,7 +1538,13 @@ fun TroubleshootingDialog(onDismiss: () -> Unit) {
                 BulletPoint(stringResource(titleId), stringResource(descId)) 
             }
             Spacer(modifier = Modifier.height(8.dp)); HorizontalDivider(); Spacer(modifier = Modifier.height(8.dp))
-            Button(onClick = { context.startService(Intent(context, OpenClawAssistantService::class.java).apply { action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT }) }, modifier = Modifier.fillMaxWidth(), colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiary)) { Text(stringResource(R.string.debug_force_start)) }
+            Button(onClick = {
+                try {
+                    context.startService(Intent(context, OpenClawAssistantService::class.java).apply { action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT })
+                } catch (e: Exception) {
+                    android.util.Log.e("MainActivity", "Failed to force start assistant: ${e.message}", e)
+                }
+            }, modifier = Modifier.fillMaxWidth(), colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiary)) { Text(stringResource(R.string.debug_force_start)) }
         }
     }, confirmButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.got_it)) } })
 }

--- a/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
+++ b/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
@@ -44,7 +44,11 @@ class MediaButtonReceiver : BroadcastReceiver() {
                 val serviceIntent = Intent(context, OpenClawAssistantService::class.java).apply {
                     action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT
                 }
-                context.startService(serviceIntent)
+                try {
+                    context.startService(serviceIntent)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to start OpenClawAssistantService: ${e.message}", e)
+                }
                 // Absorb the event so it doesn't reach the media player
                 abortBroadcast()
             }

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -58,7 +58,11 @@ class HotwordService : Service(), VoskRecognitionListener {
         }
 
         fun stop(context: Context) {
-            context.stopService(Intent(context, HotwordService::class.java))
+            try {
+                context.stopService(Intent(context, HotwordService::class.java))
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to stop HotwordService: ${e.message}", e)
+            }
         }
 
         fun shouldCopyModel(currentVersion: Int, savedVersion: Int, targetDirExists: Boolean, targetDirNotEmpty: Boolean): Boolean {
@@ -647,8 +651,12 @@ class HotwordService : Service(), VoskRecognitionListener {
             val intent = Intent(this@HotwordService, OpenClawAssistantService::class.java).apply {
                 action = OpenClawAssistantService.ACTION_SHOW_ASSISTANT
             }
-            startService(intent)
-            Log.e(TAG, "startService ACTION_SHOW_ASSISTANT called")
+            try {
+                startService(intent)
+                Log.e(TAG, "startService ACTION_SHOW_ASSISTANT called")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start OpenClawAssistantService: ${e.message}", e)
+            }
         }
     }
 

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -281,7 +281,12 @@ class NodeForegroundService : Service() {
 
     fun stop(context: Context) {
       val intent = Intent(context, NodeForegroundService::class.java).setAction(ACTION_STOP)
-      context.startService(intent)
+      try {
+        context.startService(intent)
+      } catch (e: Exception) {
+        android.util.Log.e(TAG, "Failed to start NodeForegroundService for stop action, falling back to stopService: ${e.message}", e)
+        context.stopService(Intent(context, NodeForegroundService::class.java))
+      }
     }
 
     /**

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -44,7 +44,11 @@ class SessionForegroundService : Service() {
         }
 
         fun stop(context: Context) {
-            context.stopService(Intent(context, SessionForegroundService::class.java))
+            try {
+                context.stopService(Intent(context, SessionForegroundService::class.java))
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to stop SessionForegroundService: ${e.message}", e)
+            }
         }
     }
 


### PR DESCRIPTION
🧪 Regression Guard: Fix IllegalStateException crashes from background startService/stopService calls

**What:**
Wrapped `startService` and `stopService` calls across multiple files in `try-catch` blocks and added a fallback mechanism for service termination.

**Why:**
On modern Android versions (Android 8+), starting a service while the app is in the background can result in an `IllegalStateException` (or `BackgroundServiceStartNotAllowedException` on Android 12+), crashing the app. 

**How:**
- Applied defensive `try-catch` blocks to vulnerable `startService` and `stopService` invocations in `MainActivity`, `MediaButtonReceiver`, `HotwordService`, `NodeForegroundService`, and `SessionForegroundService`.
- Crucially, in `NodeForegroundService.stop()`, if sending the `ACTION_STOP` intent via `startService` fails, the code gracefully falls back to invoking `context.stopService()` to ensure the heavy Node service correctly terminates without leaving a zombie foreground process draining resources.

**Verification:**
- Ran `./gradlew app:lintStandardDebug` (Pass)
- Ran `./gradlew app:testStandardDebugUnitTest` (Pass)

---
*PR created automatically by Jules for task [9763123651483571029](https://jules.google.com/task/9763123651483571029) started by @yuga-hashimoto*