### PR TITLE
🎨 Polish: Improve accessibility of Chat Sessions dialog

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatSessionsDialog.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatSessionsDialog.kt
@@ -20,6 +20,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.unit.dp
 import com.openclaw.assistant.R
 import com.openclaw.assistant.chat.ChatSessionEntry
@@ -77,7 +80,7 @@ private fun SessionRow(
       } else {
         MaterialTheme.colorScheme.surfaceContainer
       },
-    modifier = Modifier.fillMaxWidth(),
+    modifier = Modifier.fillMaxWidth().semantics { role = androidx.compose.ui.semantics.Role.Button },
   ) {
     Row(
       modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),


### PR DESCRIPTION
This PR improves the accessibility of the Chat Sessions dialog.

Currently, the `SessionRow` in `ChatSessionsDialog.kt` uses a `Surface` with an `onClick` parameter to handle item selection. However, it does not provide an explicit semantic role. This causes screen readers like TalkBack to read the row contents without announcing that the element is an interactive button.

This change adds `Modifier.semantics { role = Role.Button }` to the `Surface` wrapper to correctly announce the row as an interactive button to visually impaired users. This ensures compliance with standard accessibility practices in Jetpack Compose.

---
*PR created automatically by Jules for task [84415157251480330](https://jules.google.com/task/84415157251480330) started by @yuga-hashimoto*