### PR TITLE
🔄 Upstream Parity: correct App Actions prompt parameter typing

### DIFF
--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -11,7 +11,7 @@
             <parameter
                 android:name="prompt"
                 android:key="prompt"
-                android:mimeType="text/*"
+                android:mimeType="https://schema.org/Text"
                 android:required="true" />
         </intent>
     </capability>


### PR DESCRIPTION
- **Source:** Upstream commit `90fcc1f551`
- **Why:** To properly type the `prompt` parameter for Google Assistant App Actions (BII) capabilities. Using the correct schema org type (`https://schema.org/Text`) ensures better compatibility, recognition, and parsing by the Assistant compared to the generic `text/*` type.
- **Adaptation:** Directly applied the single-line XML configuration change to `app/src/main/res/xml/shortcuts.xml`.
- **Excluded upstream behavior:** N/A (this is a straightforward config change).
- **Verification:** Successfully ran `app:lintStandardDebug` and `app:testStandardDebugUnitTest`.

---
*PR created automatically by Jules for task [12586414824351025280](https://jules.google.com/task/12586414824351025280) started by @yuga-hashimoto*