### PR TITLE
🔄 Upstream Parity: Correct App Actions prompt parameter typing

### DIFF
--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -11,7 +11,7 @@
             <parameter
                 android:name="prompt"
                 android:key="prompt"
-                android:mimeType="text/*"
+                android:mimeType="https://schema.org/Text"
                 android:required="true" />
         </intent>
     </capability>


### PR DESCRIPTION
- **Source**: Upstream openclaw/openclaw commit `90fcc1f5515e0b78af14f9503db8a67ecb4f245f`.
- **Why**: Google Assistant App Actions (BII) capabilities require textual parameters to use the schema type `https://schema.org/Text` rather than generic `text/*` to be properly recognized and parsed by the Assistant.
- **Adaptation**: Directly applied the change to `shortcuts.xml` keeping the existing package structure (`com.openclaw.assistant`).
- **Excluded upstream behavior**: N/A - This was a targeted 1-line XML change, no other behavior existed in the upstream commit.
- **Verification**: Ran `./gradlew app:lintStandardDebug app:testStandardDebugUnitTest`.

---
*PR created automatically by Jules for task [450950171224860420](https://jules.google.com/task/450950171224860420) started by @yuga-hashimoto*