### PR TITLE
🧪 Regression Guard: Fix service cleanup crash during background start failures

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,10 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "Failed to stop service during cleanup", ex) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "Failed to stop service during cleanup", ex) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,17 +285,13 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stopService as well", ex) }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stopService as well", ex) }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        try {
-            context.stopService(intent)
-        } catch (stopEx: Exception) {
-            android.util.Log.e(TAG, "Failed to stopService as well", stopEx)
-        }
+        try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stopService as well", ex) }
       }
     }
 

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,10 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "Failed to stop service during cleanup", ex) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "Failed to stop service during cleanup", ex) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
**What**
Wraps `context.stopService(intent)` calls inside nested `try-catch` blocks within the error handling paths for `startForegroundService` and `startService`.

**Why**
On recent Android versions or aggressive manufacturer ROMs, if an app attempts to start a service from the background while heavily restricted, it throws an `IllegalStateException` or `SecurityException`. The existing code attempts to clean up the partially started state by calling `context.stopService()`. However, calling `stopService` from a heavily restricted state can sometimes throw a secondary exception. This patch prevents the secondary exception from crashing the app.

**Verification**
* Local lint checks passed (`./gradlew lintStandardDebug`)
* Code successfully compiled (`./gradlew assembleStandardDebug`)
* Unit tests successfully ran and passed (`./gradlew testStandardDebugUnitTest`)

---
*PR created automatically by Jules for task [16644612775448421351](https://jules.google.com/task/16644612775448421351) started by @yuga-hashimoto*