### PR TITLE
🎨 Polish: Improve accessibility labels

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1139,7 +1139,7 @@ fun CapabilityCard(
             .height(72.dp)
             .clickable(
                 onClick = onClick,
-                onClickLabel = if (isActive) "Disable $label" else "Enable $label",
+                onClickLabel = if (isActive) stringResource(R.string.a11y_disable, label) else stringResource(R.string.a11y_enable, label),
                 role = Role.Button
             ),
         colors = CardDefaults.cardColors(
@@ -1183,7 +1183,7 @@ fun CapabilityCard(
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                        contentDescription = "More info about $label",
+                        contentDescription = stringResource(R.string.a11y_more_info, label),
                         tint = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(16.dp)
                     )
@@ -1286,7 +1286,7 @@ fun CompactActionCard(modifier: Modifier = Modifier, icon: ImageVector, title: S
             Column(modifier = Modifier.weight(1f).fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
                 Row(modifier = Modifier.fillMaxWidth().height(32.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                     Icon(imageVector = icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(28.dp))
-                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable(onClickLabel = "More information about $title", role = Role.Button) { onInfoClick?.invoke() })
+                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable(onClickLabel = stringResource(R.string.a11y_more_information, title), role = Role.Button) { onInfoClick?.invoke() })
                     if (showSwitch) Switch(checked = switchValue, onCheckedChange = onSwitchChange, modifier = Modifier.scale(0.8f).offset(y = (-8).dp))
                 }
                 Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -2278,7 +2278,7 @@ fun VoiceVoxSettingsCard(
                             if (selectedCharacter != null && downloadedVvmFiles.contains(selectedCharacter.vvmFileName)) {
                                 Icon(
                                     Icons.Default.Check,
-                                    contentDescription = "Downloaded",
+                                    contentDescription = stringResource(R.string.a11y_downloaded),
                                     tint = MaterialTheme.colorScheme.primary,
                                     modifier = Modifier.size(18.dp)
                                 )
@@ -2305,7 +2305,7 @@ fun VoiceVoxSettingsCard(
                                     if (isVvmReady) {
                                         Icon(
                                             Icons.Default.Check,
-                                            contentDescription = "Downloaded",
+                                            contentDescription = stringResource(R.string.a11y_downloaded),
                                             tint = MaterialTheme.colorScheme.primary,
                                             modifier = Modifier.size(16.dp)
                                         )

--- a/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
@@ -70,13 +70,11 @@ fun StatusIndicator(
         label = "dotAlpha"
     )
 
+    val statusLabel = if (label != null) stringResource(R.string.a11y_status_label, stateDesc, label) else stateDesc
+
     Row(
         modifier = modifier.semantics(mergeDescendants = true) {
-            if (label != null) {
-                contentDescription = "$stateDesc: $label"
-            } else {
-                contentDescription = stateDesc
-            }
+            contentDescription = statusLabel
         },
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,4 +646,11 @@
     <string name="action_copy">Copy</string>
     <string name="error_mic_privacy_title">Microphone Access Blocked</string>
     <string name="error_mic_privacy_message">Your device\'s microphone privacy toggle is off. Enable it in Settings &gt; Privacy &gt; Microphone.</string>
+
+    <string name="a11y_more_info">More info about %1$s</string>
+    <string name="a11y_more_information">More information about %1$s</string>
+    <string name="a11y_disable">Disable %1$s</string>
+    <string name="a11y_enable">Enable %1$s</string>
+    <string name="a11y_downloaded">Downloaded</string>
+    <string name="a11y_status_label">%1$s: %2$s</string>
 </resources>


### PR DESCRIPTION
💡 What
Extracted multiple hardcoded accessibility strings (e.g., `contentDescription = "Downloaded"`, `onClickLabel = "More information about..."`) into translatable `strings.xml` resources.

🎯 Why
Hardcoded accessibility strings degrade the experience for non-English users because screen readers will announce the raw English text regardless of the system language. Extracting them enables full localization.

📸 Before/After
- Before: `@Composable` elements used literal strings for `contentDescription` and `onClickLabel`.
- After: Elements now correctly resolve descriptions using `stringResource(R.string...)`.

♿ Accessibility
Significantly improves screen reader support by ensuring that interactive elements announce their purpose in the user's localized language.

---
*PR created automatically by Jules for task [10363130008586541515](https://jules.google.com/task/10363130008586541515) started by @yuga-hashimoto*