### PR TITLE
refactor: extract Crashlytics boilerplate into Throwable.recordToCrashlytics()

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/OpenClawApplication.kt
+++ b/app/src/main/java/com/openclaw/assistant/OpenClawApplication.kt
@@ -5,8 +5,8 @@ import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import com.google.firebase.FirebaseApp
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.openclaw.assistant.data.SettingsRepository
+import com.openclaw.assistant.utils.recordToCrashlytics
 import com.openclaw.assistant.node.NodeRuntime
 import java.security.Security
 
@@ -54,9 +54,7 @@ class OpenClawApplication : Application() {
             Security.insertProviderAt(bcProvider, 1)
         } catch (e: Throwable) {
             Log.e("OpenClawApp", "Failed to register Bouncy Castle provider", e)
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
         }
     }
 

--- a/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
+++ b/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
@@ -1,8 +1,7 @@
 package com.openclaw.assistant.api
 
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.gson.Gson
+import com.openclaw.assistant.utils.recordToCrashlytics
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import kotlinx.coroutines.Dispatchers
@@ -135,8 +134,8 @@ class OpenClawClient() {
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (e: Exception) {
-            if (!isTransientNetworkError(e) && BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
+            if (!isTransientNetworkError(e)) {
+                e.recordToCrashlytics()
             }
             Result.failure(e)
         }

--- a/app/src/main/java/com/openclaw/assistant/gateway/DeviceIdentity.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/DeviceIdentity.kt
@@ -3,9 +3,8 @@ package com.openclaw.assistant.gateway
 import android.content.Context
 import android.util.Base64
 import android.util.Log
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.crypto.tink.CleartextKeysetHandle
+import com.openclaw.assistant.utils.recordToCrashlytics
 import com.google.crypto.tink.JsonKeysetWriter
 import com.google.crypto.tink.KeyTemplates
 import com.google.crypto.tink.KeysetHandle
@@ -48,9 +47,7 @@ class DeviceIdentity(context: Context) {
             extractPublicKey(handle)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize: ${e.message}")
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
         }
     }
 
@@ -112,9 +109,7 @@ class DeviceIdentity(context: Context) {
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to extract public key: ${e.message}")
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
         }
     }
 
