### PR TITLE
🧪 Regression Guard: Fix background service start crashes

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
+++ b/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
@@ -58,6 +58,12 @@ class MediaButtonReceiver : BroadcastReceiver() {
                         setPackage(context.packageName)
                     }
                     context.sendBroadcast(broadcastIntent)
+                } catch (e: Exception) {
+                    Log.w(TAG, "Background start failed, falling back to broadcast", e)
+                    val broadcastIntent = Intent(OpenClawAssistantService.ACTION_SHOW_ASSISTANT).apply {
+                        setPackage(context.packageName)
+                    }
+                    context.sendBroadcast(broadcastIntent)
                 }
                 // Absorb the event so it doesn't reach the media player
                 abortBroadcast()

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -672,6 +672,12 @@ class HotwordService : Service(), VoskRecognitionListener {
                     setPackage(packageName)
                 }
                 sendBroadcast(broadcastIntent)
+            } catch (e: Exception) {
+                Log.w(TAG, "Background start failed, falling back to broadcast", e)
+                val broadcastIntent = Intent(OpenClawAssistantService.ACTION_SHOW_ASSISTANT).apply {
+                    setPackage(packageName)
+                }
+                sendBroadcast(broadcastIntent)
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -289,6 +289,9 @@ class NodeForegroundService : Service() {
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         context.stopService(intent)
+      } catch (e: Exception) {
+        android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
+        context.stopService(intent)
       }
     }
 


### PR DESCRIPTION
**Source:** Internal stability review (Regression Guard persona).

**Why:** Android 8+ strictly limits background execution. While wrapping `startService` in a `try-catch` block prevents immediate crashes from known exceptions (like `IllegalStateException` or `SecurityException`), new OS versions or OEM-specific modifications can throw other unexpected exceptions (e.g., `ForegroundServiceStartNotAllowedException` on Android 12+). By expanding the fallback logic to catch a generic `Exception`, we ensure that the application consistently falls back to sending a broadcast or stopping the service gracefully instead of crashing completely and silently failing to activate the assistant.

**Verification:** Native tests (`app:testStandardDebugUnitTest`) and lint checks (`app:lintStandardDebug`) were executed successfully. Code inspection confirms the generic catch blocks correctly wrap the `startService` calls and fallback logic in `MediaButtonReceiver.kt`, `HotwordService.kt`, and `NodeForegroundService.kt`.

---
*PR created automatically by Jules for task [1233663718500001604](https://jules.google.com/task/1233663718500001604) started by @yuga-hashimoto*