### PR TITLE
🎨 Palette: Extract hardcoded content descriptions to strings.xml

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2025-10-24 - Dropdown Trigger Accessibility
 **Learning:** Using `Modifier.clickable` without a specific role and label for a row that opens a dropdown causes screen readers to misidentify its function.
 **Action:** When a clickable element opens a dropdown menu, always use `Modifier.clickable(onClickLabel = "...", role = Role.DropdownList)` to ensure proper screen reader announcement.
+
+## 2025-10-25 - Extracted Strings Definition Verification
+**Learning:** Extracting hardcoded accessibility strings into `strings.xml` using tools like `sed` can fail or cause collisions if an existing, unrelated string is overwritten instead of adding a new one. Overwriting existing translation strings breaks localization in other parts of the app.
+**Action:** When extracting new `contentDescription` strings to `strings.xml`, always add a completely new string identifier (e.g. `downloaded_content_description`) and verify its existence with `grep` rather than hijacking an existing string key.

--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1183,7 +1183,7 @@ fun CapabilityCard(
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                        contentDescription = "More info about $label",
+                        contentDescription = stringResource(R.string.more_info_about, label),
                         tint = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(16.dp)
                     )

--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -2278,7 +2278,7 @@ fun VoiceVoxSettingsCard(
                             if (selectedCharacter != null && downloadedVvmFiles.contains(selectedCharacter.vvmFileName)) {
                                 Icon(
                                     Icons.Default.Check,
-                                    contentDescription = "Downloaded",
+                                    contentDescription = stringResource(R.string.downloaded_content_description),
                                     tint = MaterialTheme.colorScheme.primary,
                                     modifier = Modifier.size(18.dp)
                                 )
@@ -2305,7 +2305,7 @@ fun VoiceVoxSettingsCard(
                                     if (isVvmReady) {
                                         Icon(
                                             Icons.Default.Check,
-                                            contentDescription = "Downloaded",
+                                            contentDescription = stringResource(R.string.downloaded_content_description),
                                             tint = MaterialTheme.colorScheme.primary,
                                             modifier = Modifier.size(16.dp)
                                         )

--- a/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.LocalContext
 import com.openclaw.assistant.R
 
 enum class ConnectionState {
@@ -47,6 +48,7 @@ fun StatusIndicator(
     dotSize: Dp = 10.dp,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
     val dotColor = when (state) {
         ConnectionState.Connected -> Color(0xFF4CAF50)
         ConnectionState.Connecting -> Color(0xFFFFA726)
@@ -73,7 +75,7 @@ fun StatusIndicator(
     Row(
         modifier = modifier.semantics(mergeDescendants = true) {
             if (label != null) {
-                contentDescription = "$stateDesc: $label"
+                contentDescription = context.getString(R.string.status_indicator_format, stateDesc, label)
             } else {
                 contentDescription = stateDesc
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,4 +646,7 @@
     <string name="action_copy">Copy</string>
     <string name="error_mic_privacy_title">Microphone Access Blocked</string>
     <string name="error_mic_privacy_message">Your device\'s microphone privacy toggle is off. Enable it in Settings &gt; Privacy &gt; Microphone.</string>
+    <string name="more_info_about">More info about %1$s</string>
+    <string name="status_indicator_format">%1$s: %2$s</string>
+    <string name="downloaded_content_description">Downloaded</string>
 </resources>


### PR DESCRIPTION
💡 **What**: Extracted hardcoded `contentDescription` strings from Compose components into `strings.xml`.
🎯 **Why**: Improves internationalization and accessibility. Screen readers will now be able to read localized strings instead of English-only hardcoded strings.
♿ **Accessibility**: Enhanced screen reader support by ensuring the descriptions can be localized. Extracted `"Downloaded"`, `"More info about..."`, and status indicator formatting strings into string resources.

---
*PR created automatically by Jules for task [16575229178617387167](https://jules.google.com/task/16575229178617387167) started by @yuga-hashimoto*