### PR TITLE
🧪 Regression Guard: Fix cascading crash on background service failure

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,10 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stop service", ex) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stop service", ex) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,10 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stop service", ex) }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stop service", ex) }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,10 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stop service", ex) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stop service", ex) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
**Fix:**
Wrapped specific fallback `stopService()` calls inside catch blocks with a nested `try-catch` to prevent cascading crashes.

**Details:**
When Android's strict background execution limits (Android 12+) block a service from starting via `startForegroundService` or `startService`, it throws an `IllegalStateException` or `SecurityException`. The existing code attempted to gracefully handle this by catching the exception and calling `stopService()`. However, calling `stopService()` on a service that the OS just refused to start can occasionally throw another exception, crashing the app. 

This update wraps those specific error-recovery `stopService()` calls in a `try-catch` block, safely logging the error without crashing the application.

**Files modified:**
- `app/src/main/java/com/openclaw/assistant/service/HotwordService.kt`
- `app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt`
- `app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt`

**Validation:**
- Passed `app:lintStandardDebug`
- Passed `app:testStandardDebugUnitTest`

---
*PR created automatically by Jules for task [14218601834093967628](https://jules.google.com/task/14218601834093967628) started by @yuga-hashimoto*