### PR TITLE
🎨 Palette: Add accessibility roles to clickable icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Semantic Roles on Clickable Elements
+**Learning:** Using Jetpack Compose's `.clickable()` modifier implicitly provides interaction states, but it lacks semantic roles needed by screen readers. When an icon or generic container functions as a button or dropdown, TalkBack won't announce it correctly unless `role = Role.Button` or `Role.DropdownList` is set.
+**Action:** Always provide an explicit `onClickLabel` and `role` when building custom interactive elements with `Modifier.clickable()` to guarantee accurate screen reader announcements.

--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.clickable
+import androidx.compose.ui.semantics.Role
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
@@ -655,7 +656,10 @@ fun MessageBubble(message: ChatMessage) {
                                 tint = contentColor.copy(alpha = 0.4f),
                                 modifier = Modifier
                                     .size(14.dp)
-                                    .clickable {
+                                    .clickable(
+                                        onClickLabel = stringResource(R.string.action_copy),
+                                        role = Role.Button
+                                    ) {
                                         val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
                                         clipboard.setPrimaryClip(android.content.ClipData.newPlainText("message", message.text))
                                     }
@@ -885,7 +889,10 @@ fun AgentSelector(
             modifier = Modifier
                 .then(
                     if (!isReadOnly && agents.isNotEmpty()) {
-                        Modifier.clickable { expanded = true }
+                        Modifier.clickable(
+                            onClickLabel = stringResource(R.string.action_expand),
+                            role = Role.DropdownList
+                        ) { expanded = true }
                     } else {
                         Modifier
                     }

--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1285,7 +1285,10 @@ fun CompactActionCard(modifier: Modifier = Modifier, icon: ImageVector, title: S
             Column(modifier = Modifier.weight(1f).fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
                 Row(modifier = Modifier.fillMaxWidth().height(32.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                     Icon(imageVector = icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(28.dp))
-                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = "More information about $title", tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable { onInfoClick?.invoke() })
+                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = "More information about $title", tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable(
+                        onClickLabel = "More information about $title",
+                        role = Role.Button
+                    ) { onInfoClick?.invoke() })
                     if (showSwitch) Switch(checked = switchValue, onCheckedChange = onSwitchChange, modifier = Modifier.scale(0.8f).offset(y = (-8).dp))
                 }
                 Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/openclaw/assistant/SessionListActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SessionListActivity.kt
@@ -8,6 +8,9 @@ import com.openclaw.assistant.data.SettingsRepository
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.clickable
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.res.stringResource
+import com.openclaw.assistant.R
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -480,7 +483,11 @@ private fun SessionListItem(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .clickable(
+                onClick = onClick,
+                onClickLabel = stringResource(R.string.action_open_session),
+                role = Role.Button
+            )
     ) {
         Row(
             modifier = Modifier

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -638,4 +638,5 @@
     <string name="action_copy">Copy</string>
     <string name="error_mic_privacy_title">Microphone Access Blocked</string>
     <string name="error_mic_privacy_message">Your device\'s microphone privacy toggle is off. Enable it in Settings &gt; Privacy &gt; Microphone.</string>
+    <string name="action_open_session">Open Session</string>
 </resources>


### PR DESCRIPTION
**💡 What:** Added explicit `role` definitions (e.g., `Role.Button`, `Role.DropdownList`) and `onClickLabel`s to `Modifier.clickable()` definitions across key activity surfaces.
**🎯 Why:** Generic `clickable` modifiers on icons or UI containers (like session list items or action cards) do not inherently communicate their interaction types to screen readers like TalkBack. Specifying a role ensures the user is informed of how to interact with the element.
**📸 Before/After:** N/A (Internal semantic tree change, purely structural).
**♿ Accessibility:** Greatly enhances screen reader navigation by ensuring clickable icon buttons and session list rows are properly announced as actionable buttons or dropdowns.

---
*PR created automatically by Jules for task [3179350477237171483](https://jules.google.com/task/3179350477237171483) started by @yuga-hashimoto*