### PR TITLE
🧪 Regression Guard: Fix background start exceptions

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
+++ b/app/src/main/java/com/openclaw/assistant/receiver/MediaButtonReceiver.kt
@@ -58,6 +58,12 @@ class MediaButtonReceiver : BroadcastReceiver() {
                         setPackage(context.packageName)
                     }
                     context.sendBroadcast(broadcastIntent)
+                } catch (e: Exception) {
+                    Log.w(TAG, "Background start failed, falling back to broadcast", e)
+                    val broadcastIntent = Intent(OpenClawAssistantService.ACTION_SHOW_ASSISTANT).apply {
+                        setPackage(context.packageName)
+                    }
+                    context.sendBroadcast(broadcastIntent)
                 }
                 // Absorb the event so it doesn't reach the media player
                 abortBroadcast()

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -672,6 +672,12 @@ class HotwordService : Service(), VoskRecognitionListener {
                     setPackage(packageName)
                 }
                 sendBroadcast(broadcastIntent)
+            } catch (e: Exception) {
+                Log.w(TAG, "Background start failed, falling back to broadcast", e)
+                val broadcastIntent = Intent(OpenClawAssistantService.ACTION_SHOW_ASSISTANT).apply {
+                    setPackage(packageName)
+                }
+                sendBroadcast(broadcastIntent)
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -289,6 +289,9 @@ class NodeForegroundService : Service() {
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         context.stopService(intent)
+      } catch (e: Exception) {
+        android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
+        context.stopService(intent)
       }
     }
 


### PR DESCRIPTION
Fixes crashes where starting services from the background throws unexpected exceptions by adding generic Exception catch blocks.

---
*PR created automatically by Jules for task [7998944551861384435](https://jules.google.com/task/7998944551861384435) started by @yuga-hashimoto*