### PR TITLE
fix: guard null return from MessageDigest.digest() in DeviceIdentity

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/DeviceIdentity.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/DeviceIdentity.kt
@@ -89,23 +89,23 @@ class DeviceIdentity(context: Context) {
                 if (typeUrl.endsWith("Ed25519PublicKey")) {
                     val valBase64 = keyData.getString("value")
                     val protoBytes = Base64.decode(valBase64, Base64.DEFAULT)
-                    
+
                     // Ed25519PublicKey proto: [08 00 12 20 <32 bytes>]
                     // We need the last 32 bytes
                     if (protoBytes.size >= 32) {
                          val rawKey = protoBytes.copyOfRange(protoBytes.size - 32, protoBytes.size)
-                         
+
                          // Base64Url encode without padding for transport
                          publicKeyBase64Url = Base64.encodeToString(
-                             rawKey, 
+                             rawKey,
                              Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP
                          )
-                         
+
                          // Device ID is SHA-256 of raw public key
                          val digest = MessageDigest.getInstance("SHA-256")
-                         val hash = digest.digest(rawKey)
+                         val hash = digest.digest(rawKey) ?: return
                          deviceId = bytesToHex(hash)
-                         
+
                          Log.d(TAG, "Initialized deviceId=$deviceId")
                     }
                 }
@@ -120,7 +120,7 @@ class DeviceIdentity(context: Context) {
 
     fun sign(data: String): String? {
         return try {
-            val signature = signer?.sign(data.toByteArray(Charsets.UTF_8))
+            val signature = signer?.sign(data.toByteArray(Charsets.UTF_8)) ?: return null
             Base64.encodeToString(
                 signature,
                 Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP


### PR DESCRIPTION
## Summary / 概要

**EN:** Fix a `NullPointerException` in `DeviceIdentity.bytesToHex` that was the #1 Crashlytics issue for the release app — **185 events, 74 affected users** in the last 7 days (v2.4.8).

**JA:** リリースアプリのCrashlytics最多発生バグ（7日間で185件・74ユーザーに影響）である `DeviceIdentity.bytesToHex` の NullPointerException を修正。

## Changes / 変更内容

| File | Change |
|------|--------|
| `DeviceIdentity.kt` | Add `?: return` guard on `MessageDigest.digest()` result before passing to `bytesToHex()` |
| `DeviceIdentity.kt` | Add `?: return null` guard on `signer?.sign()` result before passing to `Base64.encodeToString()` |

**EN:**
- `MessageDigest.digest()` is a Java API whose return type is `ByteArray!` (platform type) in Kotlin — the null-safety contract is not enforced at compile time. Without the guard, a null return would produce `NullPointerException: Attempt to read from null array` inside `bytesToHex()`.
- `signer?.sign()` returns `ByteArray?` when `signer` is null (i.e., key init failed). `Base64.encodeToString(null, …)` throws NPE — this was a latent bug waiting to crash the same way.

**JA:**
- `MessageDigest.digest()` はJava APIのためKotlinではプラットフォーム型（`ByteArray!`）扱いとなり、コンパイル時のnull安全保証が適用されない。nullが返った場合に `bytesToHex()` 内で `NullPointerException: Attempt to read from null array` が発生していた。
- `signer?.sign()` はsigner初期化失敗時に `ByteArray?` を返すが、`Base64.encodeToString(null, …)` はNPEを投げるため同様の潜在的クラッシュがあった。

## Crashlytics Reference / Crashlytics参照

| | |
|---|---|
| Issue ID | `8ce322a51891e507d0438bc5e86d6b5a` |
| Error | `NullPointerException – Attempt to read from null array` |
| Events (7d) | 185 |
| Affected users (7d) | 74 |
| First seen | v2.4.8 |

## Test Plan / テスト計画

- [ ] **EN:** Build and run on device — verify `DeviceIdentity` initializes normally and `deviceId` is set.
- [ ] **EN:** Confirm Crashlytics issue count drops after releasing a build with this fix.
- [ ] **JA:** デバイスでビルド・実行し、`DeviceIdentity` が正常に初期化されて `deviceId` がセットされることを確認。
- [ ] **JA:** このfixを含むビルドリリース後、Crashlyticsの件数が減少することを確認。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)