### PR TITLE
🧪 Regression Guard: Fix background startService crash fallbacks

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
+++ b/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
@@ -58,6 +58,12 @@ class MediaButtonReceiver : BroadcastReceiver() {
                         setPackage(context.packageName)
                     }
                     context.sendBroadcast(broadcastIntent)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Unexpected error starting service, falling back to broadcast", e)
+                    val broadcastIntent = Intent(OpenClawAssistantService.ACTION_SHOW_ASSISTANT).apply {
+                        setPackage(context.packageName)
+                    }
+                    context.sendBroadcast(broadcastIntent)
                 }
                 // Absorb the event so it doesn't reach the media player
                 abortBroadcast()

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -672,6 +672,12 @@ class HotwordService : Service(), VoskRecognitionListener {
                     setPackage(packageName)
                 }
                 sendBroadcast(broadcastIntent)
+            } catch (e: Exception) {
+                Log.e(TAG, "Unexpected error starting service, falling back to broadcast", e)
+                val broadcastIntent = Intent(OpenClawAssistantService.ACTION_SHOW_ASSISTANT).apply {
+                    setPackage(packageName)
+                }
+                sendBroadcast(broadcastIntent)
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -289,6 +289,9 @@ class NodeForegroundService : Service() {
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         context.stopService(intent)
+      } catch (e: Exception) {
+        android.util.Log.e(TAG, "Unexpected error sending ACTION_STOP via startService, falling back to stopService", e)
+        context.stopService(intent)
       }
     }
 


### PR DESCRIPTION
- Background execution limits on Android 8+ cause startService calls to throw exceptions.
- While IllegalStateException and SecurityException were handled, unexpected exceptions could still cause fatal crashes.
- Added generic Exception fallbacks to maintain stability.

---
*PR created automatically by Jules for task [15731145313132519651](https://jules.google.com/task/15731145313132519651) started by @yuga-hashimoto*