### PR TITLE
🎨 Palette: Add button semantic role to Chat Sessions row

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-05-18 - RadioButton Grouping Accessibility
 **Learning:** Placing a `RadioButton` inside a clickable layout element (like a `Row`) using `Modifier.clickable` creates conflicting semantics, confusing screen readers by presenting multiple disjointed click targets.
 **Action:** Replace `Modifier.clickable` on the parent layout with `Modifier.selectable(role = Role.RadioButton)` and explicitly set the inner `RadioButton`'s `onClick` parameter to `null` to ensure the group is treated as a single, cohesive radio button element.
+
+## 2025-05-20 - Interactive Surfaces Need Semantic Roles
+**Learning:** Using `Surface(onClick = ...)` in Jetpack Compose makes the element clickable but does not intrinsically apply a semantic role. Without a role, TalkBack treats the element as a generic clickable area, which is less descriptive for users than identifying it as a button.
+**Action:** When using `Surface` as a custom button or interactive row, always append `.semantics { role = Role.Button }` (or appropriate role) to its `Modifier` so screen readers announce it properly.

--- a/app/src/main/java/com/openclaw/assistant/ui/chat/ChatSessionsDialog.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/chat/ChatSessionsDialog.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.openclaw.assistant.R
 import com.openclaw.assistant.chat.ChatSessionEntry
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.role
 
 @Composable
 fun ChatSessionsDialog(
@@ -77,7 +79,9 @@ private fun SessionRow(
       } else {
         MaterialTheme.colorScheme.surfaceContainer
       },
-    modifier = Modifier.fillMaxWidth(),
+    modifier = Modifier
+      .fillMaxWidth()
+      .semantics { role = androidx.compose.ui.semantics.Role.Button },
   ) {
     Row(
       modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),


### PR DESCRIPTION
💡 What: Added a semantic button role to the Chat Session selection row in the Sessions Dialog.
🎯 Why: Ensures screen readers like TalkBack correctly announce the row as an interactive button.
♿ Accessibility: explicitly sets the semantic role on the interactive Surface so TalkBack behaves appropriately.

---
*PR created automatically by Jules for task [17475818479854429820](https://jules.google.com/task/17475818479854429820) started by @yuga-hashimoto*