### PR TITLE
🎨 Polish: Improve missing scope card

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1304,18 +1304,22 @@ fun MissingScopeCard(error: String, onClick: () -> Unit) {
     val onClickLabel = stringResource(if (expanded) R.string.action_collapse else R.string.action_expand)
 
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .semantics(mergeDescendants = true) {
-                this.onClick(label = onClickLabel, action = null)
-                role = Role.Button
-            },
+        modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer), 
-        onClick = { expanded = !expanded }
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer)
     ) {
-        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(
+                        onClick = { expanded = !expanded },
+                        onClickLabel = onClickLabel,
+                        role = Role.Button
+                    )
+                    .padding(16.dp)
+            ) {
                 Icon(
                     imageVector = Icons.Default.Error, 
                     contentDescription = null, 
@@ -1352,7 +1356,7 @@ fun MissingScopeCard(error: String, onClick: () -> Unit) {
             }
 
             if (expanded) {
-                Spacer(modifier = Modifier.height(16.dp))
+                Column(modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 16.dp)) {
                 // Fix Request Section
                 Text(
                     text = stringResource(R.string.fix_request_label),
@@ -1434,6 +1438,7 @@ fun MissingScopeCard(error: String, onClick: () -> Unit) {
                     ) {
                         Text(stringResource(R.string.action_open_settings))
                     }
+                }
                 }
             }
         }


### PR DESCRIPTION
Removed redundant card-wide semantics merge and move clickable role to the header Row, ensuring individual child buttons within the expanded content remain fully accessible and usable for TalkBack users.

---
*PR created automatically by Jules for task [2301761719210328753](https://jules.google.com/task/2301761719210328753) started by @yuga-hashimoto*