### PR TITLE
🎨 Polish: Improve accessibility labels

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1183,7 +1183,7 @@ fun CapabilityCard(
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                        contentDescription = "More info about $label",
+                        contentDescription = stringResource(R.string.a11y_more_info_about, label),
                         tint = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(16.dp)
                     )

--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -2278,7 +2278,7 @@ fun VoiceVoxSettingsCard(
                             if (selectedCharacter != null && downloadedVvmFiles.contains(selectedCharacter.vvmFileName)) {
                                 Icon(
                                     Icons.Default.Check,
-                                    contentDescription = "Downloaded",
+                                    contentDescription = stringResource(R.string.a11y_downloaded),
                                     tint = MaterialTheme.colorScheme.primary,
                                     modifier = Modifier.size(18.dp)
                                 )
@@ -2305,7 +2305,7 @@ fun VoiceVoxSettingsCard(
                                     if (isVvmReady) {
                                         Icon(
                                             Icons.Default.Check,
-                                            contentDescription = "Downloaded",
+                                            contentDescription = stringResource(R.string.a11y_downloaded),
                                             tint = MaterialTheme.colorScheme.primary,
                                             modifier = Modifier.size(16.dp)
                                         )

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -562,4 +562,6 @@
     <string name="action_hide_api_key">APIキーを隠す</string>
     <string name="action_show_api_key">APIキーを表示</string>
     <string name="action_refresh_agents">エージェントを更新</string>
+    <string name="a11y_downloaded">ダウンロード済み</string>
+    <string name="a11y_more_info_about">%sの詳細情報</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,4 +646,6 @@
     <string name="action_copy">Copy</string>
     <string name="error_mic_privacy_title">Microphone Access Blocked</string>
     <string name="error_mic_privacy_message">Your device\'s microphone privacy toggle is off. Enable it in Settings &gt; Privacy &gt; Microphone.</string>
+    <string name="a11y_downloaded">Downloaded</string>
+    <string name="a11y_more_info_about">More info about %s</string>
 </resources>


### PR DESCRIPTION
Replaced hardcoded `contentDescription` string literals with localized string resources in Jetpack Compose UI components to enhance accessibility for non-English users.
- Extracted `a11y_downloaded` and `a11y_more_info_about` to `strings.xml`.
- Added localized translations to `values-ja/strings.xml`.
- Updated `SettingsActivity.kt` and `MainActivity.kt` to use `stringResource`.

---
*PR created automatically by Jules for task [7046149741317619192](https://jules.google.com/task/7046149741317619192) started by @yuga-hashimoto*