### PR TITLE
🔄 Upstream Parity: prefer bootstrap auth on qr pairing

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
@@ -411,9 +411,9 @@ class GatewaySession(
 
       // If no token/password but bootstrapToken is set, use bootstrapToken auth directly.
       // Avoids trying token/password which would fail and potentially rate-limit.
-      // Only use bootstrapToken when no deviceToken is stored — bootstrapToken is single-use
+      // Prioritize bootstrapToken if provided. The bootstrapToken is single-use
       // and gets invalidated after first use; the deviceToken takes over for reconnections.
-      if (trimmedToken.isEmpty() && trimmedPassword.isEmpty() && trimmedBootstrapToken.isNotEmpty() && storedToken.isNullOrBlank()) {
+      if (trimmedToken.isEmpty() && trimmedPassword.isEmpty() && trimmedBootstrapToken.isNotEmpty()) {
         Log.d(TAG, "No token/password configured, using bootstrapToken auth directly")
         val payload = buildConnectParams(identity, connectNonce, "", null, authBootstrapToken = trimmedBootstrapToken)
         val res = request("connect", payload, timeoutMs = 8_000)


### PR DESCRIPTION
- Source: commit 11bd40fe8a0c47f43360181236d6ade25b0a4aaa
- Why: Fixes pairing behavior by preferring bootstrapToken over storedToken when available.
- Adaptation: Ported the auth check logic change directly to our `GatewaySession.kt`.
- Excluded upstream behavior: Skipped the unit test changes since our tests differ.
- Verification: Verified via local GatewaySession unit tests and linter.

---
*PR created automatically by Jules for task [2941892217886819350](https://jules.google.com/task/2941892217886819350) started by @yuga-hashimoto*