### PR TITLE
🧪 Regression Guard: Fix background service crash loop

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,17 +55,21 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "Failed to stop service", ex) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "Failed to stop service", ex) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }
         }
 
         fun stop(context: Context) {
-            context.stopService(Intent(context, HotwordService::class.java))
+            try {
+                context.stopService(Intent(context, HotwordService::class.java))
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to stop HotwordService: ${e.message}", e)
+            }
         }
 
         fun shouldCopyModel(currentVersion: Int, savedVersion: Int, targetDirExists: Boolean, targetDirNotEmpty: Boolean): Boolean {

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,10 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (stopEx: Exception) { android.util.Log.e(TAG, "Failed to stopService as well", stopEx) }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (stopEx: Exception) { android.util.Log.e(TAG, "Failed to stopService as well", stopEx) }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,17 +40,21 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "Failed to stop service", ex) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "Failed to stop service", ex) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }
         }
 
         fun stop(context: Context) {
-            context.stopService(Intent(context, SessionForegroundService::class.java))
+            try {
+                context.stopService(Intent(context, SessionForegroundService::class.java))
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to stop SessionForegroundService: ${e.message}", e)
+            }
         }
     }
 


### PR DESCRIPTION
### Background
When an Android background execution limit (Android 12+) or security policy prevents a foreground service from starting, the codebase catches the `IllegalStateException` or `SecurityException` and attempts to call `context.stopService(intent)` as a fallback to ensure the OS recognizes the service as fully stopped.

### Issue
If the OS state is sufficiently restricted or if it already considers the service invalid, the `stopService()` call itself can throw an exception. Because this was unhandled inside the fallback `catch` block, it resulted in a fatal crash, undermining the original error handling.

### Fix
Wrapped the fallback `stopService` calls in a generic `try-catch` block, logging any exception instead of crashing. This was applied to:
- `HotwordService`
- `SessionForegroundService`
- `NodeForegroundService`
Standalone `stop()` methods on companion objects were also wrapped for consistency. 

### Verification
- `git status` and `git diff` confirmed the specific try-catch wrappings.
- `./gradlew app:lintStandardDebug` passed (0 issues).
- `./gradlew app:testStandardDebugUnitTest` passed with successful execution.

---
*PR created automatically by Jules for task [1832985368580358537](https://jules.google.com/task/1832985368580358537) started by @yuga-hashimoto*