### PR TITLE
🎨 Palette: Localize downloaded character accessibility label

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2025-10-24 - Dropdown Trigger Accessibility
 **Learning:** Using `Modifier.clickable` without a specific role and label for a row that opens a dropdown causes screen readers to misidentify its function.
 **Action:** When a clickable element opens a dropdown menu, always use `Modifier.clickable(onClickLabel = "...", role = Role.DropdownList)` to ensure proper screen reader announcement.
+
+## 2024-05-05 - Accessibility issue with voicevox characters
+**Learning:** Hardcoded accessibility descriptors like contentDescription = "Downloaded" inside Compose functions degrade accessibility for non-English screen readers.
+**Action:** Always verify if hardcoded strings can be replaced with `stringResource` when adding or reviewing interactive component descriptors.

--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -2278,7 +2278,7 @@ fun VoiceVoxSettingsCard(
                             if (selectedCharacter != null && downloadedVvmFiles.contains(selectedCharacter.vvmFileName)) {
                                 Icon(
                                     Icons.Default.Check,
-                                    contentDescription = "Downloaded",
+                                    contentDescription = stringResource(R.string.voicevox_downloaded_files),
                                     tint = MaterialTheme.colorScheme.primary,
                                     modifier = Modifier.size(18.dp)
                                 )
@@ -2305,7 +2305,7 @@ fun VoiceVoxSettingsCard(
                                     if (isVvmReady) {
                                         Icon(
                                             Icons.Default.Check,
-                                            contentDescription = "Downloaded",
+                                            contentDescription = stringResource(R.string.voicevox_downloaded_files),
                                             tint = MaterialTheme.colorScheme.primary,
                                             modifier = Modifier.size(16.dp)
                                         )


### PR DESCRIPTION
💡 **What**: Replaced hardcoded "Downloaded" string with localized `stringResource(R.string.voicevox_downloaded_files)` for VoiceVox character download status icons in `SettingsActivity`.

🎯 **Why**: Using a hardcoded English string degrades the experience for non-English users using screen readers (like TalkBack) by preventing proper localization of accessibility descriptors.

📸 **Before/After**: Visually the same, but screen readers will now announce "ダウンロード済み音声データ" in Japanese instead of "Downloaded".

♿ **Accessibility**: Significant improvement for localized screen reader users, directly resolving an accessibility issue inside the interactive character dropdown.

---
*PR created automatically by Jules for task [12171183431144055380](https://jules.google.com/task/12171183431144055380) started by @yuga-hashimoto*