### PR TITLE
⚡ Bolt: Optimize TTS text splitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2024-04-03 - Kotlin `joinToString` memory allocations inside object mapping/looping
 **Learning:** Using `collection.joinToString(separator) { ... }` with a lambda that returns interpolated strings inside frequently-invoked object mapping layers (like mapping elements into a cache key inside `ChatController.messageIdentityKey`) creates immense pressure on the Garbage Collector. It instantiates intermediate string iterators, implicit list mapping elements, and implicit string builder lambda invokes. This is particularly problematic in UI component list-reconciliation (e.g. `LazyColumn` message keys), causing jitter.
 **Action:** Replace this pattern with a manual `StringBuilder` where the items are appended via an indexed loop (e.g., `for (i in collection.indices)`), preventing mapping iterators and intermediate lambda string allocations.
+
+## 2026-04-14 - Substring allocations inside chunking loops
+**Learning:** When splitting large strings into chunks (like in TTS processing), repeatedly using `substring()` to slice the string and searching within those new substrings introduces an $O(N^2)$ memory allocation bottleneck, putting intense pressure on the garbage collector.
+**Action:** To optimize string parsing and chunking loops, avoid `substring()`. Instead, maintain a sliding window using an `offset` index. Pass the original, immutable string along with the `offset` and `limit` to the search functions. Use Kotlin's `lastIndexOf(delimiter, limit)` to correctly bound backward searches within the window in-place.

--- a/app/src/main/java/com/openclaw/assistant/speech/TTSUtils.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/TTSUtils.kt
@@ -27,8 +27,8 @@ object TTSUtils {
     private val REGEX_BULLET = Regex("^\\s*[-*+]\\s+", RegexOption.MULTILINE)
     private val REGEX_NEWLINE = Regex("\n{3,}")
 
-    private val SENTENCE_ENDERS = listOf("。", "．", ". ", "! ", "? ", "！", "？")
-    private val COMMA_ENDERS = listOf("、", "，", ", ")
+    private val SENTENCE_ENDERS = arrayOf("。", "．", ". ", "! ", "? ", "！", "？")
+    private val COMMA_ENDERS = arrayOf("、", "，", ", ")
 
     /**
      * Setup locale and high-quality voice
@@ -159,54 +159,59 @@ object TTSUtils {
         if (text.length <= maxLength) return listOf(text)
 
         val chunks = mutableListOf<String>()
-        var remaining = text
+        var offset = 0
 
-        while (remaining.isNotEmpty()) {
-            if (remaining.length <= maxLength) {
-                chunks.add(remaining)
+        while (offset < text.length) {
+            if (text.length - offset <= maxLength) {
+                chunks.add(text.substring(offset).trim())
                 break
             }
 
-            // Find the last sentence boundary within maxLength
-            val searchRange = remaining.substring(0, maxLength)
-            val splitIndex = findBestSplitPoint(searchRange)
+            val limit = offset + maxLength
+            val splitIndex = findBestSplitPoint(text, offset, limit)
 
-            if (splitIndex > 0) {
-                chunks.add(remaining.substring(0, splitIndex).trim())
-                remaining = remaining.substring(splitIndex).trim()
+            if (splitIndex > offset) {
+                chunks.add(text.substring(offset, splitIndex).trim())
+                offset = splitIndex
             } else {
-                // No boundary found, force split at maxLength
-                chunks.add(remaining.substring(0, maxLength).trim())
-                remaining = remaining.substring(maxLength).trim()
+                chunks.add(text.substring(offset, limit).trim())
+                offset = limit
             }
         }
 
         return chunks.filter { it.isNotBlank() }
     }
 
-    private fun findBestSplitPoint(text: String): Int {
+    private fun findBestSplitPoint(text: String, offset: Int, limit: Int): Int {
+        val searchLength = limit - offset
         // Priority: paragraph break > sentence end > comma > space
-        val paragraphBreak = text.lastIndexOf("\n\n")
-        if (paragraphBreak > text.length / 2) return paragraphBreak + 2
+        val paragraphBreak = text.lastIndexOf("\n\n", limit - 2)
+        if (paragraphBreak >= offset && paragraphBreak - offset > searchLength / 2) return paragraphBreak + 2
 
         var bestPos = -1
         for (ender in SENTENCE_ENDERS) {
-            val pos = text.lastIndexOf(ender)
-            if (pos > bestPos) bestPos = pos + ender.length
+            val pos = text.lastIndexOf(ender, limit - ender.length)
+            if (pos >= offset) {
+                val endPos = pos + ender.length
+                if (endPos > bestPos) bestPos = endPos
+            }
         }
-        if (bestPos > text.length / 3) return bestPos
+        if (bestPos >= offset && bestPos - offset > searchLength / 3) return bestPos
 
-        val lineBreak = text.lastIndexOf("\n")
-        if (lineBreak > text.length / 3) return lineBreak + 1
+        val lineBreak = text.lastIndexOf("\n", limit - 1)
+        if (lineBreak >= offset && lineBreak - offset > searchLength / 3) return lineBreak + 1
 
         for (ender in COMMA_ENDERS) {
-            val pos = text.lastIndexOf(ender)
-            if (pos > bestPos) bestPos = pos + ender.length
+            val pos = text.lastIndexOf(ender, limit - ender.length)
+            if (pos >= offset) {
+                val endPos = pos + ender.length
+                if (endPos > bestPos) bestPos = endPos
+            }
         }
-        if (bestPos > text.length / 3) return bestPos
+        if (bestPos >= offset && bestPos - offset > searchLength / 3) return bestPos
 
-        val space = text.lastIndexOf(" ")
-        if (space > text.length / 3) return space + 1
+        val space = text.lastIndexOf(" ", limit - 1)
+        if (space >= offset && space - offset > searchLength / 3) return space + 1
 
         return -1
     }


### PR DESCRIPTION
💡 **What**: Refactored `TTSUtils.splitTextForTTS` and `findBestSplitPoint` to use an index-based sliding window (`offset` and `limit`) instead of continuously slicing intermediate chunks using `String.substring`. Additionally, converted `SENTENCE_ENDERS` and `COMMA_ENDERS` from `listOf` to `arrayOf`.
🎯 **Why**: When parsing large markdown/text blocks for TTS, repeatedly creating substrings inside a `while` loop generated immense garbage collection pressure (O(N^2) memory bottleneck). Furthermore, using `listOf` created an iterator object on every single `for` loop pass inside the backward search.
📊 **Impact**: Massively reduces heap allocations and GC jitter when the assistant speaks large responses, improving overall system responsiveness and preventing memory fragmentation.
🔬 **Measurement**: Verified by successfully running `app:testStandardDebugUnitTest --tests "com.openclaw.assistant.speech.*"` and `app:lintStandardDebug`. No regressions introduced; chunking logic adheres strictly to bounds.

---
*PR created automatically by Jules for task [13139156274416855288](https://jules.google.com/task/13139156274416855288) started by @yuga-hashimoto*