### PR TITLE
🎨 Palette: Add accessibility label to agent dropdown

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -885,7 +885,10 @@ fun AgentSelector(
             modifier = Modifier
                 .then(
                     if (!isReadOnly && agents.isNotEmpty()) {
-                        Modifier.clickable { expanded = true }
+                        Modifier.clickable(
+                            onClickLabel = stringResource(R.string.select_agent),
+                            role = androidx.compose.ui.semantics.Role.DropdownList
+                        ) { expanded = true }
                     } else {
                         Modifier
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">OpenClaw Assistant</string>
+    <string name="select_agent">Select agent</string>
     <string name="notification_channel_name">Wake Word Service</string>
     <string name="notification_channel_description">Always-on voice detection service</string>
     <string name="notification_title">OpenClaw Assistant</string>


### PR DESCRIPTION
💡 What: Added an `onClickLabel` and `Role.DropdownList` semantics to the agent selector dropdown in `ChatActivity.kt`.
🎯 Why: Without these semantics, screen readers do not announce that the row is an interactive dropdown list, making it difficult for visually impaired users to know they can select an agent.
♿ Accessibility: The agent selector now correctly announces "Select agent, drop-down list" to TalkBack users.

---
*PR created automatically by Jules for task [2675675968363941761](https://jules.google.com/task/2675675968363941761) started by @yuga-hashimoto*