### PR TITLE
fix: await connect nonce even on loopback host

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
@@ -676,7 +676,6 @@ class GatewaySession(
     }
 
     private suspend fun awaitConnectNonce(): String? {
-      if (isLoopbackHost(endpoint.host)) return null
       return try {
         withTimeout(2_000) { connectNonceDeferred.await() }
       } catch (_: Throwable) {


### PR DESCRIPTION
## Summary

The gateway handshake sends a `connect.challenge` nonce that the client must sign, for both local and remote gateways (required unconditionally since the upstream change around v2026.4.11). `awaitConnectNonce()` currently short-circuits to `null` whenever the endpoint host is loopback, on the assumption that loopback is always a trusted local gateway that doesn't issue a challenge.

That assumption breaks when `127.0.0.1` is actually an SSH port-forward (or similar tunnel) to a **remote** gateway. The server still sends `connect.challenge` with a `nonce`, the client ignores it, and the server rejects the `connect` frame with:

```
invalid connect params: at /device: must have required property 'nonce'
```

Reproduces reliably over `ssh -L 18789:localhost:18789 <remote>` pointed at any gateway running a recent upstream version.

Fixes #296.

## Changes

Remove the `isLoopbackHost` short-circuit in `awaitConnectNonce()`. The existing 2-second timeout preserves the original ergonomic for genuinely-local dev gateways that omit `connect.challenge` — they fall through to `null` and the handshake proceeds exactly as before.

`isLoopbackHost` itself is retained; it is still used by `normalizeCanvasHostUrl`.

## Relation to #441

Issue #441 already documents that "loopback = trusted local gateway" is no longer a safe assumption at the TLS layer. This PR applies the same reasoning to the nonce handshake.

## Test plan

- [x] Node connects over SSH tunnel to remote gateway at `127.0.0.1:18789` — previously failed with "must have required property 'nonce'"
- [x] Node still connects to a genuinely-local dev gateway that omits `connect.challenge` (2 s timeout fires; nonce is `null`; flow unchanged)
- [x] `FIREBASE_ENABLED=false ./gradlew lintStandardDebug` — BUILD SUCCESSFUL
- [x] `FIREBASE_ENABLED=false ./gradlew clean testStandardDebugUnitTest` — BUILD SUCCESSFUL (125 tests, 0 failures)