### PR TITLE
🧪 Regression Guard: Fix unhandled exception during service cleanup

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,10 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "Failed to stopService", ex) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "Failed to stopService", ex) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,10 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stopService", ex) }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (ex: Exception) { android.util.Log.e(TAG, "Failed to stopService", ex) }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,10 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "Failed to stopService", ex) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (ex: Exception) { Log.e(TAG, "Failed to stopService", ex) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
**💡 What:** 
Wrapped `context.stopService(intent)` inside `try-catch` blocks where it is used as a fallback inside exception handlers for `startService` and `startForegroundService` across `HotwordService`, `SessionForegroundService`, and `NodeForegroundService`.

**🎯 Why:**
On modern Android versions, aggressive background execution limits or security policies can cause `startForegroundService` to throw `IllegalStateException` or `SecurityException`. The existing error handlers attempted to clean up by calling `context.stopService(intent)`. However, if the service component is already in a state the OS considers invalid or restricted, `stopService` itself can throw an exception, resulting in an unhandled crash that terminates the app. Adding the nested try-catch prevents this secondary crash.

**🧪 Verification:**
- Ran `./gradlew app:testStandardDebugUnitTest` completely successfully.
- Lint timed out due to sandbox limitations, skipping to prevent infinite loops.

---
*PR created automatically by Jules for task [9352577685752421307](https://jules.google.com/task/9352577685752421307) started by @yuga-hashimoto*