### PR TITLE
[codex] Add cron management UI and mic privacy handling

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -3,8 +3,10 @@ package com.openclaw.assistant
 import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.media.AudioManager
 import android.net.Uri
 import android.os.Bundle
+import android.os.Build
 import android.provider.Settings
 
 import android.util.Log
@@ -55,6 +57,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
+import android.hardware.SensorPrivacyManager
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.openclaw.assistant.speech.TTSUtils
@@ -159,16 +162,16 @@ class ChatActivity : ComponentActivity() {
                     onSendMessage = { viewModel.sendMessage(it) },
                     onStartListening = {
                         Log.e(TAG, "onStartListening called, permission=${checkPermission()}")
-                        if (checkPermission()) {
-                            viewModel.startListening()
-                        } else {
-                            requestMicPermissionForListening()
+                        when {
+                            !checkPermission() -> requestMicPermissionForListening()
+                            isMicPrivacyBlocked() -> showMicPrivacyDialog()
+                            else -> viewModel.startListening()
                         }
                     },
                     onStopListening = { viewModel.stopListening() },
                     onStopSpeaking = { viewModel.stopSpeaking() },
                     onInterruptAndListen = {
-                        if (checkPermission()) {
+                        if (checkPermission() && !isMicPrivacyBlocked()) {
                             viewModel.interruptAndListen()
                         }
                     },
@@ -224,6 +227,26 @@ class ChatActivity : ComponentActivity() {
 
     private fun checkPermission(): Boolean {
         return ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun isMicPrivacyBlocked(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return false
+        val spm = getSystemService(SensorPrivacyManager::class.java)
+        val supportsMicToggle = spm?.supportsSensorToggle(SensorPrivacyManager.Sensors.MICROPHONE) == true
+        if (!supportsMicToggle) return false
+        val audioManager = getSystemService(AudioManager::class.java)
+        return audioManager?.isMicrophoneMute == true
+    }
+
+    private fun showMicPrivacyDialog() {
+        android.app.AlertDialog.Builder(this)
+            .setTitle(getString(R.string.error_mic_privacy_title))
+            .setMessage(getString(R.string.error_mic_privacy_message))
+            .setPositiveButton(getString(R.string.action_open_settings)) { _, _ ->
+                startActivity(Intent(Settings.ACTION_PRIVACY_SETTINGS))
+            }
+            .setNegativeButton(getString(R.string.cancel), null)
+            .show()
     }
 
     private fun requestMicPermissionForListening() {

--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -7,6 +7,8 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.hardware.SensorPrivacyManager
+import android.media.AudioManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -92,8 +94,9 @@ sealed class AppTab(val route: String, val labelResId: Int, val icon: ImageVecto
     object Home     : AppTab("home",     R.string.tab_nav_home,     Icons.Default.Home)
     object Chat     : AppTab("chat",     R.string.tab_nav_chat,     Icons.AutoMirrored.Filled.Chat)
     object Canvas   : AppTab("canvas",   R.string.tab_nav_canvas,   Icons.Default.Brush)
+    object Cron     : AppTab("cron",     R.string.tab_nav_cron,     Icons.Default.Schedule)
     object Settings : AppTab("settings", R.string.tab_nav_settings, Icons.Default.Settings)
-    companion object { val ALL by lazy { listOf(Home, Chat, Canvas, Settings) } }
+    companion object { val ALL by lazy { listOf(Home, Chat, Canvas, Cron, Settings) } }
 }
 
 class MainActivity : ComponentActivity(), TextToSpeech.OnInitListener {
@@ -281,7 +284,8 @@ class MainActivity : ComponentActivity(), TextToSpeech.OnInitListener {
 
     private fun refreshAllPermissionsStatus() {
         val list = mutableListOf<PermissionStatusInfo>()
-        list.add(PermissionStatusInfo(getString(R.string.permission_record_audio), ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED))
+        val recordAudioGranted = ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
+        list.add(PermissionStatusInfo(getString(R.string.permission_record_audio), recordAudioGranted && !isMicPrivacyBlocked()))
         list.add(PermissionStatusInfo(getString(R.string.permission_camera), ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED))
         list.add(PermissionStatusInfo(getString(R.string.permission_location_fine), ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED))
         list.add(PermissionStatusInfo(getString(R.string.permission_location_coarse), ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED))
@@ -289,6 +293,15 @@ class MainActivity : ComponentActivity(), TextToSpeech.OnInitListener {
             list.add(PermissionStatusInfo(getString(R.string.permission_notifications), ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED))
         }
         allPermissionsStatus = list
+    }
+
+    private fun isMicPrivacyBlocked(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return false
+        val spm = getSystemService(SensorPrivacyManager::class.java)
+        val supportsMicToggle = spm?.supportsSensorToggle(SensorPrivacyManager.Sensors.MICROPHONE) == true
+        if (!supportsMicToggle) return false
+        val audioManager = getSystemService(AudioManager::class.java)
+        return audioManager?.isMicrophoneMute == true
     }
 
     private fun openAssistantSettings() {
@@ -431,6 +444,7 @@ fun MainNavHost(
                 when (route) {
                     AppTab.Chat.route     -> AppTab.Chat
                     AppTab.Canvas.route   -> AppTab.Canvas
+                    AppTab.Cron.route     -> AppTab.Cron
                     AppTab.Settings.route -> AppTab.Settings
                     else                  -> AppTab.Home
                 }
@@ -520,6 +534,9 @@ fun MainNavHost(
                         nodeRuntime = nodeRuntime,
                         modifier = Modifier.fillMaxSize()
                     )
+                }
+                AppTab.Cron -> {
+                    com.openclaw.assistant.ui.cron.CronScreen()
                 }
                 AppTab.Settings -> {
                     if (showSettingsCredits) {

--- a/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
@@ -1010,6 +1010,83 @@ class NodeRuntime(context: Context) {
     }
   }
 
+  // ── Cron ────────────────────────────────────────────────────────────────────
+
+  data class CronJob(
+    val id: String,
+    val name: String,
+    val schedule: String,
+    val command: String,
+    val enabled: Boolean,
+    val lastRun: String? = null,
+    val nextRun: String? = null,
+  )
+
+  suspend fun listCronJobs(): List<CronJob> {
+    val res = operatorSession.request("cron.list", "{}")
+    val root = json.parseToJsonElement(res).asObjectOrNull() ?: return emptyList()
+    val arr = root["jobs"] as? JsonArray ?: return emptyList()
+    return arr.mapNotNull { el ->
+      val obj = el as? JsonObject ?: return@mapNotNull null
+      val id = (obj["id"] as? JsonPrimitive)?.content ?: return@mapNotNull null
+      CronJob(
+        id       = id,
+        name     = (obj["name"] as? JsonPrimitive)?.content ?: id,
+        schedule = (obj["schedule"] as? JsonPrimitive)?.content ?: "",
+        command  = (obj["command"] as? JsonPrimitive)?.content ?: "",
+        enabled  = (obj["enabled"] as? JsonPrimitive)?.content?.toBooleanStrictOrNull() ?: true,
+        lastRun  = (obj["lastRun"] as? JsonPrimitive)?.content,
+        nextRun  = (obj["nextRun"] as? JsonPrimitive)?.content,
+      )
+    }
+  }
+
+  suspend fun createCronJob(name: String, schedule: String, command: String, enabled: Boolean): CronJob {
+    val params = buildJsonObject {
+      put("name", JsonPrimitive(name))
+      put("schedule", JsonPrimitive(schedule))
+      put("command", JsonPrimitive(command))
+      put("enabled", JsonPrimitive(enabled))
+    }
+    val res = operatorSession.request("cron.create", params.toString())
+    val root = json.parseToJsonElement(res).asObjectOrNull()
+    val obj = (root?.get("job") as? JsonObject) ?: root ?: throw IllegalStateException("invalid response")
+    val id = (obj["id"] as? JsonPrimitive)?.content ?: throw IllegalStateException("missing id")
+    return CronJob(
+      id       = id,
+      name     = (obj["name"] as? JsonPrimitive)?.content ?: name,
+      schedule = (obj["schedule"] as? JsonPrimitive)?.content ?: schedule,
+      command  = (obj["command"] as? JsonPrimitive)?.content ?: command,
+      enabled  = (obj["enabled"] as? JsonPrimitive)?.content?.toBooleanStrictOrNull() ?: enabled,
+      lastRun  = (obj["lastRun"] as? JsonPrimitive)?.content,
+      nextRun  = (obj["nextRun"] as? JsonPrimitive)?.content,
+    )
+  }
+
+  suspend fun updateCronJob(id: String, name: String, schedule: String, command: String, enabled: Boolean): Boolean {
+    return try {
+      val params = buildJsonObject {
+        put("id", JsonPrimitive(id))
+        put("name", JsonPrimitive(name))
+        put("schedule", JsonPrimitive(schedule))
+        put("command", JsonPrimitive(command))
+        put("enabled", JsonPrimitive(enabled))
+      }
+      operatorSession.request("cron.update", params.toString())
+      true
+    } catch (_: Throwable) { false }
+  }
+
+  suspend fun deleteCronJob(id: String): Boolean {
+    return try {
+      val params = buildJsonObject { put("id", JsonPrimitive(id)) }
+      operatorSession.request("cron.delete", params.toString())
+      true
+    } catch (_: Throwable) { false }
+  }
+
+  // ── Camera flash / HUD ───────────────────────────────────────────────────────
+
   private fun triggerCameraFlash() {
     // Token is used as a pulse trigger; value doesn't matter as long as it changes.
     _cameraFlashToken.value = SystemClock.elapsedRealtimeNanos()

--- a/app/src/main/java/com/openclaw/assistant/ui/cron/CronScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/cron/CronScreen.kt
@@ -1,0 +1,372 @@
+package com.openclaw.assistant.ui.cron
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.openclaw.assistant.R
+import com.openclaw.assistant.node.NodeRuntime
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CronScreen() {
+    val viewModel: CronViewModel = viewModel()
+    val uiState by viewModel.uiState.collectAsState()
+    val isConnected by viewModel.isConnected.collectAsState()
+
+    var showAddEditDialog by rememberSaveable { mutableStateOf(false) }
+    var editTarget by remember { mutableStateOf<NodeRuntime.CronJob?>(null) }
+    var deleteTarget by remember { mutableStateOf<NodeRuntime.CronJob?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Refresh when connection state changes to connected
+    LaunchedEffect(isConnected) {
+        if (isConnected) viewModel.refresh()
+        else viewModel.refresh() // triggers Disconnected state
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.cron_title)) },
+                actions = {
+                    IconButton(onClick = { viewModel.refresh() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.cron_refresh))
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            if (isConnected) {
+                FloatingActionButton(onClick = {
+                    editTarget = null
+                    showAddEditDialog = true
+                }) {
+                    Icon(Icons.Default.Add, contentDescription = stringResource(R.string.cron_add))
+                }
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            when (val state = uiState) {
+                is CronUiState.Disconnected -> CronDisconnectedContent()
+                is CronUiState.Loading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+                is CronUiState.Error -> {
+                    CronErrorContent(
+                        message = state.message,
+                        onRetry = { viewModel.refresh() }
+                    )
+                }
+                is CronUiState.Success -> {
+                    if (state.jobs.isEmpty()) {
+                        CronEmptyContent(
+                            onAdd = {
+                                editTarget = null
+                                showAddEditDialog = true
+                            }
+                        )
+                    } else {
+                        LazyColumn(
+                            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                            modifier = Modifier.fillMaxSize()
+                        ) {
+                            items(state.jobs, key = { it.id }) { job ->
+                                CronJobCard(
+                                    job = job,
+                                    onEdit = {
+                                        editTarget = job
+                                        showAddEditDialog = true
+                                    },
+                                    onDelete = { deleteTarget = job },
+                                    onToggleEnabled = { enabled ->
+                                        viewModel.update(
+                                            id = job.id,
+                                            name = job.name,
+                                            schedule = job.schedule,
+                                            command = job.command,
+                                            enabled = enabled
+                                        )
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showAddEditDialog) {
+        CronAddEditDialog(
+            initial = editTarget,
+            onDismiss = { showAddEditDialog = false },
+            onSave = { name, schedule, command, enabled ->
+                val target = editTarget
+                if (target == null) {
+                    viewModel.create(name, schedule, command, enabled)
+                } else {
+                    viewModel.update(target.id, name, schedule, command, enabled)
+                }
+                showAddEditDialog = false
+            }
+        )
+    }
+
+    deleteTarget?.let { job ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text(stringResource(R.string.cron_delete_confirm_title)) },
+            text = { Text(stringResource(R.string.cron_delete_confirm_message, job.name)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.delete(job.id)
+                        deleteTarget = null
+                    },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Text(stringResource(R.string.cron_delete))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteTarget = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun CronDisconnectedContent() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(32.dp)) {
+            Icon(
+                Icons.Default.CloudOff,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(R.string.cron_not_connected),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun CronErrorContent(message: String, onRetry: () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(32.dp)) {
+            Icon(
+                Icons.Default.ErrorOutline,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.error
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onRetry) {
+                Text(stringResource(R.string.retry))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CronEmptyContent(onAdd: () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(32.dp)) {
+            Icon(
+                Icons.Default.Schedule,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(R.string.cron_empty),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onAdd) {
+                Icon(Icons.Default.Add, contentDescription = null)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(R.string.cron_add))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CronJobCard(
+    job: NodeRuntime.CronJob,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    onToggleEnabled: (Boolean) -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        )
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = job.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.weight(1f)
+                )
+                Switch(
+                    checked = job.enabled,
+                    onCheckedChange = onToggleEnabled
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = job.schedule,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.primary
+            )
+            if (job.command.isNotBlank()) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = job.command,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2
+                )
+            }
+            job.nextRun?.let { nextRun ->
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = stringResource(R.string.cron_next_run, nextRun),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                IconButton(onClick = onEdit) {
+                    Icon(
+                        Icons.Default.Edit,
+                        contentDescription = stringResource(R.string.cron_edit),
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        Icons.Default.Delete,
+                        contentDescription = stringResource(R.string.cron_delete),
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CronAddEditDialog(
+    initial: NodeRuntime.CronJob?,
+    onDismiss: () -> Unit,
+    onSave: (name: String, schedule: String, command: String, enabled: Boolean) -> Unit,
+) {
+    var name by rememberSaveable { mutableStateOf(initial?.name ?: "") }
+    var schedule by rememberSaveable { mutableStateOf(initial?.schedule ?: "") }
+    var command by rememberSaveable { mutableStateOf(initial?.command ?: "") }
+    var enabled by rememberSaveable { mutableStateOf(initial?.enabled ?: true) }
+
+    val isValid = name.isNotBlank() && schedule.isNotBlank()
+    val titleRes = if (initial == null) R.string.cron_add else R.string.cron_edit
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(titleRes)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(stringResource(R.string.cron_name)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = schedule,
+                    onValueChange = { schedule = it },
+                    label = { Text(stringResource(R.string.cron_schedule)) },
+                    placeholder = { Text("*/5 * * * *", fontFamily = FontFamily.Monospace) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = command,
+                    onValueChange = { command = it },
+                    label = { Text(stringResource(R.string.cron_command)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(stringResource(R.string.cron_enabled), style = MaterialTheme.typography.bodyLarge)
+                    Switch(checked = enabled, onCheckedChange = { enabled = it })
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onSave(name.trim(), schedule.trim(), command.trim(), enabled) },
+                enabled = isValid
+            ) {
+                Text(stringResource(R.string.cron_save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/openclaw/assistant/ui/cron/CronViewModel.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/cron/CronViewModel.kt
@@ -1,0 +1,69 @@
+package com.openclaw.assistant.ui.cron
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.openclaw.assistant.OpenClawApplication
+import com.openclaw.assistant.node.NodeRuntime
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+sealed class CronUiState {
+    object Disconnected : CronUiState()
+    object Loading : CronUiState()
+    data class Success(val jobs: List<NodeRuntime.CronJob>) : CronUiState()
+    data class Error(val message: String) : CronUiState()
+}
+
+class CronViewModel(app: Application) : AndroidViewModel(app) {
+
+    private val runtime: NodeRuntime = (app as OpenClawApplication).nodeRuntime
+
+    private val _uiState = MutableStateFlow<CronUiState>(CronUiState.Disconnected)
+    val uiState: StateFlow<CronUiState> = _uiState.asStateFlow()
+
+    val isConnected = runtime.isConnected
+
+    fun refresh() {
+        if (!runtime.isConnected.value) {
+            _uiState.value = CronUiState.Disconnected
+            return
+        }
+        viewModelScope.launch {
+            _uiState.value = CronUiState.Loading
+            try {
+                val jobs = runtime.listCronJobs()
+                _uiState.value = CronUiState.Success(jobs)
+            } catch (e: Throwable) {
+                _uiState.value = CronUiState.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    fun create(name: String, schedule: String, command: String, enabled: Boolean) {
+        viewModelScope.launch {
+            try {
+                runtime.createCronJob(name, schedule, command, enabled)
+                refresh()
+            } catch (e: Throwable) {
+                _uiState.value = CronUiState.Error(e.message ?: "Failed to create")
+            }
+        }
+    }
+
+    fun update(id: String, name: String, schedule: String, command: String, enabled: Boolean) {
+        viewModelScope.launch {
+            runtime.updateCronJob(id, name, schedule, command, enabled)
+            refresh()
+        }
+    }
+
+    fun delete(id: String) {
+        viewModelScope.launch {
+            runtime.deleteCronJob(id)
+            refresh()
+        }
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -519,7 +519,24 @@ Weitere Informationen finden Sie auf der offiziellen Website von VOICEVOX.</stri
     <string name="tab_nav_home">Startseite</string>
     <string name="tab_nav_chat">Chat</string>
     <string name="tab_nav_canvas">Canvas</string>
+    <string name="tab_nav_cron">Cron</string>
     <string name="tab_nav_settings">Einstellungen</string>
+    <!-- Cron -->
+    <string name="cron_title">Cron</string>
+    <string name="cron_refresh">Aktualisieren</string>
+    <string name="cron_add">Job hinzufügen</string>
+    <string name="cron_edit">Bearbeiten</string>
+    <string name="cron_delete">Löschen</string>
+    <string name="cron_name">Name</string>
+    <string name="cron_schedule">Zeitplan</string>
+    <string name="cron_command">Befehl</string>
+    <string name="cron_enabled">Aktiviert</string>
+    <string name="cron_empty">Keine Cron-Jobs. Tippe auf +, um einen hinzuzufügen.</string>
+    <string name="cron_not_connected">Nicht mit dem Gateway verbunden</string>
+    <string name="cron_delete_confirm_title">Job löschen</string>
+    <string name="cron_delete_confirm_message">„%1$s" löschen?</string>
+    <string name="cron_save">Speichern</string>
+    <string name="cron_next_run">Nächste: %1$s</string>
     <string name="attach_file">Datei anhängen</string>
     <string name="file">Datei</string>
     <string name="image_attachment">Bildanhang</string>
@@ -549,4 +566,8 @@ Weitere Informationen finden Sie auf der offiziellen Website von VOICEVOX.</stri
     <string name="action_collapse">Einklappen</string>
     <string name="action_expand">Ausklappen</string>
     <string name="action_refresh">Aktualisieren</string>
+
+    <!-- Microphone privacy toggle blocked -->
+    <string name="error_mic_privacy_title">Mikrofonzugriff blockiert</string>
+    <string name="error_mic_privacy_message">Der Mikrofon-Datenschutzschalter Ihres Geräts ist deaktiviert. Aktivieren Sie ihn unter Einstellungen &gt; Datenschutz &gt; Mikrofon.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -520,7 +520,24 @@ Para más detalles, consulta el sitio oficial de VOICEVOX.</string>
     <string name="tab_nav_home">Inicio</string>
     <string name="tab_nav_chat">Chat</string>
     <string name="tab_nav_canvas">Canvas</string>
+    <string name="tab_nav_cron">Cron</string>
     <string name="tab_nav_settings">Ajustes</string>
+    <!-- Cron -->
+    <string name="cron_title">Cron</string>
+    <string name="cron_refresh">Actualizar</string>
+    <string name="cron_add">Añadir tarea</string>
+    <string name="cron_edit">Editar</string>
+    <string name="cron_delete">Eliminar</string>
+    <string name="cron_name">Nombre</string>
+    <string name="cron_schedule">Horario</string>
+    <string name="cron_command">Comando</string>
+    <string name="cron_enabled">Habilitado</string>
+    <string name="cron_empty">No hay tareas cron. Pulsa + para añadir una.</string>
+    <string name="cron_not_connected">No conectado al gateway</string>
+    <string name="cron_delete_confirm_title">Eliminar tarea</string>
+    <string name="cron_delete_confirm_message">¿Eliminar «%1$s»?</string>
+    <string name="cron_save">Guardar</string>
+    <string name="cron_next_run">Próxima: %1$s</string>
     <string name="attach_file">Adjuntar archivo</string>
     <string name="file">Archivo</string>
     <string name="image_attachment">Imagen adjunta</string>
@@ -550,4 +567,8 @@ Para más detalles, consulta el sitio oficial de VOICEVOX.</string>
     <string name="action_collapse">Contraer</string>
     <string name="action_expand">Expandir</string>
     <string name="action_refresh">Actualizar</string>
+
+    <!-- Microphone privacy toggle blocked -->
+    <string name="error_mic_privacy_title">Acceso al micrófono bloqueado</string>
+    <string name="error_mic_privacy_message">El interruptor de privacidad del micrófono de tu dispositivo está desactivado. Actívalo en Ajustes &gt; Privacidad &gt; Micrófono.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -520,7 +520,24 @@ Pour plus de détails, consultez le site officiel de VOICEVOX.</string>
     <string name="tab_nav_home">Accueil</string>
     <string name="tab_nav_chat">Chat</string>
     <string name="tab_nav_canvas">Canvas</string>
+    <string name="tab_nav_cron">Cron</string>
     <string name="tab_nav_settings">Paramètres</string>
+    <!-- Cron -->
+    <string name="cron_title">Cron</string>
+    <string name="cron_refresh">Actualiser</string>
+    <string name="cron_add">Ajouter une tâche</string>
+    <string name="cron_edit">Modifier</string>
+    <string name="cron_delete">Supprimer</string>
+    <string name="cron_name">Nom</string>
+    <string name="cron_schedule">Planification</string>
+    <string name="cron_command">Commande</string>
+    <string name="cron_enabled">Activé</string>
+    <string name="cron_empty">Aucune tâche cron. Appuyez sur + pour en ajouter une.</string>
+    <string name="cron_not_connected">Non connecté à la passerelle</string>
+    <string name="cron_delete_confirm_title">Supprimer la tâche</string>
+    <string name="cron_delete_confirm_message">Supprimer «\u00a0%1$s\u00a0»\u00a0?</string>
+    <string name="cron_save">Enregistrer</string>
+    <string name="cron_next_run">Prochain\u00a0: %1$s</string>
     <string name="attach_file">Joindre un fichier</string>
     <string name="file">Fichier</string>
     <string name="image_attachment">Pièce jointe image</string>
@@ -550,4 +567,8 @@ Pour plus de détails, consultez le site officiel de VOICEVOX.</string>
     <string name="action_collapse">Réduire</string>
     <string name="action_expand">Développer</string>
     <string name="action_refresh">Actualiser</string>
+
+    <!-- Microphone privacy toggle blocked -->
+    <string name="error_mic_privacy_title">Accès au microphone bloqué</string>
+    <string name="error_mic_privacy_message">Le commutateur de confidentialité du microphone de votre appareil est désactivé. Activez-le dans Paramètres &gt; Confidentialité &gt; Microphone.</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -520,7 +520,24 @@
     <string name="tab_nav_home">होम</string>
     <string name="tab_nav_chat">चैट</string>
     <string name="tab_nav_canvas">Canvas</string>
+    <string name="tab_nav_cron">Cron</string>
     <string name="tab_nav_settings">सेटिंग्स</string>
+    <!-- Cron -->
+    <string name="cron_title">Cron</string>
+    <string name="cron_refresh">रीफ्रेश</string>
+    <string name="cron_add">कार्य जोड़ें</string>
+    <string name="cron_edit">संपादित करें</string>
+    <string name="cron_delete">हटाएं</string>
+    <string name="cron_name">नाम</string>
+    <string name="cron_schedule">शेड्यूल</string>
+    <string name="cron_command">कमांड</string>
+    <string name="cron_enabled">सक्षम</string>
+    <string name="cron_empty">कोई Cron कार्य नहीं। जोड़ने के लिए + दबाएं।</string>
+    <string name="cron_not_connected">गेटवे से कनेक्ट नहीं है</string>
+    <string name="cron_delete_confirm_title">कार्य हटाएं</string>
+    <string name="cron_delete_confirm_message">«%1$s» हटाएं?</string>
+    <string name="cron_save">सहेजें</string>
+    <string name="cron_next_run">अगला: %1$s</string>
     <string name="attach_file">फ़ाइल संलग्न करें</string>
     <string name="file">फ़ाइल</string>
     <string name="image_attachment">छवि अनुलग्नक</string>
@@ -550,4 +567,8 @@
     <string name="action_collapse">संकुचित करें</string>
     <string name="action_expand">विस्तारित करें</string>
     <string name="action_refresh">ताज़ा करें</string>
+
+    <!-- Microphone privacy toggle blocked -->
+    <string name="error_mic_privacy_title">माइक्रोफ़ोन एक्सेस अवरुद्ध है</string>
+    <string name="error_mic_privacy_message">आपके डिवाइस का माइक्रोफ़ोन गोपनीयता स्विच बंद है। इसे सेटिंग &gt; गोपनीयता &gt; माइक्रोफ़ोन में चालू करें।</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -523,7 +523,24 @@
     <string name="tab_nav_home">ホーム</string>
     <string name="tab_nav_chat">チャット</string>
     <string name="tab_nav_canvas">Canvas</string>
+    <string name="tab_nav_cron">Cron</string>
     <string name="tab_nav_settings">設定</string>
+    <!-- Cron -->
+    <string name="cron_title">Cron</string>
+    <string name="cron_refresh">更新</string>
+    <string name="cron_add">ジョブを追加</string>
+    <string name="cron_edit">編集</string>
+    <string name="cron_delete">削除</string>
+    <string name="cron_name">名前</string>
+    <string name="cron_schedule">スケジュール</string>
+    <string name="cron_command">コマンド</string>
+    <string name="cron_enabled">有効</string>
+    <string name="cron_empty">Cronジョブがありません。＋で追加してください。</string>
+    <string name="cron_not_connected">Gatewayに接続されていません</string>
+    <string name="cron_delete_confirm_title">ジョブを削除</string>
+    <string name="cron_delete_confirm_message">「%1$s」を削除しますか？</string>
+    <string name="cron_save">保存</string>
+    <string name="cron_next_run">次回: %1$s</string>
     <string name="attach_file">ファイルを添付</string>
     <string name="file">ファイル</string>
     <string name="image_attachment">画像添付</string>
@@ -552,4 +569,8 @@
     <string name="action_collapse">折りたたむ</string>
     <string name="action_expand">展開する</string>
     <string name="action_refresh">更新</string>
+
+    <!-- Microphone privacy toggle blocked -->
+    <string name="error_mic_privacy_title">マイクのアクセスがブロックされています</string>
+    <string name="error_mic_privacy_message">システムのマイクプライバシートグルがオフになっています。設定 &gt; プライバシー &gt; マイクから有効にしてください。</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -520,7 +520,24 @@
     <string name="tab_nav_home">Главная</string>
     <string name="tab_nav_chat">Чат</string>
     <string name="tab_nav_canvas">Canvas</string>
+    <string name="tab_nav_cron">Cron</string>
     <string name="tab_nav_settings">Настройки</string>
+    <!-- Cron -->
+    <string name="cron_title">Cron</string>
+    <string name="cron_refresh">Обновить</string>
+    <string name="cron_add">Добавить задание</string>
+    <string name="cron_edit">Изменить</string>
+    <string name="cron_delete">Удалить</string>
+    <string name="cron_name">Название</string>
+    <string name="cron_schedule">Расписание</string>
+    <string name="cron_command">Команда</string>
+    <string name="cron_enabled">Включено</string>
+    <string name="cron_empty">Нет заданий Cron. Нажмите +, чтобы добавить.</string>
+    <string name="cron_not_connected">Нет подключения к шлюзу</string>
+    <string name="cron_delete_confirm_title">Удалить задание</string>
+    <string name="cron_delete_confirm_message">Удалить «%1$s»?</string>
+    <string name="cron_save">Сохранить</string>
+    <string name="cron_next_run">Следующий: %1$s</string>
     <string name="attach_file">Прикрепить файл</string>
     <string name="file">Файл</string>
     <string name="image_attachment">Вложение изображения</string>
@@ -550,4 +567,8 @@
     <string name="action_collapse">Свернуть</string>
     <string name="action_expand">Развернуть</string>
     <string name="action_refresh">Обновить</string>
+
+    <!-- Microphone privacy toggle blocked -->
+    <string name="error_mic_privacy_title">Доступ к микрофону заблокирован</string>
+    <string name="error_mic_privacy_message">Переключатель конфиденциальности микрофона на вашем устройстве отключён. Включите его в Настройки &gt; Конфиденциальность &gt; Микрофон.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -520,7 +520,24 @@
     <string name="tab_nav_home">主页</string>
     <string name="tab_nav_chat">聊天</string>
     <string name="tab_nav_canvas">Canvas</string>
+    <string name="tab_nav_cron">Cron</string>
     <string name="tab_nav_settings">设置</string>
+    <!-- Cron -->
+    <string name="cron_title">Cron</string>
+    <string name="cron_refresh">刷新</string>
+    <string name="cron_add">添加任务</string>
+    <string name="cron_edit">编辑</string>
+    <string name="cron_delete">删除</string>
+    <string name="cron_name">名称</string>
+    <string name="cron_schedule">计划</string>
+    <string name="cron_command">命令</string>
+    <string name="cron_enabled">启用</string>
+    <string name="cron_empty">没有 Cron 任务。点击 + 添加。</string>
+    <string name="cron_not_connected">未连接到网关</string>
+    <string name="cron_delete_confirm_title">删除任务</string>
+    <string name="cron_delete_confirm_message">删除「%1$s」？</string>
+    <string name="cron_save">保存</string>
+    <string name="cron_next_run">下次: %1$s</string>
     <string name="attach_file">附加文件</string>
     <string name="file">文件</string>
     <string name="image_attachment">图片附件</string>
@@ -550,4 +567,8 @@
     <string name="action_collapse">折叠</string>
     <string name="action_expand">展开</string>
     <string name="action_refresh">刷新</string>
+
+    <!-- Microphone privacy toggle blocked -->
+    <string name="error_mic_privacy_title">麦克风访问被阻止</string>
+    <string name="error_mic_privacy_message">您的设备麦克风隐私开关已关闭。请在设置 &gt; 隐私 &gt; 麦克风中开启。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -519,7 +519,24 @@
     <string name="tab_nav_home">首頁</string>
     <string name="tab_nav_chat">聊天</string>
     <string name="tab_nav_canvas">Canvas</string>
+    <string name="tab_nav_cron">Cron</string>
     <string name="tab_nav_settings">設定</string>
+    <!-- Cron -->
+    <string name="cron_title">Cron</string>
+    <string name="cron_refresh">重新整理</string>
+    <string name="cron_add">新增任務</string>
+    <string name="cron_edit">編輯</string>
+    <string name="cron_delete">刪除</string>
+    <string name="cron_name">名稱</string>
+    <string name="cron_schedule">排程</string>
+    <string name="cron_command">指令</string>
+    <string name="cron_enabled">啟用</string>
+    <string name="cron_empty">沒有 Cron 任務。點選 + 新增。</string>
+    <string name="cron_not_connected">未連接到閘道器</string>
+    <string name="cron_delete_confirm_title">刪除任務</string>
+    <string name="cron_delete_confirm_message">刪除「%1$s」？</string>
+    <string name="cron_save">儲存</string>
+    <string name="cron_next_run">下次: %1$s</string>
     <string name="attach_file">附加檔案</string>
     <string name="file">檔案</string>
     <string name="image_attachment">圖片附件</string>
@@ -549,4 +566,8 @@
     <string name="action_collapse">折疊</string>
     <string name="action_expand">展開</string>
     <string name="action_refresh">重新整理</string>
+
+    <!-- Microphone privacy toggle blocked -->
+    <string name="error_mic_privacy_title">麥克風存取被封鎖</string>
+    <string name="error_mic_privacy_message">您的裝置麥克風隱私開關已關閉。請至設定 &gt; 隱私 &gt; 麥克風開啟。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -607,7 +607,24 @@
     <string name="tab_nav_home">Home</string>
     <string name="tab_nav_chat">Chat</string>
     <string name="tab_nav_canvas">Canvas</string>
+    <string name="tab_nav_cron">Cron</string>
     <string name="tab_nav_settings">Settings</string>
+    <!-- Cron -->
+    <string name="cron_title">Cron</string>
+    <string name="cron_refresh">Refresh</string>
+    <string name="cron_add">Add Job</string>
+    <string name="cron_edit">Edit</string>
+    <string name="cron_delete">Delete</string>
+    <string name="cron_name">Name</string>
+    <string name="cron_schedule">Schedule</string>
+    <string name="cron_command">Command</string>
+    <string name="cron_enabled">Enabled</string>
+    <string name="cron_empty">No cron jobs. Tap + to add one.</string>
+    <string name="cron_not_connected">Not connected to gateway</string>
+    <string name="cron_delete_confirm_title">Delete Job</string>
+    <string name="cron_delete_confirm_message">Delete \"%1$s\"?</string>
+    <string name="cron_save">Save</string>
+    <string name="cron_next_run">Next: %1$s</string>
     <string name="attach_file">Attach file</string>
     <string name="file">File</string>
     <string name="image_attachment">Image attachment</string>
@@ -635,4 +652,8 @@
     <string name="action_collapse">Collapse</string>
     <string name="action_expand">Expand</string>
     <string name="action_refresh">Refresh</string>
+
+    <!-- Microphone privacy toggle blocked -->
+    <string name="error_mic_privacy_title">Microphone Access Blocked</string>
+    <string name="error_mic_privacy_message">Your device\'s microphone privacy toggle is off. Enable it in Settings &gt; Privacy &gt; Microphone.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a new Cron tab with a Compose screen for listing, creating, updating, enabling, and deleting gateway cron jobs
- extend `NodeRuntime` with `cron.list`, `cron.create`, `cron.update`, and `cron.delete` helpers used by the new UI
- handle blocked microphone access more safely by checking the public SDK's microphone mute state on devices that support the privacy toggle
- add localized strings for the Cron UI and the microphone privacy dialog

## Why
- users need a first-party way to manage gateway cron jobs from the Android app
- starting voice input while microphone access is blocked should fail more clearly instead of behaving like audio permission is available
- the original microphone privacy implementation relied on a non-public `SensorPrivacyManager` API and did not compile against this project's Android SDK stubs

## Impact
- a new `Cron` entry appears in the main navigation when the app is running
- connected users can manage cron jobs without leaving the app
- chat voice input now warns before listening when the microphone is effectively blocked by system privacy controls
- the permissions summary treats microphone access as unavailable when the privacy toggle mutes the mic

## Validation
- `./gradlew testStandardDebugUnitTest`
