### PR TITLE
⚡ Bolt: Optimize formatting of AgentMessage and DeviceAuthPayload by removing list allocations

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
@@ -816,21 +816,15 @@ class GatewaySession(
     val scopeString = scopes.joinToString(",")
     val authToken = token.orEmpty()
     val version = if (nonce.isNullOrBlank()) "v1" else "v2"
-    val parts =
-      mutableListOf(
-        version,
-        deviceId,
-        clientId,
-        clientMode,
-        role,
-        scopeString,
-        signedAtMs.toString(),
-        authToken,
-      )
-    if (!nonce.isNullOrBlank()) {
-      parts.add(nonce)
+
+    // ⚡ Bolt Optimization: Eliminated mutableListOf().joinToString() to avoid list allocation overhead and reduce GC pressure.
+    val base = "$version|$deviceId|$clientId|$clientMode|$role|$scopeString|$signedAtMs|$authToken"
+
+    return if (!nonce.isNullOrBlank()) {
+      "$base|$nonce"
+    } else {
+      base
     }
-    return parts.joinToString("|")
   }
 
 }

--- a/app/src/main/java/com/openclaw/assistant/protocol/OpenClawCanvasA2UIAction.kt
+++ b/app/src/main/java/com/openclaw/assistant/protocol/OpenClawCanvasA2UIAction.kt
@@ -45,16 +45,16 @@ object OpenClawCanvasA2UIAction {
         contextJson: String?,
     ): String {
         val ctxSuffix = contextJson?.takeIf { it.isNotBlank() }?.let { " ctx=$it" }.orEmpty()
-        return listOf(
-            "CANVAS_A2UI",
-            "action=${sanitizeTagValue(actionName)}",
-            "session=${sanitizeTagValue(sessionKey)}",
-            "surface=${sanitizeTagValue(surfaceId)}",
-            "component=${sanitizeTagValue(sourceComponentId)}",
-            "host=${sanitizeTagValue(host)}",
-            "instance=${sanitizeTagValue(instanceId)}$ctxSuffix",
-            "default=update_canvas",
-        ).joinToString(separator = " ")
+
+        // ⚡ Bolt Optimization: Eliminated listOf().joinToString() to avoid list allocation overhead and reduce GC pressure.
+        val actionPart = "action=${sanitizeTagValue(actionName)}"
+        val sessionPart = "session=${sanitizeTagValue(sessionKey)}"
+        val surfacePart = "surface=${sanitizeTagValue(surfaceId)}"
+        val componentPart = "component=${sanitizeTagValue(sourceComponentId)}"
+        val hostPart = "host=${sanitizeTagValue(host)}"
+        val instancePart = "instance=${sanitizeTagValue(instanceId)}$ctxSuffix"
+
+        return "CANVAS_A2UI $actionPart $sessionPart $surfacePart $componentPart $hostPart $instancePart default=update_canvas"
     }
 
     fun jsDispatchA2UIActionStatus(actionId: String, ok: Boolean, error: String?): String {


### PR DESCRIPTION
💡 What: Replaced `listOf().joinToString()` and `mutableListOf().joinToString()` with direct Kotlin string interpolation in `formatAgentMessage` and `buildDeviceAuthPayload`.
🎯 Why: Instantiating intermediate collections just to join strings inside frequent serialization paths causes unnecessary memory allocations, creating GC pressure.
📊 Impact: Eliminates list allocation overhead on every agent payload format and device auth payload build operation.
🔬 Measurement: Local tests and linters pass confirming correctness, lower allocation rates in hot path profiling.

---
*PR created automatically by Jules for task [13632636283714341310](https://jules.google.com/task/13632636283714341310) started by @yuga-hashimoto*