### PR TITLE
refactor: extract Crashlytics recordException into CrashlyticsExt utility

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/OpenClawApplication.kt
+++ b/app/src/main/java/com/openclaw/assistant/OpenClawApplication.kt
@@ -5,8 +5,8 @@ import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import com.google.firebase.FirebaseApp
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.openclaw.assistant.data.SettingsRepository
+import com.openclaw.assistant.utils.recordToCrashlytics
 import com.openclaw.assistant.node.NodeRuntime
 import java.security.Security
 
@@ -54,9 +54,7 @@ class OpenClawApplication : Application() {
             Security.insertProviderAt(bcProvider, 1)
         } catch (e: Throwable) {
             Log.e("OpenClawApp", "Failed to register Bouncy Castle provider", e)
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
         }
     }
 

--- a/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
+++ b/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
@@ -1,7 +1,6 @@
 package com.openclaw.assistant.api
 
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.utils.recordToCrashlytics
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
@@ -135,8 +134,8 @@ class OpenClawClient() {
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (e: Exception) {
-            if (!isTransientNetworkError(e) && BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
+            if (!isTransientNetworkError(e)) {
+                e.recordToCrashlytics()
             }
             Result.failure(e)
         }

--- a/app/src/main/java/com/openclaw/assistant/gateway/DeviceIdentity.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/DeviceIdentity.kt
@@ -3,8 +3,7 @@ package com.openclaw.assistant.gateway
 import android.content.Context
 import android.util.Base64
 import android.util.Log
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.utils.recordToCrashlytics
 import com.google.crypto.tink.CleartextKeysetHandle
 import com.google.crypto.tink.JsonKeysetWriter
 import com.google.crypto.tink.KeyTemplates
@@ -48,9 +47,7 @@ class DeviceIdentity(context: Context) {
             extractPublicKey(handle)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize: ${e.message}")
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
         }
     }
 
@@ -112,9 +109,7 @@ class DeviceIdentity(context: Context) {
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to extract public key: ${e.message}")
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
         }
     }
 
