### PR TITLE
fix: guard FirebaseCrashlytics calls with FIREBASE_ENABLED check

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
+++ b/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
@@ -2,6 +2,7 @@ package com.openclaw.assistant.api
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.gson.Gson
+import com.openclaw.assistant.BuildConfig
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import kotlinx.coroutines.Dispatchers
@@ -134,7 +135,7 @@ class OpenClawClient() {
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (e: Exception) {
-            if (!isTransientNetworkError(e)) {
+            if (!isTransientNetworkError(e) && BuildConfig.FIREBASE_ENABLED) {
                 FirebaseCrashlytics.getInstance().recordException(e)
             }
             Result.failure(e)

--- a/app/src/main/java/com/openclaw/assistant/gateway/DeviceIdentity.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/DeviceIdentity.kt
@@ -5,6 +5,7 @@ import android.util.Base64
 import android.util.Log
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.crypto.tink.CleartextKeysetHandle
+import com.openclaw.assistant.BuildConfig
 import com.google.crypto.tink.JsonKeysetWriter
 import com.google.crypto.tink.KeyTemplates
 import com.google.crypto.tink.KeysetHandle
@@ -47,7 +48,7 @@ class DeviceIdentity(context: Context) {
             extractPublicKey(handle)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize: ${e.message}")
-            FirebaseCrashlytics.getInstance().recordException(e)
+            if (BuildConfig.FIREBASE_ENABLED) FirebaseCrashlytics.getInstance().recordException(e)
         }
     }
 
@@ -109,7 +110,7 @@ class DeviceIdentity(context: Context) {
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to extract public key: ${e.message}")
-            FirebaseCrashlytics.getInstance().recordException(e)
+            if (BuildConfig.FIREBASE_ENABLED) FirebaseCrashlytics.getInstance().recordException(e)
         }
     }
 
@@ -122,7 +123,7 @@ class DeviceIdentity(context: Context) {
             )
         } catch (e: Exception) {
             Log.e(TAG, "Sign failed: ${e.message}")
-            FirebaseCrashlytics.getInstance().recordException(e)
+            if (BuildConfig.FIREBASE_ENABLED) FirebaseCrashlytics.getInstance().recordException(e)
             null
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -21,6 +21,7 @@ import androidx.core.content.ContextCompat
 import com.openclaw.assistant.MainActivity
 import com.openclaw.assistant.R
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.BuildConfig
 import com.openclaw.assistant.data.SettingsRepository
 import kotlinx.coroutines.*
 import org.vosk.Model
@@ -137,7 +138,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             if (isVoskCrash) {
                 Log.e(TAG, "Caught uncaught Vosk exception on thread ${thread.name}", throwable)
                 if (throwable is UnsatisfiedLinkError || throwable.cause is UnsatisfiedLinkError) {
-                    FirebaseCrashlytics.getInstance().recordException(throwable)
+                    if (BuildConfig.FIREBASE_ENABLED) FirebaseCrashlytics.getInstance().recordException(throwable)
                     getSharedPreferences("hotword_prefs", Context.MODE_PRIVATE)
                         .edit().putBoolean("vosk_unsupported", true).apply()
                     // Don't resume - device doesn't support Vosk
@@ -150,7 +151,7 @@ class HotwordService : Service(), VoskRecognitionListener {
                         }
                     }
                 } else {
-                    FirebaseCrashlytics.getInstance().recordException(throwable)
+                    if (BuildConfig.FIREBASE_ENABLED) FirebaseCrashlytics.getInstance().recordException(throwable)
                     speechService = null
                     android.os.Handler(android.os.Looper.getMainLooper()).post {
                         if (!isSessionActive) {
@@ -355,7 +356,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             } catch (e: UnsatisfiedLinkError) {
                 Log.e(TAG, "Vosk native library not supported on this device", e)
                 debugLog("Vosk: UnsatisfiedLinkError — native lib not supported")
-                FirebaseCrashlytics.getInstance().recordException(e)
+                if (BuildConfig.FIREBASE_ENABLED) FirebaseCrashlytics.getInstance().recordException(e)
                 prefs.edit()
                     .putBoolean("vosk_unsupported", true)
                     .putInt("vosk_unsupported_version", currentVersion)
@@ -363,7 +364,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             } catch (e: Exception) {
                 Log.e(TAG, "Init error", e)
                 debugLog("Vosk: init error — ${e.message}")
-                FirebaseCrashlytics.getInstance().recordException(e)
+                if (BuildConfig.FIREBASE_ENABLED) FirebaseCrashlytics.getInstance().recordException(e)
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
@@ -15,6 +15,7 @@ import android.os.Looper
 import android.util.Log
 import androidx.core.content.ContextCompat
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.BuildConfig
 
 /**
  * Voice Interaction Service
@@ -86,7 +87,7 @@ class OpenClawAssistantService : VoiceInteractionService() {
                 Log.e(TAG, "showSession() called immediately")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to call showSession immediately", e)
-                FirebaseCrashlytics.getInstance().recordException(e)
+                if (BuildConfig.FIREBASE_ENABLED) FirebaseCrashlytics.getInstance().recordException(e)
             }
         } else {
             Log.e(TAG, "Service not ready. Queuing showSession request.")
@@ -109,7 +110,7 @@ class OpenClawAssistantService : VoiceInteractionService() {
                 Log.e(TAG, "showSession() called from onReady (pending)")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to call pending showSession", e)
-                FirebaseCrashlytics.getInstance().recordException(e)
+                if (BuildConfig.FIREBASE_ENABLED) FirebaseCrashlytics.getInstance().recordException(e)
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
@@ -9,6 +9,7 @@ import android.speech.SpeechRecognizer
 import android.util.Log
 import android.view.LayoutInflater
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.BuildConfig
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -262,7 +263,7 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
                     currentSessionId?.let { settings.sessionId = it }
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to handle session", e)
-                    FirebaseCrashlytics.getInstance().recordException(e)
+                    if (BuildConfig.FIREBASE_ENABLED) FirebaseCrashlytics.getInstance().recordException(e)
                 }
             }
         }

--- a/app/src/main/java/com/openclaw/assistant/utils/UpdateChecker.kt
+++ b/app/src/main/java/com/openclaw/assistant/utils/UpdateChecker.kt
@@ -3,6 +3,7 @@ package com.openclaw.assistant.utils
 import android.util.Log
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.gson.Gson
+import com.openclaw.assistant.BuildConfig
 import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -69,7 +70,7 @@ object UpdateChecker {
             return@withContext null
         } catch (e: Exception) {
             Log.e(TAG, "Error checking for updates", e)
-            FirebaseCrashlytics.getInstance().recordException(e)
+            if (BuildConfig.FIREBASE_ENABLED) FirebaseCrashlytics.getInstance().recordException(e)
             return@withContext null
         }
     }


### PR DESCRIPTION
## Summary / 概要

**EN:** When `FIREBASE_ENABLED=false` (CI fork PRs that lack `google-services.json`), `FirebaseApp` is never initialized. Any exception caught in the app that reaches `FirebaseCrashlytics.getInstance().recordException(e)` would throw `IllegalStateException: Default FirebaseApp is not initialized`, causing a secondary crash inside the very catch block meant to handle the original error.

`OpenClawApplication.kt` already guards its Crashlytics call correctly with `if (BuildConfig.FIREBASE_ENABLED)`. This PR applies the same pattern to the remaining 6 files.

**JA:** `FIREBASE_ENABLED=false`（`google-services.json` を持たない fork PR の CI）のとき、`FirebaseApp` は初期化されません。`FirebaseCrashlytics.getInstance().recordException(e)` を呼ぶと `IllegalStateException: Default FirebaseApp is not initialized` がスローされ、本来エラーを処理するはずの catch ブロックで二重クラッシュが発生します。

`OpenClawApplication.kt` はすでに正しく `if (BuildConfig.FIREBASE_ENABLED)` でガードされていましたが、他の 6 ファイルに同じパターンを適用します。

## Changes / 変更内容

| File | Call sites fixed |
|------|-----------------|
| `api/OpenClawClient.kt` | 1 |
| `gateway/DeviceIdentity.kt` | 3 |
| `service/HotwordService.kt` | 4 |
| `service/OpenClawAssistantService.kt` | 2 |
| `service/OpenClawSession.kt` | 1 |
| `utils/UpdateChecker.kt` | 1 |
| **Total** | **12** |

Each unguarded call was changed from:
```kotlin
FirebaseCrashlytics.getInstance().recordException(e)
```
to:
```kotlin
if (BuildConfig.FIREBASE_ENABLED) FirebaseCrashlytics.getInstance().recordException(e)
```

## Test plan / テスト計画

- [ ] Build debug APK with `FIREBASE_ENABLED=false` and verify no crash when Crashlytics call sites are reached
- [ ] Build release APK (FIREBASE_ENABLED always true) — behavior unchanged
- [ ] CI passes on fork PR (the primary scenario this fix targets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)