### PR TITLE
🎨 Polish: Improve accessibility labels and small usability improvements

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1154,7 +1154,7 @@ fun CapabilityCard(
             ) {
                 Icon(
                     imageVector = icon,
-                    contentDescription = label,
+                    contentDescription = null,
                     tint = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(24.dp)
                 )
@@ -1233,7 +1233,7 @@ fun PermissionDiagnosticsPanel(allPermissionsStatus: List<PermissionStatusInfo>,
             Spacer(modifier = Modifier.height(8.dp))
             allPermissionsStatus.forEach { perm ->
                 Row(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp).semantics(mergeDescendants = true) {},
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     val color = if (perm.isGranted) Color(0xFF4CAF50) else Color(0xFFF44336)
@@ -1258,7 +1258,7 @@ fun PermissionDiagnosticsPanel(allPermissionsStatus: List<PermissionStatusInfo>,
 fun DiagnosticItem(label: String, status: DiagnosticStatus, modifier: Modifier = Modifier) {
     val color = when (status) { DiagnosticStatus.READY -> Color(0xFF4CAF50); DiagnosticStatus.WARNING -> Color(0xFFFFC107); DiagnosticStatus.ERROR -> Color(0xFFF44336) }
     val icon = when (status) { DiagnosticStatus.READY -> Icons.Default.Check; DiagnosticStatus.WARNING -> Icons.Default.Info; DiagnosticStatus.ERROR -> Icons.Default.Error }
-    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+    Row(modifier = modifier.semantics(mergeDescendants = true) {}, verticalAlignment = Alignment.CenterVertically) {
         Icon(icon, contentDescription = status.name, tint = color, modifier = Modifier.size(16.dp))
         Spacer(modifier = Modifier.width(4.dp))
         Text(label, fontSize = 11.sp, fontWeight = FontWeight.Medium)
@@ -1269,7 +1269,7 @@ fun DiagnosticItem(label: String, status: DiagnosticStatus, modifier: Modifier =
 fun SuggestionItem(suggestion: com.openclaw.assistant.speech.diagnostics.DiagnosticSuggestion) {
     val context = LocalContext.current
     Surface(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp), color = MaterialTheme.colorScheme.surface, shape = RoundedCornerShape(8.dp), tonalElevation = 1.dp) {
-        Row(modifier = Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
+        Row(modifier = Modifier.padding(8.dp).semantics(mergeDescendants = true) {}, verticalAlignment = Alignment.CenterVertically) {
             Text(text = suggestion.message, modifier = Modifier.weight(1f), fontSize = 12.sp, lineHeight = 16.sp)
             if (suggestion.actionLabel != null && suggestion.intent != null) {
                 TextButton(onClick = { try { context.startActivity(suggestion.intent) } catch (e: Exception) { Toast.makeText(context, context.getString(R.string.state_error), Toast.LENGTH_SHORT).show() } }, contentPadding = PaddingValues(horizontal = 8.dp)) { Text(suggestion.actionLabel, fontSize = 12.sp) }
@@ -1468,7 +1468,7 @@ fun PermissionStatusCard(
             Spacer(modifier = Modifier.height(12.dp))
             missingPermissions.forEach { perm ->
                 Row(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp).semantics(mergeDescendants = true) {},
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Icon(


### PR DESCRIPTION
🎨 Polish: Improve accessibility labels and small usability improvements

Sets `contentDescription = null` for `Icon` elements nested within `CapabilityCard` components to prevent TalkBack from reading the label redundantly. It also adds `Modifier.semantics(mergeDescendants = true) {}` to several key `Row` containers, such as `PermissionDiagnosticsPanel`, `DiagnosticItem`, `PermissionStatusCard`, and `SuggestionItem`, unifying their child elements into single focusable nodes, vastly improving screen reader usability without altering visual design.

---
*PR created automatically by Jules for task [15561020331580528599](https://jules.google.com/task/15561020331580528599) started by @yuga-hashimoto*