### PR TITLE
chore: remove unused firebase-analytics dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -254,7 +254,6 @@ dependencies {
     // Firebase
     implementation(platform("com.google.firebase:firebase-bom:33.7.0"))
     implementation("com.google.firebase:firebase-crashlytics")
-    implementation("com.google.firebase:firebase-analytics")
 
     // QR Code Scanning (Google Code Scanner — no camera permission required)
     implementation("com.google.android.gms:play-services-code-scanner:16.1.0")


### PR DESCRIPTION
## Summary / 概要

- Removes the `firebase-analytics` dependency from `app/build.gradle.kts`
- `firebase-analytics` was declared as a dependency but is completely unused: there are no `FirebaseAnalytics.getInstance()` or `logEvent()` calls anywhere in the codebase
- Only `firebase-crashlytics` is actively used (9 `recordException()` call sites across 7 files)

---

- `app/build.gradle.kts` から未使用の `firebase-analytics` 依存を削除します
- `firebase-analytics` は依存関係として宣言されていましたが、コードベース全体で一切使われていません（`FirebaseAnalytics.getInstance()` や `logEvent()` の呼び出しなし）
- 実際に使用されているのは `firebase-crashlytics` のみ（7ファイル9箇所の `recordException()` 呼び出し）

## Changes / 変更内容

| File | Change |
|------|--------|
| `app/build.gradle.kts` | Remove `firebase-analytics` implementation |

## Impact / 影響

- Reduces APK size (Analytics SDK removed) / APKサイズ削減（Analytics SDK除去）
- Eliminates unnecessary background data collection / 不要なバックグラウンドデータ収集を排除
- No functional change — Crashlytics is unaffected / 機能的な変更なし — Crashlyticsへの影響なし

## Test plan / テスト計画

- [ ] Build succeeds without `firebase-analytics` / `firebase-analytics` なしでビルド成功
- [ ] Crashlytics still records exceptions in release builds / リリースビルドで Crashlytics が例外を記録できる
- [ ] No `FirebaseAnalytics` compile errors / `FirebaseAnalytics` のコンパイルエラーなし

## Context / 背景

This was identified during a scheduled Firebase code audit. Firebase MCP tools were unavailable in this run, so the analysis was performed via static code inspection. No active Crashlytics logs were retrievable, but the unused dependency was clearly visible from the dependency declaration vs. actual usage grep.

このPRはスケジュールされたFirebaseコード監査中に特定されました。今回のrunではFirebase MCPツールが利用できなかったため、静的コード解析で分析を実施。Crashlyticsの実際のログは取得できませんでしたが、依存宣言と実際の使用状況のgrepから未使用の依存関係が明確に確認されました。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)