### PR TITLE
chore: upgrade Firebase BOM 33.7.0→34.12.0 and Crashlytics plugin 3.0.2→3.0.7

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -252,7 +252,7 @@ dependencies {
     kapt("androidx.room:room-compiler:$roomVersion")
 
     // Firebase
-    implementation(platform("com.google.firebase:firebase-bom:33.7.0"))
+    implementation(platform("com.google.firebase:firebase-bom:34.12.0"))
     implementation("com.google.firebase:firebase-crashlytics")
     implementation("com.google.firebase:firebase-analytics")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
     id("org.jetbrains.kotlin.plugin.serialization") version "2.0.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
     id("com.google.gms.google-services") version "4.4.4" apply false
-    id("com.google.firebase.crashlytics") version "3.0.2" apply false
+    id("com.google.firebase.crashlytics") version "3.0.7" apply false
 }


### PR DESCRIPTION
## Summary / 概要

This PR upgrades Firebase Android dependencies to their latest versions.  
Firebase Android依存ライブラリを最新バージョンにアップグレードします。

| Dependency | Before | After |
|---|---|---|
| `firebase-bom` | 33.7.0 | 34.12.0 |
| `firebase-crashlytics-gradle` plugin | 3.0.2 | 3.0.7 |
| `google-services` plugin | 4.4.4 | 4.4.4 (no change) |

## Details / 詳細

**Firebase BOM 34.12.0** (released 2026-04-09):
- No breaking changes for Crashlytics or Analytics (the only services this project uses)
- KTX modules removed in 34.x — not used in this project, no impact
- minSdk raised to API 23 in 34.x — project minSdk=31, no impact

**Crashlytics Gradle plugin 3.0.7** (released 2026-04-09):
- Prevents build failures when processing unsupported native libraries
- Improved efficiency extracting breakpad binaries for NDK crash symbolication

## Note on Firebase MCP / Firebase MCPについて

Firebase MCP tools were not available in this environment, so crash log retrieval could not be performed. This PR is based on a code-level audit of dependency versions only.  
Firebase MCPツールが環境内で利用不可のため、クラッシュログの取得はできませんでした。本PRは依存バージョンのコードレベル確認のみに基づいています。

## Test plan / テスト計画

- [ ] CI passes (build + lint)
- [ ] App launches successfully on debug build
- [ ] Crashlytics test crash can be reported to Firebase console

🤖 Generated with [Claude Code](https://claude.ai/claude-code) (scheduled task: firebase health check)