### PR TITLE
🧪 Regression Guard: Fix service cleanup crash on stopService

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,10 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "stopService failed", ex) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "stopService failed", ex) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,10 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "stopService failed", ex) }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "stopService failed", ex) }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,10 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "stopService failed", ex) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "stopService failed", ex) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }

--- a/wear/src/main/java/com/openclaw/assistant/wear/service/WearSessionForegroundService.kt
+++ b/wear/src/main/java/com/openclaw/assistant/wear/service/WearSessionForegroundService.kt
@@ -72,6 +72,12 @@ class WearSessionForegroundService : Service() {
                 } else {
                     context.startService(intent)
                 }
+            } catch (e: IllegalStateException) {
+                android.util.Log.e("WearSessionFGS", "Background execution limits prevented starting WearSessionForegroundService: ${e.message}", e)
+                try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e("WearSessionFGS", "stopService failed", ex) }
+            } catch (e: SecurityException) {
+                android.util.Log.e("WearSessionFGS", "Security limits prevented starting WearSessionForegroundService: ${e.message}", e)
+                try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e("WearSessionFGS", "stopService failed", ex) }
             } catch (e: Exception) {
                 android.util.Log.e("WearSessionFGS", "Failed to start WearSessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
🧪 Regression Guard: Fix service cleanup crash on stopService

**💡 What**
Added a nested `try-catch` wrapper around `context.stopService(intent)` inside `catch` blocks across foreground services, and added missing background restriction exception handling to `WearSessionForegroundService.kt`.

**🎯 Why**
When Android enforces background execution limits, `startForegroundService` throws an `IllegalStateException` or `SecurityException`. The existing error handling attempted to clean up by calling `context.stopService(intent)`. However, if the OS already considers the service context invalid, `stopService` itself can throw an exception, resulting in an unhandled fatal application crash. This patch ensures the fallback cleanup doesn't trigger secondary crashes.

---
*PR created automatically by Jules for task [16972013750774884450](https://jules.google.com/task/16972013750774884450) started by @yuga-hashimoto*