### PR TITLE
🔄 Upstream Parity: fix(android): avoid trust-all TLS probing

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewayTls.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewayTls.kt
@@ -9,6 +9,7 @@ import java.security.SecureRandom
 import java.security.cert.CertificateException
 import java.security.cert.X509Certificate
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicReference
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLContext
@@ -95,18 +96,25 @@ suspend fun probeGatewayTlsFingerprint(
   if (port !in 1..65535) return null
 
   return withContext(Dispatchers.IO) {
-    val trustAll =
-      @SuppressLint("CustomX509TrustManager", "TrustAllX509TrustManager")
+    val fingerprintRef = AtomicReference<String?>(null)
+    val probeTrustManager =
+      @SuppressLint("CustomX509TrustManager")
       object : X509TrustManager {
-        @SuppressLint("TrustAllX509TrustManager")
-        override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
-        @SuppressLint("TrustAllX509TrustManager")
-        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}
+        override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {
+          throw CertificateException("gateway TLS probe does not accept client certificates")
+        }
+
+        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
+          if (chain.isEmpty()) throw CertificateException("empty certificate chain")
+          fingerprintRef.set(sha256Hex(chain[0].encoded))
+          throw CertificateException("gateway TLS probe captured fingerprint")
+        }
+
         override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
       }
 
     val context = SSLContext.getInstance("TLS")
-    context.init(null, arrayOf(trustAll), SecureRandom())
+    context.init(null, arrayOf(probeTrustManager), SecureRandom())
 
     // Use createSocket() and connect() with timeout to ensure we don't hang on TCP connect.
     var socket: SSLSocket? = null
@@ -137,6 +145,7 @@ suspend fun probeGatewayTlsFingerprint(
       android.util.Log.e("GatewayTls", "Probe timeout ($timeoutMs ms) for $trimmedHost:$port", e)
       null
     } catch (e: Throwable) {
+      fingerprintRef.get()?.let { return@withContext it }
       android.util.Log.e("GatewayTls", "Probe failed with exception for $trimmedHost:$port", e)
       null
     } finally {


### PR DESCRIPTION
- Source: Upstream commit `2c58c5d4ec`
- Why: Fixes an Android CodeQL insecure trust manager finding (`TrustAllX509TrustManager`) in gateway TLS probing. The original trust manager silently accepted all certificates, which triggered security scanners. The new approach throws an exception to safely and immediately abort the handshake once the certificate is captured.
- Adaptation: Applied directly to `GatewayTls.kt` in our codebase structure, specifically within the `probeGatewayTlsFingerprint` function. We map the variables to our local `GatewayTls.kt` implementation.
- Excluded upstream behavior: None. The feature fits perfectly.
- Verification: Clean `./gradlew app:lintStandardDebug` and `./gradlew app:testStandardDebugUnitTest`. Verified `.orig` files are not checked in.

---
*PR created automatically by Jules for task [18069196325513513291](https://jules.google.com/task/18069196325513513291) started by @yuga-hashimoto*