### PR TITLE
🧪 Regression Guard: Fix service stop crash

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,10 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (se: Exception) { Log.e(TAG, "Failed to stop HotwordService", se) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (se: Exception) { Log.e(TAG, "Failed to stop HotwordService", se) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,10 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (se: Exception) { android.util.Log.e(TAG, "Failed to stopService", se) }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (se: Exception) { android.util.Log.e(TAG, "Failed to stopService", se) }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,10 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (se: Exception) { Log.e(TAG, "Failed to stop SessionForegroundService", se) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (se: Exception) { Log.e(TAG, "Failed to stop SessionForegroundService", se) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
**Issue:** When Android 12+ background execution limits or Android 14+ media projection restrictions prevent a foreground service from starting, the OS throws an `IllegalStateException` or `SecurityException`. The existing exception handlers correctly attempt to clean up by calling `context.stopService(intent)`. However, if the OS already considers the service invalid, `stopService` itself can throw an exception, resulting in an unhandled fatal crash.

**Fix:** Wraps the `stopService` fallback calls within nested `try-catch` blocks across `HotwordService`, `SessionForegroundService`, and `NodeForegroundService`. This allows the application to fail gracefully and log the issue without crashing the entire background process.

---
*PR created automatically by Jules for task [13085118663097289270](https://jules.google.com/task/13085118663097289270) started by @yuga-hashimoto*