### PR TITLE
🔄 Upstream Parity: fix(android): use absolute logcat path

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/DebugHandler.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/DebugHandler.kt
@@ -78,7 +78,7 @@ class DebugHandler(
     val logResult = try {
       val tmpFile = java.io.File(appContext.cacheDir, "debug_logs.txt")
       if (tmpFile.exists()) tmpFile.delete()
-      val pb = ProcessBuilder("logcat", "-d", "-t", "200", "--pid=$pid")
+      val pb = ProcessBuilder("/system/bin/logcat", "-d", "-t", "200", "--pid=$pid")
       pb.redirectOutput(tmpFile)
       pb.redirectErrorStream(true)
       val proc = pb.start()


### PR DESCRIPTION
- **Source:** Upstream commit `29a34e0a4d5a93c729a4ab3b82662ea764dff591`
- **Why:** Fixes Android CodeQL relative path command finding in debug log collection. Using the absolute path prevents potential path injection or unresolvable command execution.
- **Adaptation:** Directly applied the absolute path `/system/bin/logcat` to the `ProcessBuilder` in `app/src/main/java/com/openclaw/assistant/node/DebugHandler.kt`.
- **Excluded upstream behavior:** None.
- **Verification:** Verified via `app:testStandardDebugUnitTest` and `app:lintStandardDebug` (passed). Verified modification visually via `grep`.

---
*PR created automatically by Jules for task [8457668768715548159](https://jules.google.com/task/8457668768715548159) started by @yuga-hashimoto*