### PR TITLE
🛡️ Sentinel: Enforce secure cleartext traffic policy

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>

--- a/wear/src/main/res/xml/network_security_config.xml
+++ b/wear/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>


### PR DESCRIPTION
🛡️ Sentinel: Enforce secure cleartext traffic policy

**What:** Disabled global cleartext traffic permissions by changing `cleartextTrafficPermitted` to `false` in both `app/src/main/res/xml/network_security_config.xml` and `wear/src/main/res/xml/network_security_config.xml`.

**Why:** Enforcing secure transport (HTTPS) is a primary security measure to prevent MITM attacks and eavesdropping, especially for an assistant app capable of sensitive communication. While `NetworkUtils.isUrlSecure` handles granular checks, globally allowing cleartext opens the door for unverified network components and API calls to silently fallback to insecure transmission.

**Verification:**
- Confirmed changes with `git diff`.
- Verified local and debug configs function correctly.
- Ran `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug` (Passed).
- Ran `./gradlew wear:testDebugUnitTest wear:lintDebug` (Confirmed `app` module modifications did not affect tests, Wear UI warnings expected).

---
*PR created automatically by Jules for task [8652695973979152458](https://jules.google.com/task/8652695973979152458) started by @yuga-hashimoto*