### PR TITLE
🛡️ Sentinel: Secure temp file creation and TLS probing

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/gateway/GatewayTls.kt
+++ b/app/src/main/java/com/openclaw/assistant/gateway/GatewayTls.kt
@@ -95,13 +95,18 @@ suspend fun probeGatewayTlsFingerprint(
   if (port !in 1..65535) return null
 
   return withContext(Dispatchers.IO) {
+    class ProbeException(val fingerprint: String) : CertificateException()
+
     val trustAll =
-      @SuppressLint("CustomX509TrustManager", "TrustAllX509TrustManager")
+      @SuppressLint("CustomX509TrustManager")
       object : X509TrustManager {
-        @SuppressLint("TrustAllX509TrustManager")
         override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
-        @SuppressLint("TrustAllX509TrustManager")
-        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}
+        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
+          if (chain.isNotEmpty()) {
+            throw ProbeException(sha256Hex(chain[0].encoded))
+          }
+          throw CertificateException("Empty chain")
+        }
         override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
       }
 
@@ -128,15 +133,18 @@ suspend fun probeGatewayTlsFingerprint(
       }
       
       socket.startHandshake()
-      val cert = socket.session.peerCertificates.firstOrNull() as? X509Certificate ?: run {
-          android.util.Log.e("GatewayTls", "Probe failed: Peer certificates empty for $trimmedHost:$port")
-          return@withContext null
-      }
-      sha256Hex(cert.encoded)
+      null
     } catch (e: java.net.SocketTimeoutException) {
       android.util.Log.e("GatewayTls", "Probe timeout ($timeoutMs ms) for $trimmedHost:$port", e)
       null
     } catch (e: Throwable) {
+      var cause: Throwable? = e
+      while (cause != null) {
+        if (cause is ProbeException) {
+          return@withContext cause.fingerprint
+        }
+        cause = cause.cause
+      }
       android.util.Log.e("GatewayTls", "Probe failed with exception for $trimmedHost:$port", e)
       null
     } finally {

--- a/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
@@ -111,7 +111,7 @@ class CameraCaptureManager(private val context: Context) {
       provider.unbindAll()
       provider.bindToLifecycle(owner, selector, capture)
 
-      val (bytes, orientation) = capture.takeJpegWithExif(context.mainExecutor())
+      val (bytes, orientation) = capture.takeJpegWithExif(context, context.mainExecutor())
       val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
         ?: throw IllegalStateException("UNAVAILABLE: failed to decode captured image")
       val rotated = rotateBitmapByExif(decoded, orientation)
@@ -213,7 +213,7 @@ class CameraCaptureManager(private val context: Context) {
       android.util.Log.w("CameraCaptureManager", "clip: warming up camera 1.5s...")
       kotlinx.coroutines.delay(1_500)
 
-      val file = File.createTempFile("openclaw-clip-", ".mp4")
+      val file = File.createTempFile("openclaw-clip-", ".mp4", context.cacheDir)
       val outputOptions = FileOutputOptions.Builder(file).build()
 
       val finalized = kotlinx.coroutines.CompletableDeferred<VideoRecordEvent.Finalize>()
@@ -356,9 +356,9 @@ private suspend fun Context.cameraProvider(): ProcessCameraProvider =
   }
 
 /** Returns (jpegBytes, exifOrientation) so caller can rotate the decoded bitmap. */
-private suspend fun ImageCapture.takeJpegWithExif(executor: Executor): Pair<ByteArray, Int> =
+private suspend fun ImageCapture.takeJpegWithExif(context: Context, executor: Executor): Pair<ByteArray, Int> =
   suspendCancellableCoroutine { cont ->
-    val file = File.createTempFile("openclaw-snap-", ".jpg")
+    val file = File.createTempFile("openclaw-snap-", ".jpg", context.cacheDir)
     val options = ImageCapture.OutputFileOptions.Builder(file).build()
     takePicture(
       options,

--- a/app/src/main/java/com/openclaw/assistant/node/ScreenRecordManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/ScreenRecordManager.kt
@@ -93,7 +93,7 @@ class ScreenRecordManager(private val context: Context) {
       val height = metrics.heightPixels
       val densityDpi = metrics.densityDpi
 
-      val file = File.createTempFile("openclaw-screen-", ".mp4")
+      val file = File.createTempFile("openclaw-screen-", ".mp4", context.cacheDir)
       if (includeAudio) ensureMicPermission()
 
       val recorder = createMediaRecorder()


### PR DESCRIPTION
💡 What:
1. Replaced the insecure "Trust All" X.509 TrustManager in `probeGatewayTlsFingerprint` with a secure approach that intentionally fails the handshake by throwing a custom `ProbeException` containing the fingerprint.
2. Updated multiple `File.createTempFile` invocations in `CameraCaptureManager.kt` and `ScreenRecordManager.kt` to explicitly use `context.cacheDir` as the directory parameter.

🎯 Why:
1. The previous TLS probe implementation used an empty `checkServerTrusted` block which is a severe security anti-pattern (it silently accepts all certificates). By intentionally throwing an exception, we safely abort the handshake while still capturing the necessary fingerprint, resolving potential CodeQL "insecure trust manager" findings.
2. Creating temporary files without specifying a directory defaults to `java.io.tmpdir`. By explicitly using `context.cacheDir`, we ensure that these files are securely stored within the app's sandboxed directory, preventing potential CodeQL local temp-file disclosure vulnerabilities and ensuring they cannot be read by other apps.

🔬 Verification:
- Modified files manually verified.
- Ran `./gradlew app:lintStandardDebug` (passed).
- Ran `./gradlew app:testStandardDebugUnitTest` (passed).

---
*PR created automatically by Jules for task [10875049573565088112](https://jules.google.com/task/10875049573565088112) started by @yuga-hashimoto*