### PR TITLE
🎨 Polish: Improve accessibility labels for AgentSelector and Settings

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -885,7 +885,10 @@ fun AgentSelector(
             modifier = Modifier
                 .then(
                     if (!isReadOnly && agents.isNotEmpty()) {
-                        Modifier.clickable { expanded = true }
+                        Modifier.clickable(
+                            onClickLabel = stringResource(R.string.select_agent_description),
+                            role = androidx.compose.ui.semantics.Role.DropdownList
+                        ) { expanded = true }
                     } else {
                         Modifier
                     }

--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -714,7 +714,7 @@ fun SettingsScreen(
                                         IconButton(onClick = { showNodeToken = !showNodeToken }) {
                                             Icon(
                                                 if (showNodeToken) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                                                contentDescription = if (showNodeToken) "Hide token" else "Show token"
+                                                contentDescription = if (showNodeToken) stringResource(R.string.hide_token_description) else stringResource(R.string.show_token_description)
                                             )
                                         }
                                     },
@@ -736,7 +736,7 @@ fun SettingsScreen(
                                         IconButton(onClick = { showGatewayPassword = !showGatewayPassword }) {
                                             Icon(
                                                 if (showGatewayPassword) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                                                contentDescription = if (showGatewayPassword) "Hide password" else "Show password"
+                                                contentDescription = if (showGatewayPassword) stringResource(R.string.hide_password_description) else stringResource(R.string.show_password_description)
                                             )
                                         }
                                     },
@@ -789,7 +789,7 @@ fun SettingsScreen(
                                     IconButton(onClick = { showNodeToken = !showNodeToken }) {
                                         Icon(
                                             if (showNodeToken) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                                            contentDescription = if (showNodeToken) "Hide token" else "Show token"
+                                            contentDescription = if (showNodeToken) stringResource(R.string.hide_token_description) else stringResource(R.string.show_token_description)
                                         )
                                     }
                                 },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,6 +229,11 @@
     <string name="default_agent_label">Default Agent</string>
     <string name="default_agent_hint">main</string>
     <string name="agent_selector">Agent</string>
+    <string name="select_agent_description">Select Agent</string>
+    <string name="hide_token_description">Hide token</string>
+    <string name="show_token_description">Show token</string>
+    <string name="hide_password_description">Hide password</string>
+    <string name="show_password_description">Show password</string>
     <string name="agent_default">Default</string>
 
     <!-- Session Foreground Service -->


### PR DESCRIPTION
What: Added accessibility `onClickLabel` and `Role.DropdownList` to `AgentSelector`'s `Modifier.clickable` and extracted hardcoded accessibility strings in `SettingsActivity.kt` to `strings.xml`.
Why: Follows Jetpack Compose accessibility conventions and improves TalkBack user experience.
Impact: Screen readers will accurately announce the Agent selector as a dropdown and localized strings will be used for token/password visibility toggles.
Measurement: Tests and lint checks.

---
*PR created automatically by Jules for task [11408158207669113268](https://jules.google.com/task/11408158207669113268) started by @yuga-hashimoto*