### PR TITLE
chore: remove unused firebase-analytics dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -254,7 +254,6 @@ dependencies {
     // Firebase
     implementation(platform("com.google.firebase:firebase-bom:33.7.0"))
     implementation("com.google.firebase:firebase-crashlytics")
-    implementation("com.google.firebase:firebase-analytics")
 
     // QR Code Scanning (Google Code Scanner — no camera permission required)
     implementation("com.google.android.gms:play-services-code-scanner:16.1.0")


### PR DESCRIPTION
## Summary / 概要

| Area | Change |
|------|--------|
| `app/build.gradle.kts` | Removed `firebase-analytics` dependency |

**EN:** `firebase-analytics` was declared but never actively used — no `FirebaseAnalytics` API calls, `logEvent()`, or `setAnalyticsCollectionEnabled()` exist anywhere in the codebase. The library was silently collecting automatic events (sessions, screen views, first_open, etc.) in release builds without any intentional configuration or explicit opt-in, which is undesirable for a privacy-sensitive app that handles contacts, SMS, and calendar data. `firebase-crashlytics` is unaffected as it does not depend on `firebase-analytics`.

**JA:** `firebase-analytics` は依存関係として宣言されていましたが、コードベース内に `FirebaseAnalytics` APIの呼び出し、`logEvent()`、`setAnalyticsCollectionEnabled()` は一切存在しません。リリースビルドでは、明示的な設定やオプトインなしに自動イベント（セッション、スクリーンビュー、first_open 等）が収集されていました。連絡先・SMS・カレンダーなどの機密データを扱うアプリにとって、意図しないデータ収集は望ましくないため削除します。`firebase-crashlytics` は `firebase-analytics` に依存しないため影響なし。

## Analysis / 分析

This PR was generated by a scheduled Firebase audit task. Firebase MCP tools were not available in the environment, so the audit was performed via static code analysis.

このPRはFirebase定期監査タスクにより生成されました。Firebase MCPツールが環境に登録されていなかったため、静的コード解析により監査を実施しました。

**Findings:**
- `firebase-analytics` listed in `app/build.gradle.kts` — dependency present
- `FirebaseAnalytics` usage in source — no API calls found
- `logEvent()` calls — none found
- `setAnalyticsCollectionEnabled()` — not called
- Crashlytics usage — actively used in 6 files, all guarded by `FIREBASE_ENABLED`

## Test plan / テスト計画

- [ ] Debug build launches without crash
- [ ] Release build compiles without error
- [ ] Crashlytics still reports exceptions (unaffected by this change)
- [ ] APK size decreases (~200–400 KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)