### PR TITLE
🛡️ Sentinel: Sanitize gateway connection error messages

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
@@ -432,14 +432,13 @@ class GatewaySession(
           handleConnectSuccess(res, canFallbackToShared, identityId)
           return
         }
-        val msg = res.error?.message ?: "connect failed"
         Log.w(TAG, "BootstrapToken auth failed (code=${res.error?.code})")
         // The server consumed the bootstrapToken on first use. Clear it from the desired connection
         // so subsequent retries don't loop on the same expired token. The consumer is notified via
         // onBootstrapTokenInvalid to also clear it from persistent storage.
         this@GatewaySession.desired = this@GatewaySession.desired?.copy(bootstrapToken = null)
         onBootstrapTokenInvalid?.invoke()
-        throw IllegalStateException(msg)
+        throw IllegalStateException("connect failed (code=${res.error?.code ?: "unknown"})")
       }
 
       // If no explicit token is configured but password is set, use password auth directly.
@@ -454,9 +453,8 @@ class GatewaySession(
           handleConnectSuccess(passwordRes, canFallbackToShared, identityId)
           return
         }
-        val msg = passwordRes.error?.message ?: "connect failed"
         Log.w(TAG, "Password auth failed (code=${passwordRes.error?.code})")
-        throw IllegalStateException(msg)
+        throw IllegalStateException("connect failed (code=${passwordRes.error?.code ?: "unknown"})")
       }
 
       // Try automatic auth mode detection: token first, then password fallback.
@@ -488,27 +486,24 @@ class GatewaySession(
           }
 
           // Both failed
-          val msg = passwordRes.error?.message ?: "connect failed"
           Log.w(TAG, "Password auth failed (code=${passwordRes.error?.code})")
           if (canFallbackToShared || !storedToken.isNullOrBlank()) {
             deviceAuthStore.clearToken(identityId, options.role)
           }
-          throw IllegalStateException(msg)
+          throw IllegalStateException("connect failed (code=${passwordRes.error?.code ?: "unknown"})")
         }
 
         // Token failed and no password provided
-        val msg = tokenRes.error?.message ?: "connect failed"
         if (canFallbackToShared || !storedToken.isNullOrBlank()) {
           deviceAuthStore.clearToken(identityId, options.role)
         }
-        throw IllegalStateException(msg)
+        throw IllegalStateException("connect failed (code=${tokenRes.error?.code ?: "unknown"})")
       } else {
         // No credential provided, try connect without auth
         val payload = buildConnectParams(identity, connectNonce, "", null)
         val res = request("connect", payload, timeoutMs = 8_000)
         if (!res.ok) {
-          val msg = res.error?.message ?: "connect failed"
-          throw IllegalStateException(msg)
+          throw IllegalStateException("connect failed (code=${res.error?.code ?: "unknown"})")
         }
         handleConnectSuccess(res, false, identityId)
       }

--- a/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/NodeRuntime.kt
@@ -355,8 +355,7 @@ class NodeRuntime(context: Context) {
       onInvoke = { req ->
         val result = invokeDispatcher.handleInvoke(req.command, req.paramsJson)
         if (!result.ok) {
-          val errorMsg = result.error?.message ?: "Unknown error"
-          reportCapabilityError(errorMsg)
+          reportCapabilityError("Command failed (code=${result.error?.code ?: "UNKNOWN"})")
         }
         result
       },


### PR DESCRIPTION
**What**
Sanitized dynamic error messages that were previously thrown as `IllegalStateException` or exposed in capability error reports. Instead of using the raw `error.message` directly from the server/gateway, the code now uses structured strings like `"connect failed (code=${res.error?.code ?: "unknown"})"` or `"Command failed (code=${result.error?.code ?: "UNKNOWN"})"`. The detailed, unsanitized messages have been removed from exceptions and logs.

**Why**
The original implementation read unverified `res.error?.message` strings provided by the gateway or local server and injected them directly into `IllegalStateException` throws and `reportCapabilityError()`. This leaked potentially verbose or sensitive gateway-controlled error strings into the local application's logs or state. By logging and throwing only the standardized error code (`res.error?.code`), we reduce the risk of information disclosure and adhere to the security principle of avoiding overly verbose error messages.

**Verification**
- Created python patch script and applied `content.find()` and slicing logic to safely update the multi-line Kotlin statements without formatting regressions.
- Passed `app:testStandardDebugUnitTest`.
- Passed `app:lintStandardDebug`.
- Checked diff to ensure all 5 `GatewaySession` instances and 1 `NodeRuntime` instance were correctly modified.

---
*PR created automatically by Jules for task [1753198185991517733](https://jules.google.com/task/1753198185991517733) started by @yuga-hashimoto*