### PR TITLE
🔄 Upstream Parity: Correct App Actions prompt parameter typing

### DIFF
--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -11,7 +11,7 @@
             <parameter
                 android:name="prompt"
                 android:key="prompt"
-                android:mimeType="text/*"
+                android:mimeType="https://schema.org/Text"
                 android:required="true" />
         </intent>
     </capability>


### PR DESCRIPTION
- Source: Upstream commit `90fcc1f5515e0b78af14f9503db8a67ecb4f245f` in `openclaw/openclaw`.
- Why: Android App Actions (Built-In Intents) and Google Assistant rely on Schema.org mappings for entity extraction and parameter matching. Using the generic `text/*` MIME type can lead to ambiguity or failed extractions, while using the explicit `https://schema.org/Text` guarantees correct textual mapping for the prompt parameter. This improves the reliability of the `ASK_OPENCLAW` capability when triggered via voice.
- Adaptation: Applied the one-line XML modification directly to this repository's `shortcuts.xml`. No other changes were needed since the parameter mapping logic remains the same.
- Excluded upstream behavior: N/A. The entire relevant change was ported.
- Verification: Ensured local lint checks (`./gradlew app:lintStandardDebug`) and unit tests (`./gradlew app:testStandardDebugUnitTest`) pass successfully with the updated XML attribute.

---
*PR created automatically by Jules for task [10749643715410714629](https://jules.google.com/task/10749643715410714629) started by @yuga-hashimoto*