### PR TITLE
🎨 Polish: Improve Gateway TLS Trust Dialog UX

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/GatewayTrustDialog.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/GatewayTrustDialog.kt
@@ -1,10 +1,15 @@
 package com.openclaw.assistant.ui
 
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import com.openclaw.assistant.R
 import com.openclaw.assistant.node.NodeRuntime
 
@@ -18,12 +23,26 @@ fun GatewayTrustDialog(
     onDismissRequest = onDecline,
     title = { Text(stringResource(R.string.gateway_trust_title)) },
     text = {
-      Text(
-          stringResource(
-              R.string.gateway_trust_message,
-              prompt.fingerprintSha256
+      val fullText = stringResource(R.string.gateway_trust_message, prompt.fingerprintSha256)
+      val startIndex = fullText.indexOf(prompt.fingerprintSha256)
+
+      val annotatedText = buildAnnotatedString {
+        append(fullText)
+        if (startIndex >= 0) {
+          addStyle(
+            style = SpanStyle(
+              fontFamily = FontFamily.Monospace,
+              fontWeight = FontWeight.Bold
+            ),
+            start = startIndex,
+            end = startIndex + prompt.fingerprintSha256.length
           )
-      )
+        }
+      }
+
+      SelectionContainer {
+        Text(annotatedText)
+      }
     },
     confirmButton = {
       TextButton(onClick = onAccept) {


### PR DESCRIPTION
Makes the SHA-256 fingerprint in the Gateway Trust Dialog much easier to read and verify out-of-band by:
- Wrapping the text in a `SelectionContainer` so the fingerprint can be copied.
- Extracting the exact fingerprint dynamically from the full string resource text and applying a bold, monospace font style to clearly separate it from the surrounding instruction text.

This significantly improves the permission guidance and ease of use when manually verifying custom gateway certificates.

---
*PR created automatically by Jules for task [15408885021467829592](https://jules.google.com/task/15408885021467829592) started by @yuga-hashimoto*