### PR TITLE
🔄 Upstream Parity: prefer stored device auth after pairing

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
@@ -424,7 +424,8 @@ class GatewaySession(
       // Avoids trying token/password which would fail and potentially rate-limit.
       // Prioritize bootstrapToken if provided. The bootstrapToken is single-use
       // and gets invalidated after first use; the deviceToken takes over for reconnections.
-      if (trimmedToken.isEmpty() && trimmedPassword.isEmpty() && trimmedBootstrapToken.isNotEmpty()) {
+      // Prefer stored token if available.
+      if (trimmedToken.isEmpty() && trimmedPassword.isEmpty() && trimmedBootstrapToken.isNotEmpty() && storedToken.isNullOrBlank()) {
         Log.d(TAG, "No token/password configured, using bootstrapToken auth directly")
         val payload = buildConnectParams(identity, connectNonce, "", null, authBootstrapToken = trimmedBootstrapToken)
         val res = request("connect", payload, timeoutMs = 8_000)


### PR DESCRIPTION
- Source: Upstream commit `dcf821cfb62b056e7ab516e8af4b81df276b6a80`
- Why: Improves connection reliability. Prevents potential rate-limiting or failed reconnections by preferring a stored `deviceToken` over a one-time `bootstrapToken` if both are present in the connection options.
- Adaptation: Applied the `storedToken.isNullOrBlank()` condition precisely to the `GatewaySession.kt` authentication conditional. 
- Excluded upstream behavior: None. The fix applies directly to the existing local logic.
- Verification: Validated via unit tests with `./gradlew :app:testStandardDebugUnitTest --tests "com.openclaw.assistant.gateway.*"`.

---
*PR created automatically by Jules for task [4209122702363711462](https://jules.google.com/task/4209122702363711462) started by @yuga-hashimoto*