### PR TITLE
🎨 Palette: Add accessibility semantics to agent selector dropdown

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-11 - Add semantics to clickable element used as Dropdown
+**Learning:** When turning a standard `Row` into a dropdown selector using `Modifier.clickable` in Jetpack Compose, screen readers (like TalkBack) will just announce it as a generic actionable item. By specifying an `onClickLabel` and `role = androidx.compose.ui.semantics.Role.DropdownList`, the screen reader can correctly announce the element's interactability and purpose.
+**Action:** Always verify if a `Modifier.clickable` is functionally a button, dropdown, or toggle, and apply the appropriate `role` and `onClickLabel` semantics.

--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -885,7 +885,10 @@ fun AgentSelector(
             modifier = Modifier
                 .then(
                     if (!isReadOnly && agents.isNotEmpty()) {
-                        Modifier.clickable { expanded = true }
+                        Modifier.clickable(
+                            onClickLabel = stringResource(R.string.agent_selector),
+                            role = androidx.compose.ui.semantics.Role.DropdownList
+                        ) { expanded = true }
                     } else {
                         Modifier
                     }


### PR DESCRIPTION
💡 What: Added explicit semantic role (`Role.DropdownList`) and an `onClickLabel` to the agent selector dropdown in `ChatActivity`.
🎯 Why: Previously, TalkBack announced the agent selector just as a generic actionable area. Defining proper semantics allows screen readers to clearly announce its purpose as a dropdown selector.
📸 Before/After: No visual changes. Behavior for TalkBack users is improved.
♿ Accessibility: Improved screen reader announcements for the main chat agent selector dropdown.

---
*PR created automatically by Jules for task [7866737101432263183](https://jules.google.com/task/7866737101432263183) started by @yuga-hashimoto*