### PR TITLE
🎨 Palette: Localize accessibility content descriptions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2025-10-24 - Dropdown Trigger Accessibility
 **Learning:** Using `Modifier.clickable` without a specific role and label for a row that opens a dropdown causes screen readers to misidentify its function.
 **Action:** When a clickable element opens a dropdown menu, always use `Modifier.clickable(onClickLabel = "...", role = Role.DropdownList)` to ensure proper screen reader announcement.
+
+## 2024-05-14 - Extracted Hardcoded Content Descriptions
+**Learning:** Hardcoded strings for `contentDescription` or `onClickLabel` prevent proper localization and are detrimental for accessibility for non-English users. Even interactive components like `Icon` inside `CompactActionCard` in Jetpack Compose sometimes use hardcoded accessibility strings.
+**Action:** Consistently replace hardcoded English text in `contentDescription` and `onClickLabel` with localized `stringResource(R.string.your_key)` equivalents to support screen readers in all languages.

--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1183,7 +1183,7 @@ fun CapabilityCard(
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                        contentDescription = "More info about $label",
+                        contentDescription = stringResource(R.string.action_more_info, label),
                         tint = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(16.dp)
                     )
@@ -1286,7 +1286,7 @@ fun CompactActionCard(modifier: Modifier = Modifier, icon: ImageVector, title: S
             Column(modifier = Modifier.weight(1f).fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
                 Row(modifier = Modifier.fillMaxWidth().height(32.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                     Icon(imageVector = icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(28.dp))
-                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable(onClickLabel = "More information about $title", role = Role.Button) { onInfoClick?.invoke() })
+                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable(onClickLabel = stringResource(R.string.action_more_info, title), role = Role.Button) { onInfoClick?.invoke() })
                     if (showSwitch) Switch(checked = switchValue, onCheckedChange = onSwitchChange, modifier = Modifier.scale(0.8f).offset(y = (-8).dp))
                 }
                 Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -2278,7 +2278,7 @@ fun VoiceVoxSettingsCard(
                             if (selectedCharacter != null && downloadedVvmFiles.contains(selectedCharacter.vvmFileName)) {
                                 Icon(
                                     Icons.Default.Check,
-                                    contentDescription = "Downloaded",
+                                    contentDescription = stringResource(R.string.status_downloaded),
                                     tint = MaterialTheme.colorScheme.primary,
                                     modifier = Modifier.size(18.dp)
                                 )
@@ -2305,7 +2305,7 @@ fun VoiceVoxSettingsCard(
                                     if (isVvmReady) {
                                         Icon(
                                             Icons.Default.Check,
-                                            contentDescription = "Downloaded",
+                                            contentDescription = stringResource(R.string.status_downloaded),
                                             tint = MaterialTheme.colorScheme.primary,
                                             modifier = Modifier.size(16.dp)
                                         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,4 +646,6 @@
     <string name="action_copy">Copy</string>
     <string name="error_mic_privacy_title">Microphone Access Blocked</string>
     <string name="error_mic_privacy_message">Your device\'s microphone privacy toggle is off. Enable it in Settings &gt; Privacy &gt; Microphone.</string>
+    <string name="action_more_info">More info about %s</string>
+    <string name="status_downloaded">Downloaded</string>
 </resources>

--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,11 @@
+💡 **What**:
+Extracted hardcoded English text (`contentDescription` and `onClickLabel`) used in `CompactActionCard`, `CapabilityCard`, and `VoiceVoxSettingsCard` into `strings.xml` string resources (`action_more_info` and `status_downloaded`).
+
+🎯 **Why**:
+Using hardcoded strings for accessibility descriptions prevents them from being localized by Android's resource system. This breaks the experience for non-English users using TalkBack or other screen readers, as they would hear English descriptions instead of their local language. Using `stringResource` enables full internationalization.
+
+📸 **Before/After**:
+N/A (Invisible change; only affects screen readers)
+
+♿ **Accessibility**:
+Screen readers will now read localized descriptive labels (e.g., "More info about [feature]") correctly based on the device's locale instead of enforcing English.


### PR DESCRIPTION
💡 **What**:
Extracted hardcoded English text (`contentDescription` and `onClickLabel`) used in `CompactActionCard`, `CapabilityCard`, and `VoiceVoxSettingsCard` into `strings.xml` string resources (`action_more_info` and `status_downloaded`).

🎯 **Why**:
Using hardcoded strings for accessibility descriptions prevents them from being localized by Android's resource system. This breaks the experience for non-English users using TalkBack or other screen readers, as they would hear English descriptions instead of their local language. Using `stringResource` enables full internationalization.

📸 **Before/After**:
N/A (Invisible change; only affects screen readers)

♿ **Accessibility**:
Screen readers will now read localized descriptive labels (e.g., "More info about [feature]") correctly based on the device's locale instead of enforcing English.

---
*PR created automatically by Jules for task [15376362263414053501](https://jules.google.com/task/15376362263414053501) started by @yuga-hashimoto*