### PR TITLE
🔄 Upstream Parity: Correct App Actions prompt parameter typing

### DIFF
--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -11,7 +11,7 @@
             <parameter
                 android:name="prompt"
                 android:key="prompt"
-                android:mimeType="text/*"
+                android:mimeType="https://schema.org/Text"
                 android:required="true" />
         </intent>
     </capability>


### PR DESCRIPTION
- Source: https://github.com/openclaw/openclaw/commit/90fcc1f5515e0b78af14f9503db8a67ecb4f245f
- Why: Google Assistant Custom Intents/BIIs often require parameters to use Schema.org entity definitions instead of traditional file MIME types to be properly recognized. This change corrects the `mimeType` for the `prompt` parameter in `shortcuts.xml`.
- Adaptation: Directly applied the single-line XML attribute update from `text/*` to `https://schema.org/Text`.
- Excluded upstream behavior: N/A, this is a clean drop-in fix.
- Verification: Ran `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug` successfully.

---
*PR created automatically by Jules for task [13535240570798905595](https://jules.google.com/task/13535240570798905595) started by @yuga-hashimoto*