### PR TITLE
🛡️ Sentinel: Disable cleartext traffic globally

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,7 +89,6 @@
         android:name="com.openclaw.assistant.OpenClawApplication"
         android:allowBackup="false"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>

--- a/wear/src/main/res/xml/network_security_config.xml
+++ b/wear/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>


### PR DESCRIPTION
- **What:** Removed `android:usesCleartextTraffic="true"` from the app manifest and set `<base-config cleartextTrafficPermitted="false">` in both app and wear network security configurations.
- **Why:** To enforce secure communication (HTTPS/WSS) across the application, preventing insecure HTTP/WS connections that could expose sensitive data like API keys or voice data in transit.
- **Impact:** Any attempt to connect to a non-TLS endpoint (except local loopback addresses during testing) will now fail.
- **Measurement:** Verified via static analysis (lint) and ensuring existing tests pass.

---
*PR created automatically by Jules for task [7134828067516466395](https://jules.google.com/task/7134828067516466395) started by @yuga-hashimoto*