### PR TITLE
⚡ Bolt: Optimize ChatMarkdownPreprocessor split allocation

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/chat/ChatMarkdownPreprocessor.kt
+++ b/app/src/main/java/com/openclaw/assistant/chat/ChatMarkdownPreprocessor.kt
@@ -33,11 +33,14 @@ object ChatMarkdownPreprocessor {
         if (inboundContextHeaders.none { raw.contains(it) }) return raw
 
         val normalized = raw.replace("\r\n", "\n")
-        val outputLines = mutableListOf<String>()
+        // ⚡ Bolt Optimization: Replace split("\n") and joinToString with lineSequence() and a direct StringBuilder
+        // to avoid list allocation overhead and intermediate string garbage.
+        val output = StringBuilder(raw.length)
         var inMetaBlock = false
         var inFencedJson = false
+        var isFirstLine = true
 
-        for (line in normalized.split("\n")) {
+        for (line in normalized.lineSequence()) {
             if (!inMetaBlock && inboundContextHeaders.any { line.startsWith(it) }) {
                 inMetaBlock = true
                 inFencedJson = false
@@ -62,10 +65,14 @@ object ChatMarkdownPreprocessor {
                 inMetaBlock = false
             }
 
-            outputLines.add(line)
+            if (!isFirstLine) {
+                output.append("\n")
+            }
+            output.append(line)
+            isFirstLine = false
         }
 
-        return outputLines.joinToString("\n")
+        return output.toString()
             .replace(leadingNewlinesRegex, "")
     }
 


### PR DESCRIPTION
💡 **What**: Replaced `normalized.split("\\n")` and the subsequent `mutableListOf<String>().joinToString("\\n")` in `ChatMarkdownPreprocessor.stripInboundContextBlocks` with a direct `lineSequence()` loop that appends directly to a pre-sized `StringBuilder`.
🎯 **Why**: In the previous implementation, `split("\\n")` eagerly allocated a new `List<String>` containing every line of the incoming message, and `joinToString` subsequently created another `StringBuilder` to merge them back together. For long message chunks or heavily layered context blocks, this created completely unnecessary intermediate string and list allocations, increasing Garbage Collection pressure during hot-path text parsing before UI rendering.
📊 **Impact**: Eliminates one intermediate `List<String>` allocation and avoids traversing the string multiple times, reducing GC pressure when preparing chat messages for display.
🔬 **Measurement**: Review `git diff` for exact implementation. Unit tests and lint passed without issue.

---
*PR created automatically by Jules for task [18205397861031997657](https://jules.google.com/task/18205397861031997657) started by @yuga-hashimoto*