### PR TITLE
🛡️ Sentinel: Enforce secure network traffic by disabling cleartext

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,7 +89,6 @@
         android:name="com.openclaw.assistant.OpenClawApplication"
         android:allowBackup="false"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>

--- a/wear/src/main/res/xml/network_security_config.xml
+++ b/wear/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>


### PR DESCRIPTION
**What:**
- Removes `android:usesCleartextTraffic="true"` from the app's `AndroidManifest.xml`.
- Modifies `network_security_config.xml` in both the `app` and `wear` modules to set `<base-config cleartextTrafficPermitted="false">`.

**Why:**
- Permitting cleartext HTTP traffic allows eavesdroppers to potentially intercept data sent by the app. This change ensures that the app defaults to only permitting encrypted (HTTPS/WSS) transport, closing a major insecurity gap that was identified in the lint checks.

**Impact:**
- Significantly hardens network communications by enforcing encryption.
- No longer exposes potential vulnerabilities through MitM (Man-in-the-Middle) attacks on plain HTTP connections.

**Measurement:**
- App and wear module test suites fully pass.
- Android Lint reports warning for cleartext traffic permission is resolved.

---
*PR created automatically by Jules for task [14604390084546137434](https://jules.google.com/task/14604390084546137434) started by @yuga-hashimoto*