### PR TITLE
🔄 Upstream Parity: correct App Actions prompt parameter typing

### DIFF
--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -11,7 +11,7 @@
             <parameter
                 android:name="prompt"
                 android:key="prompt"
-                android:mimeType="text/*"
+                android:mimeType="https://schema.org/Text"
                 android:required="true" />
         </intent>
     </capability>


### PR DESCRIPTION
- Source: Upstream commit `90fcc1f551`
- Why: Corrects App Actions prompt parameter typing constraints from generic `text/*` to Google Assistant BII standard `https://schema.org/Text`.
- Adaptation: Applied direct change in `app/src/main/res/xml/shortcuts.xml`.
- Excluded upstream behavior: None (direct parity).
- Verification: Passed native Android lint and unit tests (`./gradlew app:lintStandardDebug` and `app:testStandardDebugUnitTest`).

---
*PR created automatically by Jules for task [15981768010150443966](https://jules.google.com/task/15981768010150443966) started by @yuga-hashimoto*