### PR TITLE
🛡️ Sentinel: Sanitize error messages in OpenClawClient

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
+++ b/app/src/main/java/com/openclaw/assistant/api/OpenClawClient.kt
@@ -115,9 +115,8 @@ class OpenClawClient() {
 
             client.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    val errorBody = response.message
                     return@withContext Result.failure(
-                        IOException("HTTP ${response.code}: $errorBody")
+                        IOException("HTTP ${response.code}")
                     )
                 }
 
@@ -212,8 +211,7 @@ class OpenClawClient() {
                 if (response.isSuccessful) {
                     Result.success(true)
                 } else {
-                    val errorBody = response.message
-                    Result.failure(IOException("HTTP ${response.code}: $errorBody"))
+                    Result.failure(IOException("HTTP ${response.code}"))
                 }
             }
         } catch (e: Exception) {


### PR DESCRIPTION
🛡️ Sentinel: Sanitize error messages in OpenClawClient

**What**
Removed the inclusion of `response.message` in the `IOException` thrown by `OpenClawClient` upon HTTP failures.

**Why**
The HTTP status reason phrase (often server-controlled) can be overly verbose and potentially expose sensitive server details or unintended data in logs/UI.

**Verification**
Ran `app:lintStandardDebug` and `app:testStandardDebugUnitTest` successfully. Checked `git diff` to ensure changes only affect the error messages.

---
*PR created automatically by Jules for task [4947245738083321291](https://jules.google.com/task/4947245738083321291) started by @yuga-hashimoto*