### PR TITLE
🎨 Polish: Improve connection status indicator colors

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
@@ -49,8 +49,8 @@ fun StatusIndicator(
 ) {
     val dotColor = when (state) {
         ConnectionState.Connected -> Color(0xFF4CAF50)
-        ConnectionState.Connecting -> Color(0xFFFFA726)
-        ConnectionState.Disconnected -> Color(0xFF757575)
+        ConnectionState.Connecting -> MaterialTheme.colorScheme.primary
+        ConnectionState.Disconnected -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
     }
 
     val stateDesc = when (state) {


### PR DESCRIPTION
🎨 Polish: Improve connection status indicator colors

Updates the hardcoded colors for the connection status indicator (amber for connecting, grey for disconnected) to use `MaterialTheme` colors. This improves visual coherence with the overall app's dark mode palette ("Lobster Theme Palette") and retains visual distinction by using the app's primary color for the active connecting state and an on-surface variant for the disconnected state.

---
*PR created automatically by Jules for task [4608108179293694183](https://jules.google.com/task/4608108179293694183) started by @yuga-hashimoto*