### PR TITLE
🛡️ Sentinel: Improve gateway TLS probe security

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewayTls.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewayTls.kt
@@ -95,18 +95,20 @@ suspend fun probeGatewayTlsFingerprint(
   if (port !in 1..65535) return null
 
   return withContext(Dispatchers.IO) {
-    val trustAll =
-      @SuppressLint("CustomX509TrustManager", "TrustAllX509TrustManager")
+    var capturedCert: X509Certificate? = null
+    val probeTrustManager =
+      @SuppressLint("CustomX509TrustManager")
       object : X509TrustManager {
-        @SuppressLint("TrustAllX509TrustManager")
         override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
-        @SuppressLint("TrustAllX509TrustManager")
-        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}
+        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
+          capturedCert = chain.firstOrNull()
+          throw CertificateException("Intentionally aborting handshake to capture certificate")
+        }
         override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
       }
 
     val context = SSLContext.getInstance("TLS")
-    context.init(null, arrayOf(trustAll), SecureRandom())
+    context.init(null, arrayOf(probeTrustManager), SecureRandom())
 
     // Use createSocket() and connect() with timeout to ensure we don't hang on TCP connect.
     var socket: SSLSocket? = null
@@ -128,23 +130,26 @@ suspend fun probeGatewayTlsFingerprint(
       }
       
       socket.startHandshake()
-      val cert = socket.session.peerCertificates.firstOrNull() as? X509Certificate ?: run {
-          android.util.Log.e("GatewayTls", "Probe failed: Peer certificates empty for $trimmedHost:$port")
-          return@withContext null
-      }
-      sha256Hex(cert.encoded)
     } catch (e: java.net.SocketTimeoutException) {
       android.util.Log.e("GatewayTls", "Probe timeout ($timeoutMs ms) for $trimmedHost:$port", e)
-      null
     } catch (e: Throwable) {
-      android.util.Log.e("GatewayTls", "Probe failed with exception for $trimmedHost:$port", e)
-      null
+      // Expected exception if we successfully captured the certificate and aborted.
+      if (capturedCert == null) {
+        android.util.Log.e("GatewayTls", "Probe failed with exception for $trimmedHost:$port", e)
+      }
     } finally {
       try {
         socket?.close()
       } catch (_: Throwable) {
         // ignore
       }
+    }
+
+    capturedCert?.let { sha256Hex(it.encoded) } ?: run {
+      if (capturedCert == null) {
+        android.util.Log.e("GatewayTls", "Probe failed: Peer certificates empty for $trimmedHost:$port")
+      }
+      null
     }
   }
 }

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,15 +1,14 @@
-**Source**
-Upstream openclaw/openclaw commit `8790c54635`
+**What**
+Refactored the `X509TrustManager` used during the gateway TLS probe to intentionally abort the handshake via `CertificateException` immediately after capturing the peer's certificate.
 
 **Why**
-Gateway setup URLs or explicit manual endpoint inputs shouldn't enforce default ports blindly when displaying the connection UI or verifying connection security, particularly ensuring custom or cleartext implicit ports accurately reflect their configuration.
+Previously, `probeGatewayTlsFingerprint` used a `TrustAllX509TrustManager` that silently ignored validation and successfully completed the TLS handshake with any server. This is a security risk (flagged as insecure trust manager by CodeQL) because it establishes an unverified connection that could theoretically be used.
 
-**Adaptation**
-Ported the modified `displayUrl` string building logic from `GatewayConfigResolver.kt` (upstream) to `GatewayConfigUtils.kt` (this repo). Added tests covering various edge cases (bare domains vs default ports).
-Modified test parameters in `GatewayConfigUtilsTest` to use local `192.168.1.100` instead of `gateway.example` for cleartext, as `NetworkUtils.isUrlSecure` in this repo explicitly forbids public domains for WS/HTTP connections.
-
-**Excluded upstream behavior**
-N/A. This was a direct logic porting.
+**Impact**
+- **Security:** Eliminates the risk of establishing fully trusted connections to unverified servers.
+- **Performance:** Bypasses the overhead of completing a full, unnecessary TLS handshake.
 
 **Verification**
-Locally verified by running `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug` ensuring all updated assertions succeed and no memory or regressions are flagged.
+- Verified the logic with temporary isolated probe tests.
+- Linted locally with `./gradlew -q :app:lintStandardDebug` (Pass).
+- Tested locally with `./gradlew -q :app:testStandardDebugUnitTest` (Pass).


### PR DESCRIPTION
**What**
Refactored the `X509TrustManager` used during the gateway TLS probe to intentionally abort the handshake via `CertificateException` immediately after capturing the peer's certificate.

**Why**
Previously, `probeGatewayTlsFingerprint` used a `TrustAllX509TrustManager` that silently ignored validation and successfully completed the TLS handshake with any server. This is a security risk (flagged as insecure trust manager by CodeQL) because it establishes an unverified connection that could theoretically be used.

**Impact**
- **Security:** Eliminates the risk of establishing fully trusted connections to unverified servers.
- **Performance:** Bypasses the overhead of completing a full, unnecessary TLS handshake.

**Verification**
- Verified the logic with temporary isolated probe tests.
- Linted locally with `./gradlew -q :app:lintStandardDebug` (Pass).
- Tested locally with `./gradlew -q :app:testStandardDebugUnitTest` (Pass).

---
*PR created automatically by Jules for task [2877692085871841428](https://jules.google.com/task/2877692085871841428) started by @yuga-hashimoto*