@@ -127,9 +122,7 @@ class DeviceIdentity(context: Context) {
             )
         } catch (e: Exception) {
             Log.e(TAG, "Sign failed: ${e.message}")
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
             null
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -20,9 +20,8 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.openclaw.assistant.MainActivity
 import com.openclaw.assistant.R
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.openclaw.assistant.data.SettingsRepository
+import com.openclaw.assistant.utils.recordToCrashlytics
 import kotlinx.coroutines.*
 import org.vosk.Model
 import org.vosk.Recognizer
@@ -138,9 +137,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             if (isVoskCrash) {
                 Log.e(TAG, "Caught uncaught Vosk exception on thread ${thread.name}", throwable)
                 if (throwable is UnsatisfiedLinkError || throwable.cause is UnsatisfiedLinkError) {
-                    if (BuildConfig.FIREBASE_ENABLED) {
-                        FirebaseCrashlytics.getInstance().recordException(throwable)
-                    }
+                    throwable.recordToCrashlytics()
                     getSharedPreferences("hotword_prefs", Context.MODE_PRIVATE)
                         .edit().putBoolean("vosk_unsupported", true).apply()
                     // Don't resume - device doesn't support Vosk
@@ -154,9 +151,7 @@ class HotwordService : Service(), VoskRecognitionListener {
                         }
                     }
                 } else {
-                    if (BuildConfig.FIREBASE_ENABLED) {
-                        FirebaseCrashlytics.getInstance().recordException(throwable)
-                    }
+                    throwable.recordToCrashlytics()
                     speechService = null
                     android.os.Handler(android.os.Looper.getMainLooper()).post {
                         if (!isSessionActive) {
@@ -361,9 +356,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             } catch (e: UnsatisfiedLinkError) {
                 Log.e(TAG, "Vosk native library not supported on this device", e)
                 debugLog("Vosk: UnsatisfiedLinkError — native lib not supported")
-                if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
-                }
+                e.recordToCrashlytics()
                 prefs.edit()
                     .putBoolean("vosk_unsupported", true)
                     .putInt("vosk_unsupported_version", currentVersion)
@@ -371,9 +364,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             } catch (e: Exception) {
                 Log.e(TAG, "Init error", e)
                 debugLog("Vosk: init error — ${e.message}")
-                if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
-                }
+                e.recordToCrashlytics()
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
@@ -14,8 +14,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import androidx.core.content.ContextCompat
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.utils.recordToCrashlytics
 
 /**
  * Voice Interaction Service
@@ -87,9 +86,7 @@ class OpenClawAssistantService : VoiceInteractionService() {
                 Log.e(TAG, "showSession() called immediately")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to call showSession immediately", e)
-                if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
-                }
+                e.recordToCrashlytics()
             }
         } else {
             Log.e(TAG, "Service not ready. Queuing showSession request.")
@@ -112,9 +109,7 @@ class OpenClawAssistantService : VoiceInteractionService() {
                 Log.e(TAG, "showSession() called from onReady (pending)")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to call pending showSession", e)
-                if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
-                }
+                e.recordToCrashlytics()
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
@@ -8,8 +8,7 @@ import android.service.voice.VoiceInteractionSession
 import android.speech.SpeechRecognizer
 import android.util.Log
 import android.view.LayoutInflater
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.utils.recordToCrashlytics
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -263,9 +262,7 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
                     currentSessionId?.let { settings.sessionId = it }
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to handle session", e)
-                    if (BuildConfig.FIREBASE_ENABLED) {
-                        FirebaseCrashlytics.getInstance().recordException(e)
-                    }
+                    e.recordToCrashlytics()
                 }
             }
         }

--- a/app/src/main/java/com/openclaw/assistant/utils/CrashlyticsExt.kt
+++ b/app/src/main/java/com/openclaw/assistant/utils/CrashlyticsExt.kt
@@ -1,0 +1,14 @@
+package com.openclaw.assistant.utils
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.BuildConfig
+
+/**
+ * Records this throwable to Firebase Crashlytics when [BuildConfig.FIREBASE_ENABLED] is true.
+ * No-op in fork PR builds where FIREBASE_ENABLED=false and no real API key is present.
+ */
+fun Throwable.recordToCrashlytics() {
+    if (BuildConfig.FIREBASE_ENABLED) {
+        FirebaseCrashlytics.getInstance().recordException(this)
+    }
+}

--- a/app/src/main/java/com/openclaw/assistant/utils/UpdateChecker.kt
+++ b/app/src/main/java/com/openclaw/assistant/utils/UpdateChecker.kt
@@ -1,8 +1,6 @@
 package com.openclaw.assistant.utils
 
 import android.util.Log
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.Dispatchers
@@ -70,9 +68,7 @@ object UpdateChecker {
             return@withContext null
         } catch (e: Exception) {
             Log.e(TAG, "Error checking for updates", e)
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
             return@withContext null
         }
     }


### PR DESCRIPTION
## Summary / 概要

**EN:** Firebase MCP was unavailable for log retrieval in this run, so a static code analysis was performed instead. One clear improvement was identified: the `FirebaseCrashlytics` error-reporting boilerplate was duplicated 12 times across 7 files with no centralised guard.

**JA:** 今回の実行では Firebase MCP が利用できなかったため、静的コード解析を実施しました。明確な改善点として、`FirebaseCrashlytics` のエラー報告処理が 7 ファイルにわたって 12 箇所に重複していることを確認しました。

## Changes / 変更内容

| File | Change |
|------|--------|
| `utils/CrashlyticsExt.kt` | **New** — `Throwable.recordToCrashlytics()` extension; centralises `FIREBASE_ENABLED` guard |
| `OpenClawApplication.kt` | Use `e.recordToCrashlytics()`, remove direct `FirebaseCrashlytics` import |
| `service/HotwordService.kt` | 4 call sites replaced, `BuildConfig`/`FirebaseCrashlytics` imports removed |
| `service/OpenClawAssistantService.kt` | 2 call sites replaced, imports removed |
| `service/OpenClawSession.kt` | 1 call site replaced, imports removed |
| `gateway/DeviceIdentity.kt` | 3 call sites replaced, imports removed |
| `api/OpenClawClient.kt` | 1 call site replaced (transient-error guard preserved), imports removed |
| `utils/UpdateChecker.kt` | 1 call site replaced, imports removed (same package, no import needed) |

**Before / 変更前 (×12):**
```kotlin
if (BuildConfig.FIREBASE_ENABLED) {
    FirebaseCrashlytics.getInstance().recordException(e)
}
```

**After / 変更後 (×12):**
```kotlin
e.recordToCrashlytics()
```

## Why / なぜこの変更か

- The `FIREBASE_ENABLED` check is now in one place — future catch blocks can't accidentally omit it.
- Reduces 51 lines of boilerplate to 12 single-line calls.
- No behaviour change; the guard inside `recordToCrashlytics()` is identical to every replaced block.

- `FIREBASE_ENABLED` チェックが一箇所に集約され、新しい catch ブロックでの抜け漏れを防止できます。
- 51 行のボイラープレートを 12 行の 1 行呼び出しに削減。
- 動作変更なし。`recordToCrashlytics()` 内のガードは置換前の各ブロックと同一です。

## Test plan / テスト計画

- [ ] Build succeeds for both `standard` and `full` flavors in debug and release
- [ ] `FIREBASE_ENABLED=false` build: no Crashlytics calls executed (no Firebase API key required)
- [ ] `FIREBASE_ENABLED=true` build: exceptions are still reported to Crashlytics as before
- [ ] デバッグ・リリース両ビルドタイプ、standard/full 両フレーバーでビルド成功を確認
- [ ] `FIREBASE_ENABLED=false` ビルド: Crashlytics 呼び出しが発生しないことを確認
- [ ] `FIREBASE_ENABLED=true` ビルド: 例外が従来通り Crashlytics に報告されることを確認

## Firebase MCP status / Firebase MCP 状況

Firebase MCP tools (`mcp__firebase__*`) were not connected in this scheduled-task run. Log retrieval was skipped. The static improvement above was applied independently.

Firebase MCP ツール (`mcp__firebase__*`) が今回のスケジュールタスク実行時に接続されていませんでした。ログ取得はスキップし、静的解析による改善のみ実施しました。