### PR TITLE
🎨 Palette: Improve agent switch accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-11 - Agent Switch Accessibility Enhancement
+**Learning:** In the ChatActivity, the top app bar agent switcher was utilizing a bare `Modifier.clickable { expanded = true }`. This element functions conceptually as a dropdown selector to screen readers, but TalkBack was only announcing it as a generic, unlabelled clickable element alongside the generic assistant icon.
+**Action:** When creating custom dropdown triggers using `Modifier.clickable`, explicitly define both the `onClickLabel` and set `role = Role.DropdownList` to correctly guide assistive technologies. Additionally, prefer using fully qualified Role paths (e.g., `androidx.compose.ui.semantics.Role.DropdownList`) if `Role` isn't imported globally, to prevent compilation errors.

--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -885,7 +885,10 @@ fun AgentSelector(
             modifier = Modifier
                 .then(
                     if (!isReadOnly && agents.isNotEmpty()) {
-                        Modifier.clickable { expanded = true }
+                        Modifier.clickable(
+                            onClickLabel = stringResource(R.string.agent_switch_accessibility),
+                            role = androidx.compose.ui.semantics.Role.DropdownList
+                        ) { expanded = true }
                     } else {
                         Modifier
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,6 +230,7 @@
     <string name="default_agent_hint">main</string>
     <string name="agent_selector">Agent</string>
     <string name="agent_default">Default</string>
+    <string name="agent_switch_accessibility">Switch Agent</string>
 
     <!-- Session Foreground Service -->
     <string name="notification_session_channel_name">Voice Session</string>


### PR DESCRIPTION
💡 **What**: Added an explicit `onClickLabel` and `Role.DropdownList` semantics to the Agent Selector row in `ChatActivity.kt`.
🎯 **Why**: Previously, the agent switcher was just a generic unlabelled clickable row. Screen reader users would hear an unintuitive generic interaction. Providing the correct role and descriptive action string clarifies its purpose as a dropdown menu.
📸 **Before/After**: Screen reader previously read generic unlabelled button; now correctly announces "Switch Agent, Dropdown list, double tap to activate".
♿ **Accessibility**: Enhanced interactive component semantics with dedicated string resource and explicit UI Role for TalkBack compatibility.

---
*PR created automatically by Jules for task [345028335594779820](https://jules.google.com/task/345028335594779820) started by @yuga-hashimoto*