### PR TITLE
🎨 Palette: Extract hardcoded 'Downloaded' string to resources

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -2278,7 +2278,7 @@ fun VoiceVoxSettingsCard(
                             if (selectedCharacter != null && downloadedVvmFiles.contains(selectedCharacter.vvmFileName)) {
                                 Icon(
                                     Icons.Default.Check,
-                                    contentDescription = "Downloaded",
+                                    contentDescription = stringResource(R.string.downloaded),
                                     tint = MaterialTheme.colorScheme.primary,
                                     modifier = Modifier.size(18.dp)
                                 )
@@ -2305,7 +2305,7 @@ fun VoiceVoxSettingsCard(
                                     if (isVvmReady) {
                                         Icon(
                                             Icons.Default.Check,
-                                            contentDescription = "Downloaded",
+                                            contentDescription = stringResource(R.string.downloaded),
                                             tint = MaterialTheme.colorScheme.primary,
                                             modifier = Modifier.size(16.dp)
                                         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,4 +646,5 @@
     <string name="action_copy">Copy</string>
     <string name="error_mic_privacy_title">Microphone Access Blocked</string>
     <string name="error_mic_privacy_message">Your device\'s microphone privacy toggle is off. Enable it in Settings &gt; Privacy &gt; Microphone.</string>
+    <string name="downloaded">Downloaded</string>
 </resources>


### PR DESCRIPTION
💡 **What:** Extracted the hardcoded `contentDescription = "Downloaded"` string in `SettingsActivity.kt` to the Android `strings.xml` resource.

🎯 **Why:** Hardcoded accessibility descriptions in Jetpack Compose components cannot be correctly localized. This diminishes the accessibility experience for non-English users, as screen readers will announce English text instead of the appropriate localized equivalent.

♿ **Accessibility:** Screen readers will now be able to announce the "Downloaded" status correctly for users relying on localized languages once translations are provided.

---
*PR created automatically by Jules for task [5504972919986921900](https://jules.google.com/task/5504972919986921900) started by @yuga-hashimoto*