### PR TITLE
🧪 Regression Guard: Fix service stop crash

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,10 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (stopEx: Exception) { android.util.Log.e(TAG, "Failed to stopService", stopEx) }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (stopEx: Exception) { android.util.Log.e(TAG, "Failed to stopService", stopEx) }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {


### PR DESCRIPTION
🧪 Regression Guard: Fix service stop crash

**Priority area:** crash prevention, background/foreground state handling

**Issue:**
If `context.startForegroundService(intent)` or `context.startService(intent)` fails due to strict background execution limits (throwing `IllegalStateException` or `SecurityException`), the app attempts to clean up by calling `context.stopService(intent)` in the `catch` block. However, if the OS already considers the service state invalid or the process is severely restricted, `stopService` itself can throw an exception, leading to an unhandled runtime crash.

**Fix:**
Wrapped the `context.stopService(intent)` calls inside `try-catch` blocks within those fallback handlers across `NodeForegroundService`, `SessionForegroundService`, and `HotwordService`. If `stopService` fails, the exception is safely caught and logged without crashing the application.

**Verification:**
- Ran `./gradlew app:testStandardDebugUnitTest`
- Ran `./gradlew app:lintStandardDebug`
- Successfully requested code review

---
*PR created automatically by Jules for task [3609135915411465159](https://jules.google.com/task/3609135915411465159) started by @yuga-hashimoto*