### PR TITLE
🔄 Upstream Parity: fix(android): tighten pairing retry behavior

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import kotlinx.coroutines.delay
 import androidx.compose.runtime.saveable.rememberSaveable
 import com.openclaw.assistant.ui.components.PAIRING_AUTO_RETRY_MS
 import androidx.compose.ui.Alignment
@@ -983,14 +982,12 @@ private fun FinalCheckStep(
 
 
 
-    LaunchedEffect(isPairingRequired, attemptedConnect) {
+    LaunchedEffect(isPairingRequired) {
         if (isPairingRequired) pairingDetected = true
+    }
 
-        if (!isPairingRequired || !attemptedConnect) return@LaunchedEffect
-        while (true) {
-            delay(PAIRING_AUTO_RETRY_MS)
-            runtime.refreshGatewayConnection()
-        }
+    com.openclaw.assistant.ui.components.PairingAutoRetryEffect(enabled = isPairingRequired && attemptedConnect) {
+        runtime.refreshGatewayConnection()
     }
 
     val gatewayUrl = remember(manualHost, manualPort, manualTls) {

--- a/app/src/main/java/com/openclaw/assistant/ui/components/GatewayPairingRetryEffect.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/GatewayPairingRetryEffect.kt
@@ -1,0 +1,43 @@
+package com.openclaw.assistant.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import kotlinx.coroutines.delay
+
+@Composable
+internal fun PairingAutoRetryEffect(enabled: Boolean, onRetry: () -> Unit) {
+  val lifecycleOwner = LocalLifecycleOwner.current
+  var lifecycleStarted by
+    remember(lifecycleOwner) {
+      mutableStateOf(lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED))
+    }
+
+  DisposableEffect(lifecycleOwner) {
+    val observer =
+      LifecycleEventObserver { _, _ ->
+        lifecycleStarted = lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+      }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose {
+      lifecycleOwner.lifecycle.removeObserver(observer)
+    }
+  }
+
+  LaunchedEffect(enabled, lifecycleStarted) {
+    if (!enabled || !lifecycleStarted) {
+      return@LaunchedEffect
+    }
+    while (true) {
+      delay(PAIRING_AUTO_RETRY_MS)
+      onRetry()
+    }
+  }
+}

--- a/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
@@ -12,7 +12,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -39,11 +38,8 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
 
     var expanded by remember { mutableStateOf(false) }
 
-    LaunchedEffect(Unit) {
-        while (true) {
-            delay(PAIRING_AUTO_RETRY_MS)
-            nodeRuntime.refreshGatewayConnection()
-        }
+    PairingAutoRetryEffect(enabled = true) {
+        nodeRuntime.refreshGatewayConnection()
     }
 
     Card(


### PR DESCRIPTION
- Source: Upstream commit `1f899f8442` ("fix(android): tighten pairing retry behavior") by Ayaan Zaidi
- Why: Replaces unconditional `delay` inside a `LaunchedEffect` loop with a lifecycle-aware observer. This prevents the pairing screen from attempting to spam gateway connection retries while the app is backgrounded, reducing battery and system resource consumption.
- Adaptation: Adapted to the `com.openclaw.assistant` package namespace. Created `GatewayPairingRetryEffect.kt` locally with the `PairingAutoRetryEffect` composable and integrated it into the `PairingRequiredCard` and `SetupGuideScreen`.
- Excluded upstream behavior: The `ConnectTabScreen` and `OnboardingFlow` usages from upstream were excluded or mapped to their local equivalents (`PairingRequiredCard`, `SetupGuideScreen`).
- Verification: Passed `./gradlew app:lintStandardDebug` and `./gradlew app:testStandardDebugUnitTest`. Tested compilation.

---
*PR created automatically by Jules for task [3468533330931594198](https://jules.google.com/task/3468533330931594198) started by @yuga-hashimoto*