### PR TITLE
🔄 Upstream Parity: prefer stored device auth after pairing

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
@@ -424,7 +424,7 @@ class GatewaySession(
       // Avoids trying token/password which would fail and potentially rate-limit.
       // Prioritize bootstrapToken if provided. The bootstrapToken is single-use
       // and gets invalidated after first use; the deviceToken takes over for reconnections.
-      if (trimmedToken.isEmpty() && trimmedPassword.isEmpty() && trimmedBootstrapToken.isNotEmpty()) {
+      if (trimmedToken.isEmpty() && trimmedPassword.isEmpty() && trimmedBootstrapToken.isNotEmpty() && storedToken.isNullOrBlank()) {
         Log.d(TAG, "No token/password configured, using bootstrapToken auth directly")
         val payload = buildConnectParams(identity, connectNonce, "", null, authBootstrapToken = trimmedBootstrapToken)
         val res = request("connect", payload, timeoutMs = 8_000)


### PR DESCRIPTION
- **Source**: Upstream commit dcf821cfb6 `fix(android): prefer stored device auth after pairing`
- **Why**: To ensure that after a successful pairing, the gateway reconnection prioritizes the stored device token over the initial bootstrap token. A bootstrap token is single-use, so reusing it instead of the device token causes reconnection failures.
- **Adaptation**: Upstream changed `selectAuth`, while in this repository the logic resides in `sendConnect`. Adapted the fix to append the check `&& storedToken.isNullOrBlank()` to the condition where the bootstrap token auth is directly used. This accomplishes the exact same logic.
- **Excluded upstream behavior**: N/A (applied the exact logical fix to the local architecture).
- **Verification**: Ran lint and unit tests locally.

---
*PR created automatically by Jules for task [987789748041051488](https://jules.google.com/task/987789748041051488) started by @yuga-hashimoto*