### PR TITLE
🎨 Palette: Extract hardcoded accessibility labels to string resources

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2025-10-24 - Dropdown Trigger Accessibility
 **Learning:** Using `Modifier.clickable` without a specific role and label for a row that opens a dropdown causes screen readers to misidentify its function.
 **Action:** When a clickable element opens a dropdown menu, always use `Modifier.clickable(onClickLabel = "...", role = Role.DropdownList)` to ensure proper screen reader announcement.
+
+## 2024-05-19 - Standardize contentDescription for File Attachments
+**Learning:** Hardcoded accessibility descriptions in Jetpack Compose (e.g., `contentDescription = "Attach file"`) prevent localization for screen readers, diminishing the experience for non-English users.
+**Action:** Always extract `contentDescription` strings to `strings.xml` and use `stringResource(R.string.key)` to ensure accessibility labels are fully localizable.

--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1183,7 +1183,7 @@ fun CapabilityCard(
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                        contentDescription = "More info about $label",
+                        contentDescription = stringResource(R.string.action_more_info, label),
                         tint = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(16.dp)
                     )
@@ -1286,7 +1286,7 @@ fun CompactActionCard(modifier: Modifier = Modifier, icon: ImageVector, title: S
             Column(modifier = Modifier.weight(1f).fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
                 Row(modifier = Modifier.fillMaxWidth().height(32.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                     Icon(imageVector = icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(28.dp))
-                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable(onClickLabel = "More information about $title", role = Role.Button) { onInfoClick?.invoke() })
+                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable(onClickLabel = stringResource(R.string.action_more_info, title), role = Role.Button) { onInfoClick?.invoke() })
                     if (showSwitch) Switch(checked = switchValue, onCheckedChange = onSwitchChange, modifier = Modifier.scale(0.8f).offset(y = (-8).dp))
                 }
                 Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -2278,7 +2278,7 @@ fun VoiceVoxSettingsCard(
                             if (selectedCharacter != null && downloadedVvmFiles.contains(selectedCharacter.vvmFileName)) {
                                 Icon(
                                     Icons.Default.Check,
-                                    contentDescription = "Downloaded",
+                                    contentDescription = stringResource(R.string.voicevox_downloaded),
                                     tint = MaterialTheme.colorScheme.primary,
                                     modifier = Modifier.size(18.dp)
                                 )
@@ -2305,7 +2305,7 @@ fun VoiceVoxSettingsCard(
                                     if (isVvmReady) {
                                         Icon(
                                             Icons.Default.Check,
-                                            contentDescription = "Downloaded",
+                                            contentDescription = stringResource(R.string.voicevox_downloaded),
                                             tint = MaterialTheme.colorScheme.primary,
                                             modifier = Modifier.size(16.dp)
                                         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,4 +646,5 @@
     <string name="action_copy">Copy</string>
     <string name="error_mic_privacy_title">Microphone Access Blocked</string>
     <string name="error_mic_privacy_message">Your device\'s microphone privacy toggle is off. Enable it in Settings &gt; Privacy &gt; Microphone.</string>
+    <string name="action_more_info">More info about %1$s</string>
 </resources>


### PR DESCRIPTION
💡 **What:** Replaced hardcoded accessibility labels (`contentDescription` and `onClickLabel`) in `SettingsActivity.kt` and `MainActivity.kt` with localized `stringResource` calls.
🎯 **Why:** Hardcoded strings in Jetpack Compose prevent proper localization for screen readers, diminishing the experience for non-English users.
📸 **Before/After:** No visual changes, but screen readers will now announce properly translated text if localized strings are provided.
♿ **Accessibility:** This directly improves accessibility by ensuring all actionable icons have localizable screen reader announcements.

Verified by running `./gradlew app:lintStandardDebug` and `./gradlew app:testStandardDebugUnitTest`.

---
*PR created automatically by Jules for task [7576101837075008378](https://jules.google.com/task/7576101837075008378) started by @yuga-hashimoto*