### PR TITLE
🔄 Upstream Parity: Android: modernize WebView and discovery API usage (#67627)

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CanvasController.kt
@@ -73,6 +73,12 @@ class CanvasController {
         allowFileAccess = false
         allowContentAccess = false
         mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+        builtInZoomControls = false
+        displayZoomControls = false
+        setSupportZoom(false)
+        if (androidx.webkit.WebViewFeature.isFeatureSupported(androidx.webkit.WebViewFeature.ALGORITHMIC_DARKENING)) {
+          androidx.webkit.WebSettingsCompat.setAlgorithmicDarkeningAllowed(this, false)
+        }
       }
       // Required so JavaScript interactions (dialogs, file choosers, etc.) work properly.
       // Without this, alert()/confirm() calls silently fail and can halt button actions.


### PR DESCRIPTION
- Source
https://github.com/openclaw/openclaw/commit/44a6e50fcc53d5d8a190fb1728e375b0a79334ac

- Why
To prevent system-level pinch-to-zoom and forced dark-mode color inversion, avoiding common UX bugs and visual regressions in the embedded web UI (Canvas).

- Adaptation
Ported the WebView `builtInZoomControls`, `displayZoomControls`, `setSupportZoom`, and `WebSettingsCompat.setAlgorithmicDarkeningAllowed` additions from `CanvasScreen.kt` upstream directly into this app's `CanvasController.kt` initialization block, mapping fully qualified paths to ensure safety across API levels.

- Excluded upstream behavior
Excluded the `GatewayDiscovery.kt` updates from the original commit since those require a major version bump of `dnsjava` which is outside the scope of a single small improvement.

- Verification
Run `./gradlew app:lintStandardDebug` and `./gradlew app:testStandardDebugUnitTest` successfully on local mock environment.

---
*PR created automatically by Jules for task [13371629575071912904](https://jules.google.com/task/13371629575071912904) started by @yuga-hashimoto*