### PR TITLE
🛡️ Sentinel: Disable cleartext traffic globally

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,7 +89,6 @@
         android:name="com.openclaw.assistant.OpenClawApplication"
         android:allowBackup="false"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>

--- a/wear/src/main/res/xml/network_security_config.xml
+++ b/wear/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>


### PR DESCRIPTION
**What**: Disabled cleartext traffic globally for both the app and wear modules by explicitly setting `cleartextTrafficPermitted="false"` in their respective `network_security_config.xml` files and removing the `android:usesCleartextTraffic="true"` override from the app's `AndroidManifest.xml`.

**Why**: To address priority 1 of the Sentinel directive (insecure transport / cleartext traffic). While `NetworkUtils.kt` limits cleartext (HTTP/WS) usage to private/local networks, the global application config was universally permitting cleartext traffic, which risks accidental external unencrypted connections (MITM vulnerabilities) if other components bypass the utility checks. The network security config is the proper place to enforce OS-level HTTPS requirements.

**Impact**: Enhances the overall security posture by strictly requiring TLS/HTTPS for all external communication.

**Measurement**: Verified via Gradle standard debug test and linting runs (app module natively validated).

---
*PR created automatically by Jules for task [1026263218302573227](https://jules.google.com/task/1026263218302573227) started by @yuga-hashimoto*