### PR TITLE
⚡ Bolt: Optimize chat markdown preprocessor memory allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2025-05-27 - O(N^2) String Chunking Regression in `lastIndexOf`
 **Learning:** Using `text.substring().lastIndexOf(delimiter)` inside a text chunking loop (e.g. for Text-to-Speech normalization) creates a hidden performance regression. `substring` allocates new strings for each chunk, but more problematically, `lastIndexOf` searches backwards across the *entire* text. If the delimiter is missing from the chunk, it will search backwards all the way to index 0, resulting in O(N^2) complexity and massive latency spikes for long strings without delimiters.
 **Action:** When searching backward for a delimiter to split text within a length constraint without allocating substrings, use a custom bounded `regionMatches` loop (tracking `offset` and `limit`) instead of an unbounded `lastIndexOf`. Additionally, convert constant boundary lists (like sentence enders) to `arrayOf()` to prevent hidden iterator allocations during the per-chunk delimiter searches.
+
+## 2024-05-27 - Hoist Static Collection Allocations in Loop Parsers
+**Learning:** Replaced `.split("\n")` and `mutableListOf<String>().joinToString("\n")` pipeline with `lineSequence()` and a pre-sized `StringBuilder` to eliminate massive GC pressure in frequently called parsers. Also replaced final trailing Regex replaces with simple `trimStart()`.
+**Action:** Always favor `lineSequence()` and direct string building when processing and transforming multi-line text strings over intermediate list allocations.

--- a/app/src/main/java/com/openclaw/assistant/chat/ChatMarkdownPreprocessor.kt
+++ b/app/src/main/java/com/openclaw/assistant/chat/ChatMarkdownPreprocessor.kt
@@ -21,8 +21,6 @@ object ChatMarkdownPreprocessor {
         """(?m)^\[[A-Za-z]{3}\s+\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}(?::\d{2})?\s+(?:GMT|UTC)[+-]?\d{0,2}\]\s*"""
     )
 
-    private val leadingNewlinesRegex = Regex("^\\n+")
-
     fun preprocess(raw: String): String {
         val withoutContextBlocks = stripInboundContextBlocks(raw)
         val withoutTimestamps = stripPrefixedTimestamps(withoutContextBlocks)
@@ -33,11 +31,14 @@ object ChatMarkdownPreprocessor {
         if (inboundContextHeaders.none { raw.contains(it) }) return raw
 
         val normalized = raw.replace("\r\n", "\n")
-        val outputLines = mutableListOf<String>()
+        // ⚡ Bolt Optimization: Eliminated split("\n") and mutableListOf().joinToString()
+        // to avoid intermediate list allocations and reduce GC pressure.
+        val sb = StringBuilder(normalized.length)
         var inMetaBlock = false
         var inFencedJson = false
+        var isFirstLine = true
 
-        for (line in normalized.split("\n")) {
+        for (line in normalized.lineSequence()) {
             if (!inMetaBlock && inboundContextHeaders.any { line.startsWith(it) }) {
                 inMetaBlock = true
                 inFencedJson = false
@@ -62,11 +63,12 @@ object ChatMarkdownPreprocessor {
                 inMetaBlock = false
             }
 
-            outputLines.add(line)
+            if (!isFirstLine) sb.append("\n")
+            sb.append(line)
+            isFirstLine = false
         }
 
-        return outputLines.joinToString("\n")
-            .replace(leadingNewlinesRegex, "")
+        return sb.toString().trimStart('\n')
     }
 
     private fun stripPrefixedTimestamps(raw: String): String =


### PR DESCRIPTION
💡 What: 
- Replaced `.split("\n")` with `.lineSequence()` to iterate through multi-line strings without allocating a huge intermediate list.
- Replaced `mutableListOf<String>().joinToString("\n")` with direct appends to a `StringBuilder` pre-allocated to `normalized.length`.
- Replaced regex `.replace(leadingNewlinesRegex, "")` with standard library `trimStart('\n')` for prefix trimming.

🎯 Why: 
`ChatMarkdownPreprocessor.preprocess` is invoked on every single chat message when it is converted to UI format. Splitting and joining massive texts heavily taxes the Garbage Collector by creating thousands of intermediate temporary objects. By switching to `lineSequence` and manual `StringBuilder` appends, memory allocation overhead is drastically reduced.

📊 Impact: 
- Eliminates 1 intermediate `List<String>` allocation per message preprocessing.
- Pre-sizing the `StringBuilder` ensures 0 array reallocations under the hood.
- Regex compilation and execution for `^\\n+` is replaced by an optimized char-checking loop.

🔬 Measurement: 
Verified by passing unit tests (`app:testStandardDebugUnitTest`) and lint (`app:lintStandardDebug`). Memory profiler traces during heavy text generation should show significantly reduced allocation rates for `String` and `ArrayList` primitives.

---
*PR created automatically by Jules for task [4937922387623336885](https://jules.google.com/task/4937922387623336885) started by @yuga-hashimoto*