### PR TITLE
🎨 Polish: Improve accessibility labels

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1183,7 +1183,7 @@ fun CapabilityCard(
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                        contentDescription = "More info about $label",
+                        contentDescription = stringResource(R.string.more_info_about, label),
                         tint = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(16.dp)
                     )

--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -2278,7 +2278,7 @@ fun VoiceVoxSettingsCard(
                             if (selectedCharacter != null && downloadedVvmFiles.contains(selectedCharacter.vvmFileName)) {
                                 Icon(
                                     Icons.Default.Check,
-                                    contentDescription = "Downloaded",
+                                    contentDescription = stringResource(R.string.voicevox_downloaded),
                                     tint = MaterialTheme.colorScheme.primary,
                                     modifier = Modifier.size(18.dp)
                                 )
@@ -2305,7 +2305,7 @@ fun VoiceVoxSettingsCard(
                                     if (isVvmReady) {
                                         Icon(
                                             Icons.Default.Check,
-                                            contentDescription = "Downloaded",
+                                            contentDescription = stringResource(R.string.voicevox_downloaded),
                                             tint = MaterialTheme.colorScheme.primary,
                                             modifier = Modifier.size(16.dp)
                                         )

--- a/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
@@ -70,13 +70,11 @@ fun StatusIndicator(
         label = "dotAlpha"
     )
 
+    val fullDesc = if (label != null) stringResource(R.string.status_indicator_desc, stateDesc, label) else stateDesc
+
     Row(
         modifier = modifier.semantics(mergeDescendants = true) {
-            if (label != null) {
-                contentDescription = "$stateDesc: $label"
-            } else {
-                contentDescription = stateDesc
-            }
+            contentDescription = fullDesc
         },
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,4 +646,6 @@
     <string name="action_copy">Copy</string>
     <string name="error_mic_privacy_title">Microphone Access Blocked</string>
     <string name="error_mic_privacy_message">Your device\'s microphone privacy toggle is off. Enable it in Settings &gt; Privacy &gt; Microphone.</string>
+    <string name="more_info_about">More info about %1$s</string>
+    <string name="status_indicator_desc">%1$s: %2$s</string>
 </resources>


### PR DESCRIPTION
## What
This PR updates several hardcoded `contentDescription` properties in Jetpack Compose UI elements to use properly localized `stringResource` calls.

## Why
Using hardcoded English strings for accessibility labels prevents screen readers from announcing them correctly in other languages, degrading the experience for non-English users.

## Changes
- In `SettingsActivity.kt`: Replaced hardcoded `"Downloaded"` with `stringResource(R.string.voicevox_downloaded)` for VoiceVox models.
- In `MainActivity.kt`: Replaced `"More info about $label"` with a format string `stringResource(R.string.more_info_about, label)`.
- In `StatusIndicator.kt`: Replaced string concatenation `"$stateDesc: $label"` with `stringResource(R.string.status_indicator_desc, stateDesc, label)`.
- Added the corresponding entries to `app/src/main/res/values/strings.xml`.

---
*PR created automatically by Jules for task [588377301308891840](https://jules.google.com/task/588377301308891840) started by @yuga-hashimoto*