### PR TITLE
🔄 Upstream Parity: Correct App Actions prompt parameter typing

### DIFF
--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -11,7 +11,7 @@
             <parameter
                 android:name="prompt"
                 android:key="prompt"
-                android:mimeType="text/*"
+                android:mimeType="https://schema.org/Text"
                 android:required="true" />
         </intent>
     </capability>


### PR DESCRIPTION
- Source: Upstream commit 90fcc1f5515e0b78af14f9503db8a67ecb4f245f
- Why: Android App Actions (BII) capabilities require Schema.org semantic types rather than standard HTTP MIME types to properly map voice commands and system intents to the application.
- Adaptation: Ported the exact xml fix directly.
- Excluded upstream behavior: None.
- Verification: Passed `./gradlew app:testStandardDebugUnitTest` and `app:lintStandardDebug`.

---
*PR created automatically by Jules for task [5636896881551439279](https://jules.google.com/task/5636896881551439279) started by @yuga-hashimoto*