### PR TITLE
🧪 Regression Guard: Fix service stop crashes

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,18 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    Log.e(TAG, "Failed to stopService as well", stopEx)
+                }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    Log.e(TAG, "Failed to stopService as well", stopEx)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,16 +285,24 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try {
+          context.stopService(intent)
+        } catch (stopEx: Exception) {
+          android.util.Log.e(TAG, "Failed to stopService as well", stopEx)
+        }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try {
+          context.stopService(intent)
+        } catch (stopEx: Exception) {
+          android.util.Log.e(TAG, "Failed to stopService as well", stopEx)
+        }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {
-            context.stopService(intent)
+          context.stopService(intent)
         } catch (stopEx: Exception) {
-            android.util.Log.e(TAG, "Failed to stopService as well", stopEx)
+          android.util.Log.e(TAG, "Failed to stopService as well", stopEx)
         }
       }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,18 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    Log.e(TAG, "Failed to stopService as well", stopEx)
+                }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    Log.e(TAG, "Failed to stopService as well", stopEx)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
🧪 Regression Guard: Fix service stop fallback crashes

**What:**
Wraps the `context.stopService(intent)` fallback calls inside a nested `try-catch` block in `HotwordService`, `SessionForegroundService`, and `NodeForegroundService`.

**Why:**
When the system prevents starting a service due to background execution limits (`IllegalStateException`) or security constraints (`SecurityException`), the services attempt to gracefully clean up by calling `context.stopService()`. However, if the OS already considers the service state invalid or torn down, this fallback call itself can throw an exception, leading to a fatal application crash. This change catches those secondary exceptions and logs them, improving stability on devices with aggressive background restrictions.

**Impact:**
Prevents fatal crashes related to foreground service start/stop lifecycles.
No new functionality introduced.
Safety-only defensive change.

**Testing:**
Ran standard unit test suite to ensure no regressions. Verified the try-catch block is properly scoped via `git diff`.

---
*PR created automatically by Jules for task [17308380113327352464](https://jules.google.com/task/17308380113327352464) started by @yuga-hashimoto*