### PR TITLE
🔄 Upstream Parity: correct App Actions prompt parameter typing

### DIFF
--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -11,7 +11,7 @@
             <parameter
                 android:name="prompt"
                 android:key="prompt"
-                android:mimeType="text/*"
+                android:mimeType="https://schema.org/Text"
                 android:required="true" />
         </intent>
     </capability>


### PR DESCRIPTION
- Source: Upstream commit 90fcc1f5515e0b78af14f9503db8a67ecb4f245f
- Why: Android App Actions textual parameters should use the schema type `android:mimeType="https://schema.org/Text"` rather than generic `text/*` to be properly recognized and parsed by the Assistant.
- Adaptation: Applied the XML fix directly to `shortcuts.xml`.
- Excluded upstream behavior: None (pure configuration string update).
- Verification: Validated with `app:lintStandardDebug`.

---
*PR created automatically by Jules for task [426913485255466219](https://jules.google.com/task/426913485255466219) started by @yuga-hashimoto*