### PR TITLE
🎨 Palette: Improve accessibility of chat sessions dialog options

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatSessionsDialog.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatSessionsDialog.kt
@@ -20,6 +20,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.openclaw.assistant.R
 import com.openclaw.assistant.chat.ChatSessionEntry
@@ -77,7 +80,7 @@ private fun SessionRow(
       } else {
         MaterialTheme.colorScheme.surfaceContainer
       },
-    modifier = Modifier.fillMaxWidth(),
+    modifier = Modifier.fillMaxWidth().semantics { role = Role.Button },
   ) {
     Row(
       modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),


### PR DESCRIPTION
- 💡 **What:** Added `Role.Button` semantic modifier to the chat session rows in the `ChatSessionsDialog`.
- 🎯 **Why:** Previously, the rows were clickable (via `Surface(onClick = ...)`), but lacked a semantic role. Adding `Role.Button` explicitly makes TalkBack correctly announce them as interactive button items.
- 📸 **Before/After:** No visual changes.
- ♿ **Accessibility:** TalkBack now correctly identifies these session selection entries as buttons, significantly improving keyboard and screen reader navigation.

---
*PR created automatically by Jules for task [13843778275046782606](https://jules.google.com/task/13843778275046782606) started by @yuga-hashimoto*