### PR TITLE
🧪 Regression Guard: Fix background service cleanup crash

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,10 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService as well", stopEx) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService as well", stopEx) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,10 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (stopEx: Exception) { android.util.Log.e(TAG, "Failed to stopService as well", stopEx) }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (stopEx: Exception) { android.util.Log.e(TAG, "Failed to stopService as well", stopEx) }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,10 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService as well", stopEx) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService as well", stopEx) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
🧪 Regression Guard: Fix background service cleanup crash

**What**
Wraps fallback `context.stopService(intent)` calls inside nested `try-catch` blocks within the `IllegalStateException` and `SecurityException` fallback handlers of `HotwordService`, `SessionForegroundService`, and `NodeForegroundService`.

**Why**
Under strict Android OS versions or aggressive battery management schemas, trying to start a service from the background throws an exception. Catching that exception and immediately attempting to `stopService` as cleanup can result in a *second* unhandled exception from the OS, crashing the entire background process and preventing auto-recovery.

**Verification**
- `./gradlew app:lintStandardDebug` (Pass)
- `./gradlew app:testStandardDebugUnitTest` (Pass)

---
*PR created automatically by Jules for task [3375731685420943900](https://jules.google.com/task/3375731685420943900) started by @yuga-hashimoto*