### PR TITLE
🧪 Regression Guard: Fix background startService crash

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
+++ b/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
@@ -58,6 +58,12 @@ class MediaButtonReceiver : BroadcastReceiver() {
                         setPackage(context.packageName)
                     }
                     context.sendBroadcast(broadcastIntent)
+                } catch (e: Exception) {
+                    Log.w(TAG, "Background start failed, falling back to broadcast", e)
+                    val broadcastIntent = Intent(OpenClawAssistantService.ACTION_SHOW_ASSISTANT).apply {
+                        setPackage(context.packageName)
+                    }
+                    context.sendBroadcast(broadcastIntent)
                 }
                 // Absorb the event so it doesn't reach the media player
                 abortBroadcast()

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -672,6 +672,12 @@ class HotwordService : Service(), VoskRecognitionListener {
                     setPackage(packageName)
                 }
                 sendBroadcast(broadcastIntent)
+            } catch (e: Exception) {
+                Log.w(TAG, "Background start failed, falling back to broadcast", e)
+                val broadcastIntent = Intent(OpenClawAssistantService.ACTION_SHOW_ASSISTANT).apply {
+                    setPackage(packageName)
+                }
+                sendBroadcast(broadcastIntent)
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -289,6 +289,9 @@ class NodeForegroundService : Service() {
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         context.stopService(intent)
+      } catch (e: Exception) {
+        android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
+        context.stopService(intent)
       }
     }
 


### PR DESCRIPTION
Added generic `catch (e: Exception)` blocks as a fallback to `startService` calls that previously only caught `IllegalStateException` and `SecurityException`. This guarantees that if the Android OS throws an unexpected or newer exception type (like `ForegroundServiceStartNotAllowedException` in Android 12+) due to background start limitations, the app will not crash and will correctly fall back to the safe broadcast or `stopService` alternatives.
Affected files:
- `app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt`
- `app/src/main/java/com/openclaw/assistant/service/HotwordService.kt`
- `app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt`

---
*PR created automatically by Jules for task [14079946648705039617](https://jules.google.com/task/14079946648705039617) started by @yuga-hashimoto*