### PR TITLE
🧪 Regression Guard: Fix background service cleanup crash

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,18 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    Log.e(TAG, "Failed to stopService as well", stopEx)
+                }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    Log.e(TAG, "Failed to stopService as well", stopEx)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,18 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try {
+            context.stopService(intent)
+        } catch (stopEx: Exception) {
+            android.util.Log.e(TAG, "Failed to stopService as well", stopEx)
+        }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try {
+            context.stopService(intent)
+        } catch (stopEx: Exception) {
+            android.util.Log.e(TAG, "Failed to stopService as well", stopEx)
+        }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,18 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    Log.e(TAG, "Failed to stopService as well", stopEx)
+                }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    Log.e(TAG, "Failed to stopService as well", stopEx)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
**What**
Wrapped the fallback `context.stopService(intent)` calls inside `try-catch` blocks within the `start()` methods of background services (`HotwordService.kt`, `SessionForegroundService.kt`, and `NodeForegroundService.kt`).

**Why**
When starting a service fails (e.g., due to `IllegalStateException` or `SecurityException` from Android background execution limits), the fallback code calls `context.stopService(intent)` to clean up. However, depending on the exact context state and Android version, `stopService` itself can throw an exception, resulting in an unhandled fatal crash. This defensively hardens the cleanup routines.

**Verification**
- Verified the `stopService` calls are properly nested with a try-catch block.
- `./gradlew app:lintStandardDebug` passes.
- `./gradlew app:testStandardDebugUnitTest` passes.

---
*PR created automatically by Jules for task [8990355519591267913](https://jules.google.com/task/8990355519591267913) started by @yuga-hashimoto*