### PR TITLE
⚡ Bolt: Use optimized TTSUtils chunking in AndroidTTSProvider

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/speech/AndroidTTSProvider.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/AndroidTTSProvider.kt
@@ -17,8 +17,6 @@ import kotlin.coroutines.resume
 
 private const val TAG = "AndroidTTSProvider"
 
-private val SENTENCE_ENDERS = listOf("。", "．", ". ", "! ", "? ", "！", "？")
-private val COMMA_ENDERS = listOf("。", "，", ", ")
 
 /**
  * Android native TTS provider (wrapper around TextToSpeech)
@@ -105,13 +103,11 @@ class AndroidTTSProvider(private val context: Context) : TTSProvider {
     }
     
     override suspend fun speak(text: String): Boolean {
-        val maxLen = try {
-            TextToSpeech.getMaxSpeechInputLength()
-        } catch (e: Exception) {
-            3900
-        }
-        
-        val chunks = splitText(text, maxLen * 9 / 10)
+        // Optimization: Use TTSUtils.getMaxInputLength and splitTextForTTS
+        // This reduces GC overhead by avoiding intermediate substring allocations
+        // and prevents O(N^2) complexity backwards string searches.
+        val maxLen = TTSUtils.getMaxInputLength(tts)
+        val chunks = TTSUtils.splitTextForTTS(text, maxLen)
         
         for ((index, chunk) in chunks.withIndex()) {
             val success = speakChunk(chunk, index == 0)
@@ -219,58 +215,5 @@ class AndroidTTSProvider(private val context: Context) : TTSProvider {
         }
         
         awaitClose { stop() }
-    }
-    
-    private fun splitText(text: String, maxLength: Int): List<String> {
-        if (text.length <= maxLength) return listOf(text)
-        
-        val chunks = mutableListOf<String>()
-        var remaining = text
-        
-        while (remaining.isNotEmpty()) {
-            if (remaining.length <= maxLength) {
-                chunks.add(remaining)
-                break
-            }
-            
-            val searchRange = remaining.substring(0, maxLength)
-            val splitIndex = findBestSplitPoint(searchRange)
-            
-            if (splitIndex > 0) {
-                chunks.add(remaining.substring(0, splitIndex).trim())
-                remaining = remaining.substring(splitIndex).trim()
-            } else {
-                chunks.add(remaining.substring(0, maxLength).trim())
-                remaining = remaining.substring(maxLength).trim()
-            }
-        }
-        
-        return chunks.filter { it.isNotBlank() }
-    }
-    
-    private fun findBestSplitPoint(text: String): Int {
-        val paragraphBreak = text.lastIndexOf("\n\n")
-        if (paragraphBreak > text.length / 2) return paragraphBreak + 2
-        
-        var bestPos = -1
-        for (ender in SENTENCE_ENDERS) {
-            val pos = text.lastIndexOf(ender)
-            if (pos > bestPos) bestPos = pos + ender.length
-        }
-        if (bestPos > text.length / 3) return bestPos
-        
-        val lineBreak = text.lastIndexOf("\n")
-        if (lineBreak > text.length / 3) return lineBreak + 1
-        
-        for (ender in COMMA_ENDERS) {
-            val pos = text.lastIndexOf(ender)
-            if (pos > bestPos) bestPos = pos + ender.length
-        }
-        if (bestPos > text.length / 3) return bestPos
-        
-        val space = text.lastIndexOf(" ")
-        if (space > text.length / 3) return space + 1
-        
-        return -1
     }
 }


### PR DESCRIPTION
💡 **What:** 
Replaced the custom TTS text chunking logic (`splitText` and `findBestSplitPoint`) in `AndroidTTSProvider.kt` with the centralized and optimized `TTSUtils.splitTextForTTS` and `TTSUtils.getMaxInputLength` methods.

🎯 **Why:** 
The local implementation inside `AndroidTTSProvider` was using an unbounded `String.lastIndexOf()` inside a loop. If a string lacked a delimiter (like a newline or period) within the search range, `lastIndexOf` would search backward all the way to index 0 on every iteration, leading to O(N^2) time complexity. Additionally, it allocated intermediate strings via `substring(0, maxLength)` on every pass. The centralized `TTSUtils` method avoids these issues by using an index-based bounded search and minimizing allocations.

📊 **Impact:** 
- **Time Complexity:** Reduces the backward delimiter search from O(N^2) to O(N) by utilizing the bounded `lastIndexOfBounded` implementation in `TTSUtils`.
- **Memory/GC Overhead:** Eliminates redundant intermediate string allocations that were created for every chunk's search range.
- **Maintainability:** Removes duplicated text-chunking logic and unifies it under `TTSUtils`.

🔬 **Measurement:** 
Run `./gradlew app:lintStandardDebug` and `./gradlew app:testStandardDebugUnitTest` to verify no regressions in speech logic. The performance impact is most noticeable on very long, unformatted strings sent to the local Android TTS engine.

---
*PR created automatically by Jules for task [13353115940154976057](https://jules.google.com/task/13353115940154976057) started by @yuga-hashimoto*