### PR TITLE
⚡ Bolt: Optimize A2UI action formatting by removing joinToString

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/protocol/OpenClawCanvasA2UIAction.kt
+++ b/app/src/main/java/com/openclaw/assistant/protocol/OpenClawCanvasA2UIAction.kt
@@ -45,16 +45,15 @@ object OpenClawCanvasA2UIAction {
         contextJson: String?,
     ): String {
         val ctxSuffix = contextJson?.takeIf { it.isNotBlank() }?.let { " ctx=$it" }.orEmpty()
-        return listOf(
-            "CANVAS_A2UI",
-            "action=${sanitizeTagValue(actionName)}",
-            "session=${sanitizeTagValue(sessionKey)}",
-            "surface=${sanitizeTagValue(surfaceId)}",
-            "component=${sanitizeTagValue(sourceComponentId)}",
-            "host=${sanitizeTagValue(host)}",
-            "instance=${sanitizeTagValue(instanceId)}$ctxSuffix",
-            "default=update_canvas",
-        ).joinToString(separator = " ")
+        // ⚡ Bolt Optimization: Replace listOf(...).joinToString() with direct string interpolation
+        // for performance in hot paths, using local variables for readability.
+        val a = sanitizeTagValue(actionName)
+        val s = sanitizeTagValue(sessionKey)
+        val sf = sanitizeTagValue(surfaceId)
+        val c = sanitizeTagValue(sourceComponentId)
+        val h = sanitizeTagValue(host)
+        val i = sanitizeTagValue(instanceId)
+        return "CANVAS_A2UI action=$a session=$s surface=$sf component=$c host=$h instance=$i$ctxSuffix default=update_canvas"
     }
 
     fun jsDispatchA2UIActionStatus(actionId: String, ok: Boolean, error: String?): String {


### PR DESCRIPTION
💡 What: Replaced `listOf(...).joinToString(separator = " ")` with direct string interpolation in `OpenClawCanvasA2UIAction.formatAgentMessage`.
🎯 Why: `formatAgentMessage` is called to dispatch structured data back to the UI. The original approach unnecessarily instantiated an intermediate `List` object, an iterator, and closure mappings on every single call. String interpolation is handled directly by the compiler (using `StringBuilder`/`StringConcatFactory`) and avoids creating those intermediate heap allocations.
📊 Impact: Eliminates transient collection allocations and Garbage Collector pressure during A2UI action formatting.
🔬 Measurement: Verify using an Android memory profiler observing reduced object allocations, or micro-benchmarking list joining vs string interpolation (which typically yields a massive nanosecond speedup in JVM environments).

---
*PR created automatically by Jules for task [16228103187583410387](https://jules.google.com/task/16228103187583410387) started by @yuga-hashimoto*