### PR TITLE
🎨 Polish: Improve test connection button feedback

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
@@ -959,6 +959,8 @@ private fun FinalCheckStep(
     var pairingDetected by remember { mutableStateOf(false) }
     var isFinishing by remember { mutableStateOf(false) }
 
+    val isConnecting = statusText.contains("Connecting", ignoreCase = true)
+
     val finishWithHttpTest: () -> Unit = {
         scope.launch {
             isFinishing = true
@@ -1107,7 +1109,6 @@ private fun FinalCheckStep(
                 textAlign = TextAlign.Center
             )
         } else {
-            val isConnecting = statusText.contains("Connecting", ignoreCase = true)
             val state = when {
                 isConnected -> ConnectionState.Connected
                 isConnecting -> ConnectionState.Connecting
@@ -1162,9 +1163,14 @@ private fun FinalCheckStep(
                 },
                 modifier = Modifier.fillMaxWidth().height(56.dp),
                 shape = RoundedCornerShape(16.dp),
+                enabled = !isConnecting,
                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
             ) {
-                Text(stringResource(R.string.test_connection_button), fontSize = 18.sp)
+                if (isConnecting) {
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                } else {
+                    Text(stringResource(R.string.test_connection_button), fontSize = 18.sp)
+                }
             }
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -1248,7 +1254,7 @@ private fun CommandBlock(command: String) {
         Spacer(modifier = Modifier.width(8.dp))
         Icon(
             imageVector = Icons.Default.ContentCopy,
-            contentDescription = stringResource(R.string.pairing_copy_command),
+            contentDescription = null,
             tint = Color(0xFF58A6FF),
             modifier = Modifier.size(16.dp)
         )


### PR DESCRIPTION
This PR implements a small UX improvement to the Setup Guide screen by adding an explicit loading state and disabling the Test Connection button while it is actively attempting to connect. Additionally, it cleans up a duplicate accessibility description.

---
*PR created automatically by Jules for task [8153748647248999086](https://jules.google.com/task/8153748647248999086) started by @yuga-hashimoto*