### PR TITLE
🎨 Polish: Improve accessibility for chat indicators

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -736,7 +737,8 @@ fun ThinkingIndicator() {
             modifier = Modifier
                 .padding(vertical = 8.dp)
                 .background(MaterialTheme.colorScheme.surface, CircleShape)
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .semantics(mergeDescendants = true) {},
             verticalAlignment = Alignment.CenterVertically
         ) {
             CircularProgressIndicator(
@@ -765,7 +767,8 @@ fun SpeakingIndicator(onStop: () -> Unit) {
             modifier = Modifier
                 .padding(vertical = 8.dp)
                 .background(MaterialTheme.colorScheme.errorContainer, CircleShape)
-                .padding(horizontal = 12.dp, vertical = 6.dp),
+                .padding(horizontal = 12.dp, vertical = 6.dp)
+                .semantics(mergeDescendants = true) {},
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(Icons.Default.Mic, contentDescription = null, modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.onErrorContainer)


### PR DESCRIPTION
**What:** Added `Modifier.semantics(mergeDescendants = true) {}` to the `Row` layouts inside `ThinkingIndicator` and `SpeakingIndicator` in `ChatActivity.kt`.

**Why:** To improve accessibility. These indicators group a visual element (loading spinner or mic icon) with a text label ("Thinking" or "Speaking"). Without `mergeDescendants`, screen readers might read the elements as disjointed components or require multiple swipes to navigate past them.

**Impact:** Screen reader users (like TalkBack) will now hear a single, cohesive announcement when focusing on the indicator, making the UI more intuitive and easier to navigate. It also creates a larger, unified touch target for accessibility services.

**Measurement:** Verified via unit tests (`testStandardDebugUnitTest`) and lint checks (`lintStandardDebug`). Changes are isolated to the Compose modifier layer with zero impact on visual layout or standard interaction behavior.

---
*PR created automatically by Jules for task [12885481806764047065](https://jules.google.com/task/12885481806764047065) started by @yuga-hashimoto*