### PR TITLE
🔄 Upstream Parity: Keep camera temp files private

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
@@ -111,7 +111,7 @@ class CameraCaptureManager(private val context: Context) {
       provider.unbindAll()
       provider.bindToLifecycle(owner, selector, capture)
 
-      val (bytes, orientation) = capture.takeJpegWithExif(context.mainExecutor())
+      val (bytes, orientation) = capture.takeJpegWithExif(context.mainExecutor(), context.cacheDir)
       val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
         ?: throw IllegalStateException("UNAVAILABLE: failed to decode captured image")
       val rotated = rotateBitmapByExif(decoded, orientation)
@@ -213,7 +213,7 @@ class CameraCaptureManager(private val context: Context) {
       android.util.Log.w("CameraCaptureManager", "clip: warming up camera 1.5s...")
       kotlinx.coroutines.delay(1_500)
 
-      val file = File.createTempFile("openclaw-clip-", ".mp4")
+      val file = File.createTempFile("openclaw-clip-", ".mp4", context.cacheDir)
       val outputOptions = FileOutputOptions.Builder(file).build()
 
       val finalized = kotlinx.coroutines.CompletableDeferred<VideoRecordEvent.Finalize>()
@@ -356,9 +356,9 @@ private suspend fun Context.cameraProvider(): ProcessCameraProvider =
   }
 
 /** Returns (jpegBytes, exifOrientation) so caller can rotate the decoded bitmap. */
-private suspend fun ImageCapture.takeJpegWithExif(executor: Executor): Pair<ByteArray, Int> =
+private suspend fun ImageCapture.takeJpegWithExif(executor: Executor, tempDir: File): Pair<ByteArray, Int> =
   suspendCancellableCoroutine { cont ->
-    val file = File.createTempFile("openclaw-snap-", ".jpg")
+    val file = File.createTempFile("openclaw-snap-", ".jpg", tempDir)
     val options = ImageCapture.OutputFileOptions.Builder(file).build()
     takePicture(
       options,

--- a/app/src/main/java/com/openclaw/assistant/node/ScreenRecordManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/ScreenRecordManager.kt
@@ -93,7 +93,7 @@ class ScreenRecordManager(private val context: Context) {
       val height = metrics.heightPixels
       val densityDpi = metrics.densityDpi
 
-      val file = File.createTempFile("openclaw-screen-", ".mp4")
+      val file = File.createTempFile("openclaw-screen-", ".mp4", context.cacheDir)
       if (includeAudio) ensureMicPermission()
 
       val recorder = createMediaRecorder()


### PR DESCRIPTION
- **Source:** Upstream commit `d525d6486d` (fix(android): keep camera temp files private)
- **Why:** To remediate potential Android CodeQL local temp-file disclosure findings and improve app reliability by explicitly saving media capture temp files to the application's secure `cacheDir`, rather than the unreliable system default temporary directory.
- **Adaptation:** Updated `CameraCaptureManager` and `ScreenRecordManager` to pass `context.cacheDir` to all `File.createTempFile` calls. Adapted the private extension function `takeJpegWithExif` to accept a `tempDir` parameter to inject this dependency.
- **Excluded upstream behavior:** The patch ports all exact logic safely without impacting UI/UX or touching any unneeded functionality.
- **Verification:** Ran `./gradlew app:lintStandardDebug` and `./gradlew app:testStandardDebugUnitTest` successfully, confirming no regressions. Tested code visually.

---
*PR created automatically by Jules for task [8381661843548152600](https://jules.google.com/task/8381661843548152600) started by @yuga-hashimoto*