### PR TITLE
🔄 Upstream Parity: fix(android): keep camera temp files private

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
@@ -111,7 +111,7 @@ class CameraCaptureManager(private val context: Context) {
       provider.unbindAll()
       provider.bindToLifecycle(owner, selector, capture)
 
-      val (bytes, orientation) = capture.takeJpegWithExif(context.mainExecutor())
+      val (bytes, orientation) = capture.takeJpegWithExif(context.mainExecutor(), context.cacheDir)
       val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
         ?: throw IllegalStateException("UNAVAILABLE: failed to decode captured image")
       val rotated = rotateBitmapByExif(decoded, orientation)
@@ -213,7 +213,7 @@ class CameraCaptureManager(private val context: Context) {
       android.util.Log.w("CameraCaptureManager", "clip: warming up camera 1.5s...")
       kotlinx.coroutines.delay(1_500)
 
-      val file = File.createTempFile("openclaw-clip-", ".mp4")
+      val file = File.createTempFile("openclaw-clip-", ".mp4", context.cacheDir)
       val outputOptions = FileOutputOptions.Builder(file).build()
 
       val finalized = kotlinx.coroutines.CompletableDeferred<VideoRecordEvent.Finalize>()
@@ -356,9 +356,9 @@ private suspend fun Context.cameraProvider(): ProcessCameraProvider =
   }
 
 /** Returns (jpegBytes, exifOrientation) so caller can rotate the decoded bitmap. */
-private suspend fun ImageCapture.takeJpegWithExif(executor: Executor): Pair<ByteArray, Int> =
+private suspend fun ImageCapture.takeJpegWithExif(executor: Executor, tempDir: File): Pair<ByteArray, Int> =
   suspendCancellableCoroutine { cont ->
-    val file = File.createTempFile("openclaw-snap-", ".jpg")
+    val file = File.createTempFile("openclaw-snap-", ".jpg", tempDir)
     val options = ImageCapture.OutputFileOptions.Builder(file).build()
     takePicture(
       options,


### PR DESCRIPTION
**Source:** Upstream commit `d525d6486d305482906b974136b8d25395211709` (fix(android): keep camera temp files private)

**Why:** The upstream repository identified and fixed a CodeQL local temp-file disclosure vulnerability in the camera capture implementation. Using the default `java.io.tmpdir` on Android can sometimes lead to crashes or permission errors across different OS versions. Forcing the files into the secure, application-specific `context.cacheDir` improves both security and stability.

**Adaptation:** The upstream `takeJpegWithExif` and `clip` methods were patched exactly as implemented upstream. `File.createTempFile` invocations in `CameraCaptureManager.kt` now explicitly use `context.cacheDir`.

**Excluded upstream behavior:** N/A (applied the targeted security fix cleanly).

**Verification:** Verified via local git diff and successful execution of `./gradlew app:lintStandardDebug` and `./gradlew app:testStandardDebugUnitTest`. Removed `.kotlin/errors` build artifacts before finalizing.

---
*PR created automatically by Jules for task [12542371869680357898](https://jules.google.com/task/12542371869680357898) started by @yuga-hashimoto*