### PR TITLE
🧪 Regression Guard: Fix cascading crashes during service stops

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,10 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService", stopEx) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService", stopEx) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,16 +285,24 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try {
+          context.stopService(intent)
+        } catch (stopEx: Exception) {
+          android.util.Log.e(TAG, "Failed to stopService", stopEx)
+        }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try {
+          context.stopService(intent)
+        } catch (stopEx: Exception) {
+          android.util.Log.e(TAG, "Failed to stopService", stopEx)
+        }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {
-            context.stopService(intent)
+          context.stopService(intent)
         } catch (stopEx: Exception) {
-            android.util.Log.e(TAG, "Failed to stopService as well", stopEx)
+          android.util.Log.e(TAG, "Failed to stopService as well", stopEx)
         }
       }
     }

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,10 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService", stopEx) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService", stopEx) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
🧪 Regression Guard: Fix cascading service crash

**Context:** When the app attempts to start a foreground service but is blocked by Android 12+ background execution restrictions, the `startService` call throws an `IllegalStateException` or `SecurityException`. The existing error handlers attempted to clean up by calling `context.stopService(intent)`. 

**The Bug:** In certain system states, that fallback `stopService()` call can *also* throw an exception, leading to an unhandled exception and a full app crash.

**The Fix:** I wrapped the `context.stopService(intent)` fallback calls in a standard `try-catch (e: Exception)` block inside the specific `IllegalStateException` and `SecurityException` catch blocks across `HotwordService`, `NodeForegroundService`, and `SessionForegroundService`. 

**Verification:**
- Ran the full test suite (`./gradlew app:testStandardDebugUnitTest`), which completed successfully.
- Linting timed out but is expected to pass as this is a strict stability fix without new features.

---
*PR created automatically by Jules for task [17552503084504588760](https://jules.google.com/task/17552503084504588760) started by @yuga-hashimoto*