### PR TITLE
refactor: extract Throwable.recordToCrashlytics() extension to eliminate Crashlytics boilerplate

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/OpenClawApplication.kt
+++ b/app/src/main/java/com/openclaw/assistant/OpenClawApplication.kt
@@ -5,8 +5,8 @@ import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import com.google.firebase.FirebaseApp
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.openclaw.assistant.data.SettingsRepository
+import com.openclaw.assistant.utils.recordToCrashlytics
 import com.openclaw.assistant.node.NodeRuntime
 import java.security.Security
 
@@ -54,9 +54,7 @@ class OpenClawApplication : Application() {
             Security.insertProviderAt(bcProvider, 1)
         } catch (e: Throwable) {
             Log.e("OpenClawApp", "Failed to register Bouncy Castle provider", e)
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
         }
     }
 

--- a/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
+++ b/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
@@ -1,7 +1,6 @@
 package com.openclaw.assistant.api
 
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.utils.recordToCrashlytics
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
@@ -135,9 +134,7 @@ class OpenClawClient() {
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (e: Exception) {
-            if (!isTransientNetworkError(e) && BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            if (!isTransientNetworkError(e)) e.recordToCrashlytics()
             Result.failure(e)
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/gateway/DeviceIdentity.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/DeviceIdentity.kt
@@ -3,8 +3,7 @@ package com.openclaw.assistant.gateway
 import android.content.Context
 import android.util.Base64
 import android.util.Log
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.utils.recordToCrashlytics
 import com.google.crypto.tink.CleartextKeysetHandle
 import com.google.crypto.tink.JsonKeysetWriter
 import com.google.crypto.tink.KeyTemplates
@@ -48,9 +47,7 @@ class DeviceIdentity(context: Context) {
             extractPublicKey(handle)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize: ${e.message}")
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
         }
     }
 
@@ -112,9 +109,7 @@ class DeviceIdentity(context: Context) {
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to extract public key: ${e.message}")
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
         }
     }
 
@@ -127,9 +122,7 @@ class DeviceIdentity(context: Context) {
             )
         } catch (e: Exception) {
             Log.e(TAG, "Sign failed: ${e.message}")
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
             null
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -20,9 +20,8 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.openclaw.assistant.MainActivity
 import com.openclaw.assistant.R
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.openclaw.assistant.data.SettingsRepository
+import com.openclaw.assistant.utils.recordToCrashlytics
 import kotlinx.coroutines.*
 import org.vosk.Model
 import org.vosk.Recognizer
@@ -138,9 +137,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             if (isVoskCrash) {
                 Log.e(TAG, "Caught uncaught Vosk exception on thread ${thread.name}", throwable)
                 if (throwable is UnsatisfiedLinkError || throwable.cause is UnsatisfiedLinkError) {
-                    if (BuildConfig.FIREBASE_ENABLED) {
-                        FirebaseCrashlytics.getInstance().recordException(throwable)
-                    }
+                    throwable.recordToCrashlytics()
                     getSharedPreferences("hotword_prefs", Context.MODE_PRIVATE)
                         .edit().putBoolean("vosk_unsupported", true).apply()
                     // Don't resume - device doesn't support Vosk
@@ -154,9 +151,7 @@ class HotwordService : Service(), VoskRecognitionListener {
                         }
                     }
                 } else {
-                    if (BuildConfig.FIREBASE_ENABLED) {
-                        FirebaseCrashlytics.getInstance().recordException(throwable)
-                    }
+                    throwable.recordToCrashlytics()
                     speechService = null
                     android.os.Handler(android.os.Looper.getMainLooper()).post {
                         if (!isSessionActive) {
@@ -361,9 +356,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             } catch (e: UnsatisfiedLinkError) {
                 Log.e(TAG, "Vosk native library not supported on this device", e)
                 debugLog("Vosk: UnsatisfiedLinkError — native lib not supported")
-                if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
-                }
+                e.recordToCrashlytics()
                 prefs.edit()
                     .putBoolean("vosk_unsupported", true)
                     .putInt("vosk_unsupported_version", currentVersion)
@@ -371,9 +364,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             } catch (e: Exception) {
                 Log.e(TAG, "Init error", e)
                 debugLog("Vosk: init error — ${e.message}")
-                if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
-                }
+                e.recordToCrashlytics()
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
@@ -14,8 +14,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import androidx.core.content.ContextCompat
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.utils.recordToCrashlytics
 
 /**
  * Voice Interaction Service
@@ -87,9 +86,7 @@ class OpenClawAssistantService : VoiceInteractionService() {
                 Log.e(TAG, "showSession() called immediately")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to call showSession immediately", e)
-                if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
-                }
+                e.recordToCrashlytics()
             }
         } else {
             Log.e(TAG, "Service not ready. Queuing showSession request.")
@@ -112,9 +109,7 @@ class OpenClawAssistantService : VoiceInteractionService() {
                 Log.e(TAG, "showSession() called from onReady (pending)")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to call pending showSession", e)
-                if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
-                }
+                e.recordToCrashlytics()
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
@@ -8,8 +8,7 @@ import android.service.voice.VoiceInteractionSession
 import android.speech.SpeechRecognizer
 import android.util.Log
 import android.view.LayoutInflater
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.utils.recordToCrashlytics
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -263,9 +262,7 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
                     currentSessionId?.let { settings.sessionId = it }
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to handle session", e)
-                    if (BuildConfig.FIREBASE_ENABLED) {
-                        FirebaseCrashlytics.getInstance().recordException(e)
-                    }
+                    e.recordToCrashlytics()
                 }
             }
         }

--- a/app/src/main/java/com/openclaw/assistant/utils/CrashlyticsExt.kt
+++ b/app/src/main/java/com/openclaw/assistant/utils/CrashlyticsExt.kt
@@ -1,0 +1,14 @@
+package com.openclaw.assistant.utils
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.BuildConfig
+
+/**
+ * Records this throwable to Firebase Crashlytics when Firebase is enabled.
+ * No-op when [BuildConfig.FIREBASE_ENABLED] is false (e.g. fork PRs or unit-test builds).
+ */
+fun Throwable.recordToCrashlytics() {
+    if (BuildConfig.FIREBASE_ENABLED) {
+        FirebaseCrashlytics.getInstance().recordException(this)
+    }
+}

--- a/app/src/main/java/com/openclaw/assistant/utils/UpdateChecker.kt
+++ b/app/src/main/java/com/openclaw/assistant/utils/UpdateChecker.kt
@@ -1,8 +1,6 @@
 package com.openclaw.assistant.utils
 
 import android.util.Log
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.Dispatchers
@@ -70,9 +68,7 @@ object UpdateChecker {
             return@withContext null
         } catch (e: Exception) {
             Log.e(TAG, "Error checking for updates", e)
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
             return@withContext null
         }
     }


### PR DESCRIPTION
## Summary / 概要

**EN:**
This PR eliminates the 3-line `if (FIREBASE_ENABLED) { FirebaseCrashlytics.getInstance().recordException(e) }` boilerplate that appears 12 times across 7 files by introducing a single `Throwable.recordToCrashlytics()` extension function.

**JA:**
Firebase MCPログ取得調査の一環として実施。`if (FIREBASE_ENABLED) { FirebaseCrashlytics.getInstance().recordException(e) }` という3行のボイラープレートが7ファイル12箇所に散在していたため、`Throwable.recordToCrashlytics()` 拡張関数に一元化するリファクタリングです。

## Changes / 変更内容

| File | Change |
|------|--------|
| `utils/CrashlyticsExt.kt` (new) | Extension function wrapping the FIREBASE_ENABLED guard |
| `OpenClawApplication.kt` | 3-line → 1-line, removed unused import |
| `api/OpenClawClient.kt` | Combined transient-error check + record into 1 line |
| `gateway/DeviceIdentity.kt` | 3× 3-line blocks → 3× 1-line calls |
| `service/HotwordService.kt` | 4× 3-line blocks → 4× 1-line calls, removed unused imports |
| `service/OpenClawAssistantService.kt` | 2× 3-line blocks → 2× 1-line calls |
| `service/OpenClawSession.kt` | 3-line → 1-line, removed unused imports |
| `utils/UpdateChecker.kt` | 3-line → 1-line, removed unused imports |

**No behavior change** — same FIREBASE_ENABLED guard, same Crashlytics API call, just centralised.

## Motivation / 背景

Firebase MCPツールが利用不可（未設定）だったためログの直接取得はできなかったが、静的解析でコード改善点を特定。同一の3行パターンが12箇所に散在しており、将来的なカスタムキー追加時にも一箇所の変更で済むようになります。

## Test plan / テスト計画

- [ ] CI build passes (lint + unit tests)
- [ ] No change in runtime behavior — FIREBASE_ENABLED=false still suppresses all Crashlytics calls
- [ ] FIREBASE_ENABLED=true builds still report exceptions to Crashlytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)