### PR TITLE
🔄 Upstream Parity: modernize discovery API usage

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewayDiscovery.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewayDiscovery.kt
@@ -14,6 +14,7 @@ import java.io.IOException
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.charset.CodingErrorAction
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
@@ -358,7 +359,7 @@ class GatewayDiscovery(
   }
 
   private fun records(msg: Message?, section: Int): List<Record> {
-    return msg?.getSectionArray(section)?.toList() ?: emptyList()
+    return msg?.getSection(section).orEmpty()
   }
 
   private fun keyName(raw: String): String {
@@ -434,14 +435,14 @@ class GatewayDiscovery(
           try {
             SimpleResolver().apply {
               setAddress(InetSocketAddress(addr, 53))
-              setTimeout(3)
+              setTimeout(Duration.ofSeconds(3))
             }
           } catch (_: Throwable) {
             null
           }
         }
       if (resolvers.isEmpty()) return null
-      ExtendedResolver(resolvers.toTypedArray()).apply { setTimeout(3) }
+      ExtendedResolver(resolvers.toTypedArray()).apply { setTimeout(Duration.ofSeconds(3)) }
     } catch (_: Throwable) {
       null
     }


### PR DESCRIPTION
- Source: https://github.com/openclaw/openclaw/commit/44a6e50fcc53d5d8a190fb1728e375b0a79334ac
- Why: Using `java.time.Duration` for timeouts provides clearer semantics than arbitrary integers (preventing bugs where the unit might be misinterpreted), and using `.orEmpty()` simplifies DNS section array retrieval safely.
- Adaptation: Applied the `java.time.Duration` import and usage inside `GatewayDiscovery.kt`. Also ported the simplification for DNS message sections to use `.orEmpty()`.
- Excluded upstream behavior: Intentionally skipped the WebView adjustments (like algorithmic darkening checks) from the same commit, as the `openclaw-assistant` repository's `CanvasScreen` structure implements different logic for Force Dark and doesn't fully match the upstream webview hierarchy.
- Verification: Ran `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug` with a dummy google-services.json file; all passed.

---
*PR created automatically by Jules for task [12793656081924246344](https://jules.google.com/task/12793656081924246344) started by @yuga-hashimoto*