### PR TITLE
🎨 Palette: Improve Agent Selector accessibility

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -885,7 +885,10 @@ fun AgentSelector(
             modifier = Modifier
                 .then(
                     if (!isReadOnly && agents.isNotEmpty()) {
-                        Modifier.clickable { expanded = true }
+                        Modifier.clickable(
+                            onClickLabel = stringResource(R.string.action_expand),
+                            role = androidx.compose.ui.semantics.Role.DropdownList
+                        ) { expanded = true }
                     } else {
                         Modifier
                     }


### PR DESCRIPTION
💡 What: Added `role = Role.DropdownList` and an `onClickLabel` to the `Modifier.clickable` of the Agent Selector in `ChatActivity.kt`.
🎯 Why: To ensure screen readers properly announce the element's interactability and purpose as a dropdown menu, instead of just a generic clickable area.
📸 Before/After: N/A
♿ Accessibility: Improves semantics for TalkBack users interacting with the Agent Selector dropdown.

---
*PR created automatically by Jules for task [5368096490248596086](https://jules.google.com/task/5368096490248596086) started by @yuga-hashimoto*