### PR TITLE
🎨 Polish: Improve SystemStatusCard colors for dark mode

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1043,14 +1043,14 @@ fun SystemStatusCard(
     val isConnecting = statusText.contains("Connecting", ignoreCase = true) || statusText.contains("Verify gateway TLS fingerprint", ignoreCase = true)
 
     val backgroundColor = when {
-        connected -> Color(0xFFE8F5E9)
-        isConnecting -> Color(0xFFFFF3E0)
-        else -> Color(0xFFFFEBEE)
+        connected -> MaterialTheme.colorScheme.primaryContainer
+        isConnecting -> MaterialTheme.colorScheme.surfaceVariant
+        else -> MaterialTheme.colorScheme.errorContainer
     }
     val contentColor = when {
-        connected -> Color(0xFF1B5E20)
-        isConnecting -> Color(0xFFE65100)
-        else -> Color(0xFFB71C1C)
+        connected -> MaterialTheme.colorScheme.onPrimaryContainer
+        isConnecting -> MaterialTheme.colorScheme.onSurfaceVariant
+        else -> MaterialTheme.colorScheme.onErrorContainer
     }
 
     Card(


### PR DESCRIPTION
**What**: Replaced the hardcoded hex colors (`Color(0xFFE8F5E9)`, etc.) in `MainActivity`'s `SystemStatusCard` with `MaterialTheme.colorScheme` properties.
**Why**: To properly support dark mode natively using Material 3 theming without looking jarring, while retaining semantic color meaning (Primary for connected, Surface for connecting, Error for disconnected).
**Verification**: Ran `app:lintStandardDebug` and `app:testStandardDebugUnitTest`.

---
*PR created automatically by Jules for task [4301278356427290038](https://jules.google.com/task/4301278356427290038) started by @yuga-hashimoto*