### PR TITLE
🔄 Upstream Parity: fix(android): auto-resume pairing approval

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import kotlinx.coroutines.delay
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -194,6 +195,8 @@ private fun canInstallUnknownApps(context: Context): Boolean {
         true
     }
 }
+
+private const val PAIRING_AUTO_RETRY_MS = 6_000L
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -979,9 +982,19 @@ private fun FinalCheckStep(
         }
     }
 
-    LaunchedEffect(isPairingRequired) {
+
+
+    LaunchedEffect(isPairingRequired, attemptedConnect) {
         if (isPairingRequired) pairingDetected = true
+
+        if (!isPairingRequired || !attemptedConnect) return@LaunchedEffect
+        while (true) {
+            delay(PAIRING_AUTO_RETRY_MS)
+            runtime.refreshGatewayConnection()
+        }
     }
+
+
 
     val gatewayUrl = remember(manualHost, manualPort, manualTls) {
         "${if (manualTls) "https" else "http"}://$manualHost:$manualPort"

--- a/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import kotlinx.coroutines.delay
 import androidx.compose.runtime.saveable.rememberSaveable
+import com.openclaw.assistant.ui.components.PAIRING_AUTO_RETRY_MS
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -195,8 +196,6 @@ private fun canInstallUnknownApps(context: Context): Boolean {
         true
     }
 }
-
-private const val PAIRING_AUTO_RETRY_MS = 6_000L
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -993,8 +992,6 @@ private fun FinalCheckStep(
             runtime.refreshGatewayConnection()
         }
     }
-
-
 
     val gatewayUrl = remember(manualHost, manualPort, manualTls) {
         "${if (manualTls) "https" else "http"}://$manualHost:$manualPort"

--- a/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -25,6 +26,8 @@ import androidx.compose.ui.unit.sp
 import com.openclaw.assistant.OpenClawApplication
 import com.openclaw.assistant.R
 
+private const val PAIRING_AUTO_RETRY_MS = 6_000L
+
 @Composable
 fun PairingRequiredCard(deviceId: String, displayName: String = "") {
     val context = LocalContext.current
@@ -34,7 +37,16 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
     val approveCommand = stringResource(R.string.approve_command_format, deviceId)
     val rejectCommand = stringResource(R.string.reject_command_format, deviceId)
 
+
     var expanded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(PAIRING_AUTO_RETRY_MS)
+            nodeRuntime.refreshGatewayConnection()
+        }
+    }
+
 
     Card(
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.unit.sp
 import com.openclaw.assistant.OpenClawApplication
 import com.openclaw.assistant.R
 
-private const val PAIRING_AUTO_RETRY_MS = 6_000L
+internal const val PAIRING_AUTO_RETRY_MS = 6_000L
 
 @Composable
 fun PairingRequiredCard(deviceId: String, displayName: String = "") {
@@ -37,7 +37,6 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
     val approveCommand = stringResource(R.string.approve_command_format, deviceId)
     val rejectCommand = stringResource(R.string.reject_command_format, deviceId)
 
-
     var expanded by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
@@ -46,7 +45,6 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
             nodeRuntime.refreshGatewayConnection()
         }
     }
-
 
     Card(
         modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
- Source
Commit 911f9a104c from upstream android repo
- Why
To tighten the retry behavior when a gateway connection fails due to pending pairing approval
- Adaptation
Added `PAIRING_AUTO_RETRY_MS` and `LaunchedEffect` block to `SetupGuideScreen` and `PairingRequiredCard` in this repo's implementation to auto retry when pairing approval is required. Handled `attemptedConnect` correctly inside the `LaunchedEffect` in `SetupGuideScreen.kt`.
- Excluded upstream behavior
Excluded purely stylistic UI restructuring changes and only ported the core logic. Excluded modifications to `ConnectTabScreen` and `OnboardingFlow` as their functionality is implemented in different files (`SetupGuideScreen`, `PairingRequiredCard`) in this codebase.
- Verification
Ran `./gradlew app:lintStandardDebug` and `./gradlew app:testStandardDebugUnitTest` with a dummy `google-services.json` file. All checks passed.

---
*PR created automatically by Jules for task [660857136999854207](https://jules.google.com/task/660857136999854207) started by @yuga-hashimoto*