### PR TITLE
🧪 Regression Guard: Fix background service crash

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,10 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stopService", ex) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stopService", ex) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,15 +285,13 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stopService", ex) }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stopService", ex) }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        try {
-            context.stopService(intent)
-        } catch (stopEx: Exception) {
+        try { context.stopService(intent) } catch (stopEx: Exception) {
             android.util.Log.e(TAG, "Failed to stopService as well", stopEx)
         }
       }

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,10 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stopService", ex) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stopService", ex) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
**What:** 
Added nested `try-catch` blocks around `context.stopService(intent)` calls inside the exception fallback paths of `HotwordService`, `SessionForegroundService`, and `NodeForegroundService`.

**Why:**
When the OS blocks starting a foreground service (e.g., due to background execution limits throwing `IllegalStateException`), the current implementation attempts to clean up by immediately calling `stopService()`. However, calling `stopService()` on a service the OS already considers invalid or dead can itself throw an exception, leading to an unhandled crash. 

**Verification:**
- Validated via standard debug unit tests (`./gradlew app:testStandardDebugUnitTest`).
- Validated via standard debug linting checks (`./gradlew app:lintStandardDebug`).
- Ran and verified code review suggestions regarding redundant `try-catch` blocks.

---
*PR created automatically by Jules for task [2317320525303886623](https://jules.google.com/task/2317320525303886623) started by @yuga-hashimoto*