### PR TITLE
🧪 Regression Guard: Fix background service crash fallbacks

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
+++ b/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
@@ -58,6 +58,12 @@ class MediaButtonReceiver : BroadcastReceiver() {
                         setPackage(context.packageName)
                     }
                     context.sendBroadcast(broadcastIntent)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Unexpected error starting service, falling back to broadcast", e)
+                    val broadcastIntent = Intent(OpenClawAssistantService.ACTION_SHOW_ASSISTANT).apply {
+                        setPackage(context.packageName)
+                    }
+                    context.sendBroadcast(broadcastIntent)
                 }
                 // Absorb the event so it doesn't reach the media player
                 abortBroadcast()

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -672,6 +672,12 @@ class HotwordService : Service(), VoskRecognitionListener {
                     setPackage(packageName)
                 }
                 sendBroadcast(broadcastIntent)
+            } catch (e: Exception) {
+                Log.e(TAG, "Unexpected error starting service, falling back to broadcast", e)
+                val broadcastIntent = Intent(OpenClawAssistantService.ACTION_SHOW_ASSISTANT).apply {
+                    setPackage(packageName)
+                }
+                sendBroadcast(broadcastIntent)
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -289,6 +289,9 @@ class NodeForegroundService : Service() {
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         context.stopService(intent)
+      } catch (e: Exception) {
+        android.util.Log.e(TAG, "Unexpected error sending ACTION_STOP via startService, falling back to stopService", e)
+        context.stopService(intent)
       }
     }
 


### PR DESCRIPTION
When attempting to start background or foreground services on newer Android versions, the OS strictly limits background execution. While `IllegalStateException` and `SecurityException` are correctly caught in various places across `MediaButtonReceiver`, `HotwordService`, and `NodeForegroundService` to implement fallback behavior (like sending broadcasts or using `stopService`), any other unexpected exception thrown by the system (e.g., `ForegroundServiceStartNotAllowedException` on Android 12+, or custom vendor exceptions) would crash the app.

This patch adds a generic `catch (e: Exception)` block alongside the existing handlers to ensure these edge-cases safely trigger the exact same fallback behavior instead of crashing.

---
*PR created automatically by Jules for task [14282685003012993686](https://jules.google.com/task/14282685003012993686) started by @yuga-hashimoto*