### PR TITLE
🎨 Palette: Extract hardcoded contentDescription to string resource

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -2278,7 +2278,7 @@ fun VoiceVoxSettingsCard(
                             if (selectedCharacter != null && downloadedVvmFiles.contains(selectedCharacter.vvmFileName)) {
                                 Icon(
                                     Icons.Default.Check,
-                                    contentDescription = "Downloaded",
+                                    contentDescription = stringResource(R.string.desc_downloaded),
                                     tint = MaterialTheme.colorScheme.primary,
                                     modifier = Modifier.size(18.dp)
                                 )
@@ -2305,7 +2305,7 @@ fun VoiceVoxSettingsCard(
                                     if (isVvmReady) {
                                         Icon(
                                             Icons.Default.Check,
-                                            contentDescription = "Downloaded",
+                                            contentDescription = stringResource(R.string.desc_downloaded),
                                             tint = MaterialTheme.colorScheme.primary,
                                             modifier = Modifier.size(16.dp)
                                         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,4 +646,5 @@
     <string name="action_copy">Copy</string>
     <string name="error_mic_privacy_title">Microphone Access Blocked</string>
     <string name="error_mic_privacy_message">Your device\'s microphone privacy toggle is off. Enable it in Settings &gt; Privacy &gt; Microphone.</string>
+    <string name="desc_downloaded">Downloaded</string>
 </resources>


### PR DESCRIPTION
💡 What: Replaced a hardcoded string ("Downloaded") in `SettingsActivity.kt` with a localized string resource (`R.string.desc_downloaded`).
🎯 Why: Hardcoded strings in `contentDescription` prevent screen readers from properly localizing text, which diminishes the experience for non-English users.
📸 Before/After: Visuals are unchanged. The internal accessibility label is updated.
♿ Accessibility: Ensure proper localization for screen readers reading the `Icon` description.

---
*PR created automatically by Jules for task [12824219281578865775](https://jules.google.com/task/12824219281578865775) started by @yuga-hashimoto*