### PR TITLE
🔄 Upstream Parity: modernize dnsjava usage in GatewayDiscovery

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewayDiscovery.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewayDiscovery.kt
@@ -14,6 +14,7 @@ import java.io.IOException
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.charset.CodingErrorAction
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
@@ -358,7 +359,7 @@ class GatewayDiscovery(
   }
 
   private fun records(msg: Message?, section: Int): List<Record> {
-    return msg?.getSectionArray(section)?.toList() ?: emptyList()
+    return msg?.getSection(section).orEmpty()
   }
 
   private fun keyName(raw: String): String {
@@ -434,14 +435,14 @@ class GatewayDiscovery(
           try {
             SimpleResolver().apply {
               setAddress(InetSocketAddress(addr, 53))
-              setTimeout(3)
+              setTimeout(Duration.ofSeconds(3))
             }
           } catch (_: Throwable) {
             null
           }
         }
       if (resolvers.isEmpty()) return null
-      ExtendedResolver(resolvers.toTypedArray()).apply { setTimeout(3) }
+      ExtendedResolver(resolvers.toTypedArray()).apply { setTimeout(Duration.ofSeconds(3)) }
     } catch (_: Throwable) {
       null
     }


### PR DESCRIPTION
- Source: https://github.com/openclaw/openclaw/commit/44a6e50fcc53d5d8a190fb1728e375b0a79334ac
- Why: Updates deprecated integer-based timeouts in dnsjava to `java.time.Duration` and replaces the manual array conversion with the cleaner `orEmpty()` handling, improving correctness and clarity in local network discovery.
- Adaptation: Applied directly to `GatewayDiscovery.kt` with required duration import added.
- Excluded upstream behavior: Skipped the bundled WebView Algorithmic Darkening changes to adhere to the strict "one small conceptual change" constraint.
- Verification: Ran `./gradlew app:testStandardDebugUnitTest` and `./gradlew app:lintStandardDebug` (0 failures).

---
*PR created automatically by Jules for task [2344302371483777379](https://jules.google.com/task/2344302371483777379) started by @yuga-hashimoto*