### PR TITLE
🎨 Palette: Fix hardcoded string on Refresh Agents icon button

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -866,7 +866,7 @@ fun SettingsScreen(
                                                         isFetchingAgents = false
                                                     }
                                                 }) {
-                                                    Icon(Icons.Default.Refresh, contentDescription = "Refresh Agents")
+                                                    Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.action_refresh))
                                                 }
                                             }
                                             ExposedDropdownMenuDefaults.TrailingIcon(expanded = showAgentMenu)
@@ -917,7 +917,7 @@ fun SettingsScreen(
                                                 isFetchingAgents = false
                                             }
                                         }) {
-                                            Icon(Icons.Default.Refresh, contentDescription = "Refresh Agents")
+                                            Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.action_refresh))
                                         }
                                     }
                                 },


### PR DESCRIPTION
💡 What: Replaced hardcoded english string "Refresh Agents" in SettingsActivity with the existing `R.string.action_refresh` localized string resource for the icon description.
🎯 Why: Ensures screen readers announce the correct translated accessibility label for users depending on their device locale setting, rather than forcing english.
📸 Before/After: Visual UI identical, talkback output localized.
♿ Accessibility: Improves accessibility / internationalization support for the app.

---
*PR created automatically by Jules for task [10774502625906007289](https://jules.google.com/task/10774502625906007289) started by @yuga-hashimoto*