### PR TITLE
⚡ Bolt: Optimize ChatMarkdownPreprocessor split and join allocations

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/chat/ChatMarkdownPreprocessor.kt
+++ b/app/src/main/java/com/openclaw/assistant/chat/ChatMarkdownPreprocessor.kt
@@ -33,11 +33,13 @@ object ChatMarkdownPreprocessor {
         if (inboundContextHeaders.none { raw.contains(it) }) return raw
 
         val normalized = raw.replace("\r\n", "\n")
-        val outputLines = mutableListOf<String>()
+        val outputBuilder = StringBuilder(normalized.length)
         var inMetaBlock = false
         var inFencedJson = false
+        var isFirst = true
 
-        for (line in normalized.split("\n")) {
+        // ⚡ Bolt: Use lineSequence() instead of split("\n") to avoid creating a large intermediate list of strings
+        for (line in normalized.lineSequence()) {
             if (!inMetaBlock && inboundContextHeaders.any { line.startsWith(it) }) {
                 inMetaBlock = true
                 inFencedJson = false
@@ -62,10 +64,15 @@ object ChatMarkdownPreprocessor {
                 inMetaBlock = false
             }
 
-            outputLines.add(line)
+            if (!isFirst) {
+                outputBuilder.append("\n")
+            }
+            outputBuilder.append(line)
+            isFirst = false
         }
 
-        return outputLines.joinToString("\n")
+        // ⚡ Bolt: Direct conversion to string avoids list-to-string memory allocations overhead
+        return outputBuilder.toString()
             .replace(leadingNewlinesRegex, "")
     }
 


### PR DESCRIPTION
💡 What: Replace `.split("\n")` with `.lineSequence()` and `mutableListOf<String>().joinToString("\n")` with direct `StringBuilder` append in `ChatMarkdownPreprocessor.kt`.
🎯 Why: The original code creates unnecessary intermediate collection allocations and increases Garbage Collection overhead when processing multiline messages.
📊 Impact: Eliminates creation of large intermediate string lists, reducing heap usage and GC pressure during chat preprocessing.
🔬 Measurement: Local testing with 10k iterations measured a speedup, saving allocations per long chat message.

---
*PR created automatically by Jules for task [3559958485188096043](https://jules.google.com/task/3559958485188096043) started by @yuga-hashimoto*