### PR TITLE
⚡ Bolt: Optimize ChatMarkdownPreprocessor performance

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/chat/ChatMarkdownPreprocessor.kt
+++ b/app/src/main/java/com/openclaw/assistant/chat/ChatMarkdownPreprocessor.kt
@@ -21,23 +21,27 @@ object ChatMarkdownPreprocessor {
         """(?m)^\[[A-Za-z]{3}\s+\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}(?::\d{2})?\s+(?:GMT|UTC)[+-]?\d{0,2}\]\s*"""
     )
 
-    private val leadingNewlinesRegex = Regex("^\\n+")
-
     fun preprocess(raw: String): String {
         val withoutContextBlocks = stripInboundContextBlocks(raw)
         val withoutTimestamps = stripPrefixedTimestamps(withoutContextBlocks)
         return normalize(withoutTimestamps)
     }
 
+    /**
+     * Optimizations applied:
+     * - Uses `lineSequence()` instead of `split("\n")` to avoid allocating an intermediate list of strings.
+     * - Uses `StringBuilder` instead of `mutableListOf<String>` + `joinToString("\n")` to avoid intermediate collection allocations and reduce GC overhead.
+     * - Uses `trimStart('\n')` instead of `Regex("^\\n+").replace()` to avoid regex engine overhead.
+     */
     private fun stripInboundContextBlocks(raw: String): String {
         if (inboundContextHeaders.none { raw.contains(it) }) return raw
 
         val normalized = raw.replace("\r\n", "\n")
-        val outputLines = mutableListOf<String>()
+        val outputLines = java.lang.StringBuilder(normalized.length)
         var inMetaBlock = false
         var inFencedJson = false
 
-        for (line in normalized.split("\n")) {
+        for (line in normalized.lineSequence()) {
             if (!inMetaBlock && inboundContextHeaders.any { line.startsWith(it) }) {
                 inMetaBlock = true
                 inFencedJson = false
@@ -62,11 +66,13 @@ object ChatMarkdownPreprocessor {
                 inMetaBlock = false
             }
 
-            outputLines.add(line)
+            if (outputLines.isNotEmpty()) {
+                outputLines.append('\n')
+            }
+            outputLines.append(line)
         }
 
-        return outputLines.joinToString("\n")
-            .replace(leadingNewlinesRegex, "")
+        return outputLines.toString().trimStart('\n')
     }
 
     private fun stripPrefixedTimestamps(raw: String): String =


### PR DESCRIPTION
### 💡 What
Optimized the string processing in `ChatMarkdownPreprocessor.kt` by replacing intermediate list allocations with sequence processing and a `StringBuilder`.

### 🎯 Why
The previous implementation used `split("\n")` and `mutableListOf<String>`, which created unnecessary intermediate collections and generated excessive Garbage Collection (GC) pressure, especially when processing long, multi-line chat messages. It also used a relatively expensive Regex operation to strip leading newlines.

### 📊 Impact
Reduces memory allocations per message processed. Eliminates intermediate `List<String>` generation and avoids Regex engine overhead, resulting in fewer minor GC pauses during rapid message ingestion.

### 🔬 Measurement
Run the application and monitor Android Studio's Memory Profiler during high-frequency chat message loading. The number of String and List allocations originating from `ChatMarkdownPreprocessor` should be significantly reduced. All existing unit tests pass.

---
*PR created automatically by Jules for task [358985314053725949](https://jules.google.com/task/358985314053725949) started by @yuga-hashimoto*