### PR TITLE
🎨 Polish: Improve accessibility labels for action cards

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1139,7 +1139,7 @@ fun CapabilityCard(
             .height(72.dp)
             .clickable(
                 onClick = onClick,
-                onClickLabel = if (isActive) "Disable $label" else "Enable $label",
+                onClickLabel = if (isActive) stringResource(R.string.disable_feature, label) else stringResource(R.string.enable_feature, label),
                 role = Role.Button
             ),
         colors = CardDefaults.cardColors(
@@ -1286,7 +1286,7 @@ fun CompactActionCard(modifier: Modifier = Modifier, icon: ImageVector, title: S
             Column(modifier = Modifier.weight(1f).fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
                 Row(modifier = Modifier.fillMaxWidth().height(32.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                     Icon(imageVector = icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(28.dp))
-                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable(onClickLabel = "More information about $title", role = Role.Button) { onInfoClick?.invoke() })
+                    if (showInfoIcon) Icon(imageVector = Icons.AutoMirrored.Filled.HelpOutline, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp).clickable(onClickLabel = stringResource(R.string.more_info_about, title), role = Role.Button) { onInfoClick?.invoke() })
                     if (showSwitch) Switch(checked = switchValue, onCheckedChange = onSwitchChange, modifier = Modifier.scale(0.8f).offset(y = (-8).dp))
                 }
                 Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,4 +646,8 @@
     <string name="action_copy">Copy</string>
     <string name="error_mic_privacy_title">Microphone Access Blocked</string>
     <string name="error_mic_privacy_message">Your device\'s microphone privacy toggle is off. Enable it in Settings &gt; Privacy &gt; Microphone.</string>
+
+    <string name="disable_feature">Disable %s</string>
+    <string name="enable_feature">Enable %s</string>
+    <string name="more_info_about">More information about %s</string>
 </resources>


### PR DESCRIPTION
**💡 What**
Extracted hardcoded English text in the `onClickLabel` properties of `CapabilityCard` and `CompactActionCard` to `strings.xml`.

**🎯 Why**
Previously, accessibility services like TalkBack would read hardcoded English strings (e.g. "Enable [Action]", "Disable [Action]", "More information about [Action]") regardless of the device's system language. Using `stringResource` allows these labels to be properly localized.

**📸 Before/After**
Before: `onClickLabel = "More information about $title"`
After: `onClickLabel = stringResource(R.string.more_info_about, title)`

**♿ Accessibility**
Directly improves TalkBack and screen reader experience by allowing action labels to be translated, ensuring users hear the correct localized text for interactive elements.

---
*PR created automatically by Jules for task [13225144054307416044](https://jules.google.com/task/13225144054307416044) started by @yuga-hashimoto*