### PR TITLE
🧪 Regression Guard: Add service fallback stops on limit exceptions

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -53,6 +53,12 @@ class HotwordService : Service(), VoskRecognitionListener {
                 } else {
                     context.startService(intent)
                 }
+            } catch (e: IllegalStateException) {
+                Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
+                context.stopService(intent)
+            } catch (e: SecurityException) {
+                Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
+                context.stopService(intent)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -38,6 +38,12 @@ class SessionForegroundService : Service() {
                 } else {
                     context.startService(intent)
                 }
+            } catch (e: IllegalStateException) {
+                Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
+                context.stopService(intent)
+            } catch (e: SecurityException) {
+                Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
+                context.stopService(intent)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
**What:** Added explicit fallback calls to `context.stopService(intent)` when `startForegroundService` / `startService` throws an `IllegalStateException` or `SecurityException` inside `HotwordService` and `SessionForegroundService`. Retained the original generic `Exception` catch block to prevent novel crashes.

**Why:** When Android 8+ limits background execution, catching the exception prevents a crash, but leaving the service in an undefined partial state can cause later lifecycle bugs or prevent future restarts. Explicitly calling `stopService` ensures the OS cleans up any dangling bindings or state related to the failed start intent.

**Impact:** Improves stability of background services and hotword triggers by ensuring a clean slate if a background start attempt is blocked by the OS.

**Measurement:** Confirmed through local unit tests and lint checks (`./gradlew app:testStandardDebugUnitTest app:lintStandardDebug`) that the changes compile safely and do not violate any existing service behaviors.

---
*PR created automatically by Jules for task [7705365393556708452](https://jules.google.com/task/7705365393556708452) started by @yuga-hashimoto*