### PR TITLE
fix: improve Crashlytics diagnostics in HotwordService

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -362,7 +362,11 @@ class HotwordService : Service(), VoskRecognitionListener {
                 Log.e(TAG, "Vosk native library not supported on this device", e)
                 debugLog("Vosk: UnsatisfiedLinkError — native lib not supported")
                 if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
+                    FirebaseCrashlytics.getInstance().apply {
+                        setCustomKey("audio_retry_count", audioRetryCount)
+                        setCustomKey("is_session_active", isSessionActive)
+                        recordException(e)
+                    }
                 }
                 prefs.edit()
                     .putBoolean("vosk_unsupported", true)
@@ -372,7 +376,11 @@ class HotwordService : Service(), VoskRecognitionListener {
                 Log.e(TAG, "Init error", e)
                 debugLog("Vosk: init error — ${e.message}")
                 if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
+                    FirebaseCrashlytics.getInstance().apply {
+                        setCustomKey("audio_retry_count", audioRetryCount)
+                        setCustomKey("is_session_active", isSessionActive)
+                        recordException(e)
+                    }
                 }
             }
         }
@@ -533,6 +541,11 @@ class HotwordService : Service(), VoskRecognitionListener {
             debugLog("Mic unavailable after $MAX_AUDIO_RETRIES retries — giving up")
             audioRetryCount = 0
             showMicUnavailableNotification()
+            if (BuildConfig.FIREBASE_ENABLED) {
+                FirebaseCrashlytics.getInstance().recordException(
+                    RuntimeException("Microphone unavailable after $MAX_AUDIO_RETRIES retries")
+                )
+            }
             return
         }
         audioRetryCount++


### PR DESCRIPTION
## Summary / 概要

**EN:** Firebase MCP was unavailable this run, so analysis was performed via `firebase-debug.log` and direct code inspection. Two gaps were found in the Crashlytics instrumentation of `HotwordService` and fixed.

**JA:** Firebase MCPが今回のセッションでは利用できなかったため、`firebase-debug.log`とソースコードの直接確認により分析を実施。`HotwordService`のCrashlyticsが2箇所不十分であったため修正しました。

---

## Changes / 変更内容

| File | Change (EN) | 変更内容 (JA) |
|------|-------------|--------------|
| `HotwordService.kt` | Report non-fatal to Crashlytics when mic permanently unavailable (max retries exceeded) | マイクが永続的に使用不可（最大リトライ超過）の際にCrashlyticsへ非致命的エラーを送信 |
| `HotwordService.kt` | Add `audio_retry_count` and `is_session_active` custom keys before Vosk init exception reports | Vosk初期化エラー報告前に`audio_retry_count`・`is_session_active`カスタムキーを付加 |

---

## Details / 詳細

**EN:**

1. **Missing non-fatal for mic unavailability**: `scheduleAudioRetry()` shows a user-visible notification when the mic hits max retries, but never reported to Crashlytics. We now record a `RuntimeException("Microphone unavailable after N retries")` so we can see how many users are affected by persistent mic hardware/permission issues.

2. **Missing context on Vosk init failures**: `UnsatisfiedLinkError` and general `Exception` during Vosk model loading were reported to Crashlytics without any state context. We now attach `audio_retry_count` and `is_session_active` as custom keys before calling `recordException()`, making it possible to correlate crashes with device state.

**JA:**

1. **マイク使用不可の非致命的エラーが未報告**: `scheduleAudioRetry()`はリトライ上限に達した際ユーザー向け通知を表示するが、Crashlyticsへは報告されていなかった。`RuntimeException("Microphone unavailable after N retries")`を記録することで、マイクのハードウェア/権限問題がどれだけのユーザーに影響しているか把握できる。

2. **Vosk初期化失敗時のコンテキスト欠如**: Voskモデル読み込み時の`UnsatisfiedLinkError`と一般的な`Exception`は、状態情報なしにCrashlyticsへ報告されていた。`recordException()`の前に`audio_retry_count`と`is_session_active`をカスタムキーとして付加し、クラッシュとデバイス状態の相関を取りやすくした。

---

## Firebase Health Audit Findings / Firebase健全性監査の結果

| Check | Status |
|-------|--------|
| Firebase project (`openclawassistant-d6bc2`) | Active |
| Billing | Disabled (Crashlytics/Analytics unaffected) |
| `app/google-services.json` | ✅ Valid — both release + debug clients |
| `app/src/debug/google-services.json` | ✅ Valid — debug client only |
| `app/src/release/google-services.json` | ✅ Valid — release client only |
| `FIREBASE_ENABLED` guard on all `recordException` calls | ✅ All guarded |
| Missing non-fatal: mic max retries exceeded | ❌ Fixed in this PR |
| Missing custom keys on Vosk init failures | ❌ Fixed in this PR |

---

## Test plan / テスト計画

- [ ] Build release APK — confirm no Crashlytics compilation errors
- [ ] Build debug APK with `FIREBASE_ENABLED=false` — confirm no crash on launch
- [ ] Simulate mic unavailability (revoke RECORD_AUDIO mid-session) — verify Crashlytics receives the non-fatal after retry exhaustion
- [ ] Check Crashlytics dashboard for `audio_retry_count` / `is_session_active` keys appearing on Vosk init reports

🤖 Generated with [Claude Code](https://claude.com/claude-code) — scheduled Firebase audit task