### PR TITLE
🎨 Polish: Improve disconnected status clarity

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
@@ -50,7 +50,7 @@ fun StatusIndicator(
     val dotColor = when (state) {
         ConnectionState.Connected -> Color(0xFF4CAF50)
         ConnectionState.Connecting -> Color(0xFFFFA726)
-        ConnectionState.Disconnected -> Color(0xFF757575)
+        ConnectionState.Disconnected -> MaterialTheme.colorScheme.error
     }
 
     val stateDesc = when (state) {


### PR DESCRIPTION
Updates the StatusIndicator to use `MaterialTheme.colorScheme.error` instead of a hardcoded neutral grey (`0xFF757575`) when in the `Disconnected` state. 

This makes the disconnected state more visible and actionable, drawing attention to the fact that the gateway connection is offline, which is a critical error state for an app that relies heavily on local gateway connectivity.

---
*PR created automatically by Jules for task [16686398654932101030](https://jules.google.com/task/16686398654932101030) started by @yuga-hashimoto*