### PR TITLE
🔄 Upstream Parity: Fix App Actions prompt parameter typing

### DIFF
--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -11,7 +11,7 @@
             <parameter
                 android:name="prompt"
                 android:key="prompt"
-                android:mimeType="text/*"
+                android:mimeType="https://schema.org/Text"
                 android:required="true" />
         </intent>
     </capability>


### PR DESCRIPTION
- **Source:** Upstream commit 90fcc1f5515e0b78af14f9503db8a67ecb4f245f
- **Why:** To fix App Actions prompt parameter typing so Google Assistant correctly recognizes and parses the parameter as a text schema.
- **Adaptation:** Ported exactly the XML change to `app/src/main/res/xml/shortcuts.xml`. The structure was the same.
- **Excluded upstream behavior:** N/A (only one line changed in the original commit).
- **Verification:** Ran `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug` and manually verified the diff.

---
*PR created automatically by Jules for task [15826646671138711455](https://jules.google.com/task/15826646671138711455) started by @yuga-hashimoto*