@@ -127,9 +122,7 @@ class DeviceIdentity(context: Context) {
             )
         } catch (e: Exception) {
             Log.e(TAG, "Sign failed: ${e.message}")
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
             null
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -20,9 +20,8 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.openclaw.assistant.MainActivity
 import com.openclaw.assistant.R
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.openclaw.assistant.data.SettingsRepository
+import com.openclaw.assistant.utils.recordToCrashlytics
 import kotlinx.coroutines.*
 import org.vosk.Model
 import org.vosk.Recognizer
@@ -138,9 +137,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             if (isVoskCrash) {
                 Log.e(TAG, "Caught uncaught Vosk exception on thread ${thread.name}", throwable)
                 if (throwable is UnsatisfiedLinkError || throwable.cause is UnsatisfiedLinkError) {
-                    if (BuildConfig.FIREBASE_ENABLED) {
-                        FirebaseCrashlytics.getInstance().recordException(throwable)
-                    }
+                    throwable.recordToCrashlytics()
                     getSharedPreferences("hotword_prefs", Context.MODE_PRIVATE)
                         .edit().putBoolean("vosk_unsupported", true).apply()
                     // Don't resume - device doesn't support Vosk
@@ -154,9 +151,7 @@ class HotwordService : Service(), VoskRecognitionListener {
                         }
                     }
                 } else {
-                    if (BuildConfig.FIREBASE_ENABLED) {
-                        FirebaseCrashlytics.getInstance().recordException(throwable)
-                    }
+                    throwable.recordToCrashlytics()
                     speechService = null
                     android.os.Handler(android.os.Looper.getMainLooper()).post {
                         if (!isSessionActive) {
@@ -361,9 +356,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             } catch (e: UnsatisfiedLinkError) {
                 Log.e(TAG, "Vosk native library not supported on this device", e)
                 debugLog("Vosk: UnsatisfiedLinkError — native lib not supported")
-                if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
-                }
+                e.recordToCrashlytics()
                 prefs.edit()
                     .putBoolean("vosk_unsupported", true)
                     .putInt("vosk_unsupported_version", currentVersion)
@@ -371,9 +364,7 @@ class HotwordService : Service(), VoskRecognitionListener {
             } catch (e: Exception) {
                 Log.e(TAG, "Init error", e)
                 debugLog("Vosk: init error — ${e.message}")
-                if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
-                }
+                e.recordToCrashlytics()
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawAssistantService.kt
@@ -14,8 +14,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import androidx.core.content.ContextCompat
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.utils.recordToCrashlytics
 
 /**
  * Voice Interaction Service
@@ -87,9 +86,7 @@ class OpenClawAssistantService : VoiceInteractionService() {
                 Log.e(TAG, "showSession() called immediately")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to call showSession immediately", e)
-                if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
-                }
+                e.recordToCrashlytics()
             }
         } else {
             Log.e(TAG, "Service not ready. Queuing showSession request.")
@@ -112,9 +109,7 @@ class OpenClawAssistantService : VoiceInteractionService() {
                 Log.e(TAG, "showSession() called from onReady (pending)")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to call pending showSession", e)
-                if (BuildConfig.FIREBASE_ENABLED) {
-                    FirebaseCrashlytics.getInstance().recordException(e)
-                }
+                e.recordToCrashlytics()
             }
         }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/OpenClawSession.kt
@@ -8,8 +8,7 @@ import android.service.voice.VoiceInteractionSession
 import android.speech.SpeechRecognizer
 import android.util.Log
 import android.view.LayoutInflater
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.utils.recordToCrashlytics
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -263,9 +262,7 @@ class OpenClawSession(context: Context) : VoiceInteractionSession(context),
                     currentSessionId?.let { settings.sessionId = it }
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to handle session", e)
-                    if (BuildConfig.FIREBASE_ENABLED) {
-                        FirebaseCrashlytics.getInstance().recordException(e)
-                    }
+                    e.recordToCrashlytics()
                 }
             }
         }

--- a/app/src/main/java/com/openclaw/assistant/utils/CrashlyticsExt.kt
+++ b/app/src/main/java/com/openclaw/assistant/utils/CrashlyticsExt.kt
@@ -1,0 +1,14 @@
+package com.openclaw.assistant.utils
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.openclaw.assistant.BuildConfig
+
+/**
+ * Records this throwable to Crashlytics when Firebase is enabled.
+ * No-op in builds where FIREBASE_ENABLED is false (e.g. fork PRs without a real API key).
+ */
+fun Throwable.recordToCrashlytics() {
+    if (BuildConfig.FIREBASE_ENABLED) {
+        FirebaseCrashlytics.getInstance().recordException(this)
+    }
+}

--- a/app/src/main/java/com/openclaw/assistant/utils/UpdateChecker.kt
+++ b/app/src/main/java/com/openclaw/assistant/utils/UpdateChecker.kt
@@ -1,8 +1,6 @@
 package com.openclaw.assistant.utils
 
 import android.util.Log
-import com.openclaw.assistant.BuildConfig
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.Dispatchers
@@ -70,9 +68,7 @@ object UpdateChecker {
             return@withContext null
         } catch (e: Exception) {
             Log.e(TAG, "Error checking for updates", e)
-            if (BuildConfig.FIREBASE_ENABLED) {
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+            e.recordToCrashlytics()
             return@withContext null
         }
     }


### PR DESCRIPTION
## Summary / 概要

| Item | Detail |
|------|--------|
| Type | Refactor |
| Files changed | 8 (1 new, 7 updated) |
| Lines removed | 17 net (51 deleted, 34 added) |

The 3-line Crashlytics guard pattern appeared **13 times across 7 files**:
```kotlin
if (BuildConfig.FIREBASE_ENABLED) {
    FirebaseCrashlytics.getInstance().recordException(e)
}
```
This PR extracts it into a single `Throwable` extension in `CrashlyticsExt.kt`, replacing all call sites with `e.recordToCrashlytics()`.

---

クラッシュレポート送信のボイラープレートパターン（3行）が7ファイル・13箇所に重複していたため、`Throwable`拡張関数 `recordToCrashlytics()` に集約しました。ガード条件の変更が必要な場合は1箇所を直すだけで済みます。

## Changes / 変更内容

- **New**: `utils/CrashlyticsExt.kt` — `Throwable.recordToCrashlytics()` extension
- **Updated**: `OpenClawApplication`, `OpenClawClient`, `DeviceIdentity`, `HotwordService`, `OpenClawAssistantService`, `OpenClawSession`, `UpdateChecker`
- Removed unused `import com.google.firebase.crashlytics.FirebaseCrashlytics` and `import com.openclaw.assistant.BuildConfig` from all 7 files

## Test plan / テスト計画

- [ ] Build succeeds (`./gradlew assembleDebug`)
- [ ] Release build succeeds (`./gradlew assembleRelease`)
- [ ] No Crashlytics calls outside of `CrashlyticsExt.kt` (verify with grep)
- [ ] Existing CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) via scheduled Firebase audit task