### PR TITLE
🛡️ Sentinel: Sanitize verbose auth error messages

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewaySession.kt
@@ -432,7 +432,8 @@ class GatewaySession(
           handleConnectSuccess(res, canFallbackToShared, identityId)
           return
         }
-        val msg = res.error?.message ?: "connect failed"
+        // Sanitized error message to prevent verbose error disclosure
+        val msg = "connect failed (code=${res.error?.code})"
         Log.w(TAG, "BootstrapToken auth failed (code=${res.error?.code})")
         // The server consumed the bootstrapToken on first use. Clear it from the desired connection
         // so subsequent retries don't loop on the same expired token. The consumer is notified via
@@ -454,7 +455,8 @@ class GatewaySession(
           handleConnectSuccess(passwordRes, canFallbackToShared, identityId)
           return
         }
-        val msg = passwordRes.error?.message ?: "connect failed"
+        // Sanitized error message to prevent verbose error disclosure
+        val msg = "connect failed (code=${passwordRes.error?.code})"
         Log.w(TAG, "Password auth failed (code=${passwordRes.error?.code})")
         throw IllegalStateException(msg)
       }
@@ -488,7 +490,8 @@ class GatewaySession(
           }
 
           // Both failed
-          val msg = passwordRes.error?.message ?: "connect failed"
+          // Sanitized error message to prevent verbose error disclosure
+          val msg = "connect failed (code=${passwordRes.error?.code})"
           Log.w(TAG, "Password auth failed (code=${passwordRes.error?.code})")
           if (canFallbackToShared || !storedToken.isNullOrBlank()) {
             deviceAuthStore.clearToken(identityId, options.role)
@@ -497,7 +500,8 @@ class GatewaySession(
         }
 
         // Token failed and no password provided
-        val msg = tokenRes.error?.message ?: "connect failed"
+        // Sanitized error message to prevent verbose error disclosure
+        val msg = "connect failed (code=${tokenRes.error?.code})"
         if (canFallbackToShared || !storedToken.isNullOrBlank()) {
           deviceAuthStore.clearToken(identityId, options.role)
         }
@@ -507,7 +511,8 @@ class GatewaySession(
         val payload = buildConnectParams(identity, connectNonce, "", null)
         val res = request("connect", payload, timeoutMs = 8_000)
         if (!res.ok) {
-          val msg = res.error?.message ?: "connect failed"
+          // Sanitized error message to prevent verbose error disclosure
+          val msg = "connect failed (code=${res.error?.code})"
           throw IllegalStateException(msg)
         }
         handleConnectSuccess(res, false, identityId)

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,15 +1,12 @@
-**Source**
-Upstream openclaw/openclaw commit `8790c54635`
+**What:**
+Sanitized server error messages thrown and logged during GatewaySession authentication failures. Replaced arbitrary server-provided error messages (`res.error?.message`) with safe, static messages that only include the relevant error codes.
 
-**Why**
-Gateway setup URLs or explicit manual endpoint inputs shouldn't enforce default ports blindly when displaying the connection UI or verifying connection security, particularly ensuring custom or cleartext implicit ports accurately reflect their configuration.
+**Why:**
+This prevents overly verbose and potentially sensitive remote error messages from being exposed directly to the application logs or UI through `IllegalStateException` throws and `Log.w` calls.
 
-**Adaptation**
-Ported the modified `displayUrl` string building logic from `GatewayConfigResolver.kt` (upstream) to `GatewayConfigUtils.kt` (this repo). Added tests covering various edge cases (bare domains vs default ports).
-Modified test parameters in `GatewayConfigUtilsTest` to use local `192.168.1.100` instead of `gateway.example` for cleartext, as `NetworkUtils.isUrlSecure` in this repo explicitly forbids public domains for WS/HTTP connections.
+**Impact:**
+Increases security hardening by avoiding information disclosure while still maintaining sufficient debuggability via standard error codes.
 
-**Excluded upstream behavior**
-N/A. This was a direct logic porting.
-
-**Verification**
-Locally verified by running `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug` ensuring all updated assertions succeed and no memory or regressions are flagged.
+**Verification:**
+* Validated no syntax errors or regressions using `./gradlew testStandardDebugUnitTest` and `./gradlew lintStandardDebug`.
+* Pre-commit checks and code review completed.


### PR DESCRIPTION
**What:**
Sanitized server error messages thrown and logged during GatewaySession authentication failures. Replaced arbitrary server-provided error messages (`res.error?.message`) with safe, static messages that only include the relevant error codes.

**Why:**
This prevents overly verbose and potentially sensitive remote error messages from being exposed directly to the application logs or UI through `IllegalStateException` throws and `Log.w` calls.

**Impact:**
Increases security hardening by avoiding information disclosure while still maintaining sufficient debuggability via standard error codes.

**Verification:**
* Validated no syntax errors or regressions using `./gradlew testStandardDebugUnitTest` and `./gradlew lintStandardDebug`.
* Pre-commit checks and code review completed.

---
*PR created automatically by Jules for task [11837842304846914730](https://jules.google.com/task/11837842304846914730) started by @yuga-hashimoto*