### PR TITLE
🎨 Palette: Improve accessibility of agent selector

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-05-18 - RadioButton Grouping Accessibility
 **Learning:** Placing a `RadioButton` inside a clickable layout element (like a `Row`) using `Modifier.clickable` creates conflicting semantics, confusing screen readers by presenting multiple disjointed click targets.
 **Action:** Replace `Modifier.clickable` on the parent layout with `Modifier.selectable(role = Role.RadioButton)` and explicitly set the inner `RadioButton`'s `onClick` parameter to `null` to ensure the group is treated as a single, cohesive radio button element.
+
+## 2025-10-24 - Dropdown Trigger Accessibility
+**Learning:** Using `Modifier.clickable` without a specific role and label for a row that opens a dropdown causes screen readers to misidentify its function.
+**Action:** When a clickable element opens a dropdown menu, always use `Modifier.clickable(onClickLabel = "...", role = Role.DropdownList)` to ensure proper screen reader announcement.

--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -885,7 +886,10 @@ fun AgentSelector(
             modifier = Modifier
                 .then(
                     if (!isReadOnly && agents.isNotEmpty()) {
-                        Modifier.clickable { expanded = true }
+                        Modifier.clickable(
+                            onClickLabel = stringResource(R.string.agent_selector),
+                            role = Role.DropdownList
+                        ) { expanded = true }
                     } else {
                         Modifier
                     }


### PR DESCRIPTION
*   💡 What: Updated `Modifier.clickable` to include `onClickLabel` and `Role.DropdownList` on the Agent Selector trigger.
*   🎯 Why: To provide better screen reader support when opening the agent dropdown.
*   📸 Before/After: Not applicable (no visual change).
*   ♿ Accessibility: Added proper `role` and `onClickLabel` for screen readers on the dropdown trigger.

---
*PR created automatically by Jules for task [11671953662623331111](https://jules.google.com/task/11671953662623331111) started by @yuga-hashimoto*