### PR TITLE
🎨 Polish: Improve accessibility descriptions

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1183,7 +1183,7 @@ fun CapabilityCard(
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                        contentDescription = "More info about $label",
+                        contentDescription = stringResource(R.string.a11y_more_info, label),
                         tint = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(16.dp)
                     )

--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -2278,7 +2278,7 @@ fun VoiceVoxSettingsCard(
                             if (selectedCharacter != null && downloadedVvmFiles.contains(selectedCharacter.vvmFileName)) {
                                 Icon(
                                     Icons.Default.Check,
-                                    contentDescription = "Downloaded",
+                                    contentDescription = stringResource(R.string.a11y_downloaded),
                                     tint = MaterialTheme.colorScheme.primary,
                                     modifier = Modifier.size(18.dp)
                                 )
@@ -2305,7 +2305,7 @@ fun VoiceVoxSettingsCard(
                                     if (isVvmReady) {
                                         Icon(
                                             Icons.Default.Check,
-                                            contentDescription = "Downloaded",
+                                            contentDescription = stringResource(R.string.a11y_downloaded),
                                             tint = MaterialTheme.colorScheme.primary,
                                             modifier = Modifier.size(16.dp)
                                         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,4 +646,8 @@
     <string name="action_copy">Copy</string>
     <string name="error_mic_privacy_title">Microphone Access Blocked</string>
     <string name="error_mic_privacy_message">Your device\'s microphone privacy toggle is off. Enable it in Settings &gt; Privacy &gt; Microphone.</string>
+
+    <!-- Accessibility Descriptions -->
+    <string name="a11y_more_info">More info about %1$s</string>
+    <string name="a11y_downloaded">Downloaded</string>
 </resources>


### PR DESCRIPTION
## What
Extracted hardcoded `contentDescription` strings from `MainActivity.kt` and `SettingsActivity.kt` into `strings.xml`.

## Why
Using hardcoded strings for accessibility properties like `contentDescription` prevents proper localization for screen readers, diminishing the experience for non-English users. This aligns with Jetpack Compose accessibility conventions.

## Result
Accessibility labels ("More info about...", "Downloaded") now use `stringResource()` and can be safely localized, improving the app's overall accessibility profile.

## Verification
- Verified string additions in `strings.xml`.
- Ran `./gradlew :app:assembleStandardDebug` to verify compilation and resource resolution.
- Ran `./gradlew :app:testStandardDebugUnitTest`.

---
*PR created automatically by Jules for task [15399883687223412258](https://jules.google.com/task/15399883687223412258) started by @yuga-hashimoto*