### PR TITLE
🧪 Regression Guard: Fix background service crash stability

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -61,6 +61,11 @@ class HotwordService : Service(), VoskRecognitionListener {
                 context.stopService(intent)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
+                try {
+                    context.stopService(intent)
+                } catch (e2: Exception) {
+                    Log.e(TAG, "Failed to stop HotwordService: ${e2.message}", e2)
+                }
             }
         }
 

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -46,6 +46,11 @@ class SessionForegroundService : Service() {
                 context.stopService(intent)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
+                try {
+                    context.stopService(intent)
+                } catch (e2: Exception) {
+                    Log.e(TAG, "Failed to stop SessionForegroundService: ${e2.message}", e2)
+                }
             }
         }
 


### PR DESCRIPTION
🎯 What: Added nested `try-catch` blocks around the `context.stopService(intent)` fallback calls in `HotwordService` and `SessionForegroundService`.
💡 Why: If `startForegroundService` fails and throws an exception, the fallback cleanup (`stopService`) might also throw an exception, potentially causing a crash. Wrapping the cleanup ensures the application remains stable even if cleanup fails.
✅ Verification: Tested locally using unit tests and linting.
✨ Result: Increased resilience against unexpected background service management failures on various Android versions.

---
*PR created automatically by Jules for task [11685899749060411550](https://jules.google.com/task/11685899749060411550) started by @yuga-hashimoto*