### PR TITLE
🎨 Polish: Improve Gateway Trust Dialog UX

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/GatewayTrustDialog.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/GatewayTrustDialog.kt
@@ -7,6 +7,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.openclaw.assistant.R
 import com.openclaw.assistant.node.NodeRuntime
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Spacer
 
 @Composable
 fun GatewayTrustDialog(
@@ -18,12 +23,21 @@ fun GatewayTrustDialog(
     onDismissRequest = onDecline,
     title = { Text(stringResource(R.string.gateway_trust_title)) },
     text = {
-      Text(
-          stringResource(
-              R.string.gateway_trust_message,
-              prompt.fingerprintSha256
-          )
-      )
+      androidx.compose.foundation.layout.Column {
+        Text(stringResource(R.string.gateway_trust_message))
+        androidx.compose.foundation.layout.Spacer(androidx.compose.ui.Modifier.height(16.dp))
+        androidx.compose.material3.Surface(
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp),
+            color = androidx.compose.material3.MaterialTheme.colorScheme.surfaceVariant
+        ) {
+            Text(
+                prompt.fingerprintSha256,
+                modifier = androidx.compose.ui.Modifier.padding(8.dp),
+                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                style = androidx.compose.material3.MaterialTheme.typography.bodySmall
+            )
+        }
+      }
     },
     confirmButton = {
       TextButton(onClick = onAccept) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -349,7 +349,7 @@ Weitere Informationen finden Sie auf der offiziellen Website von VOICEVOX.</stri
 <string name="status_operator_online_node_offline">Operator online (Knoten offline)</string>
 <string name="status_node_online_operator_offline">Knoten online (Operator offline)</string>
 <string name="gateway_trust_title">Vertrauen Sie diesem Gateway?</string>
-<string name="gateway_trust_message">Erstmalige TLS-Verbindung.\n\nÜberprüfen Sie diesen SHA-256-Fingerabdruck Out-of-Band, bevor Sie ihm vertrauen:\n%s</string>
+<string name="gateway_trust_message">Erstmalige TLS-Verbindung.\n\nÜberprüfen Sie diesen SHA-256-Fingerabdruck Out-of-Band, bevor Sie ihm vertrauen:</string>
 <string name="gateway_trust_confirm">Vertrauen und verbinden</string>
 <string name="gateway_fingerprint_label">SHA-256 Fingerabdruck:</string>
 <string name="gateway_not_connected">Nicht mit dem Gateway verbunden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -350,7 +350,7 @@ Para más detalles, consulta el sitio oficial de VOICEVOX.</string>
 <string name="status_operator_online_node_offline">Operador en línea (nodo fuera de línea)</string>
 <string name="status_node_online_operator_offline">Nodo en línea (Operador fuera de línea)</string>
 <string name="gateway_trust_title">¿Confías en esta puerta de enlace?</string>
-<string name="gateway_trust_message">Conexión TLS por primera vez.\n\nVerifique esta huella digital SHA-256 fuera de banda antes de confiar:\n%s</string>
+<string name="gateway_trust_message">Conexión TLS por primera vez.\n\nVerifique esta huella digital SHA-256 fuera de banda antes de confiar:</string>
 <string name="gateway_trust_confirm">Confiar y conectar</string>
 <string name="gateway_fingerprint_label">SHA-256 Huella digital:</string>
 <string name="gateway_not_connected">No conectado a la puerta de enlace</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -350,7 +350,7 @@ Pour plus de détails, consultez le site officiel de VOICEVOX.</string>
 <string name="status_operator_online_node_offline">Opérateur en ligne (nœud hors ligne)</string>
 <string name="status_node_online_operator_offline">Nœud en ligne (opérateur hors ligne)</string>
 <string name="gateway_trust_title">Faire confiance à cette passerelle ?</string>
-<string name="gateway_trust_message">Première connexion TLS.\n\nVérifiez cette empreinte digitale SHA-256 hors bande avant de faire confiance :\n%s</string>
+<string name="gateway_trust_message">Première connexion TLS.\n\nVérifiez cette empreinte digitale SHA-256 hors bande avant de faire confiance :</string>
 <string name="gateway_trust_confirm">Confiance et connexion</string>
 <string name="gateway_fingerprint_label">Empreinte digitale SHA-256 :</string>
 <string name="gateway_not_connected">Non connecté à la passerelle</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -350,7 +350,7 @@
 <string name="status_operator_online_node_offline">ऑपरेटर ऑनलाइन (नोड ऑफ़लाइन)</string>
 <string name="status_node_online_operator_offline">नोड ऑनलाइन (ऑपरेटर ऑफ़लाइन)</string>
 <string name="gateway_trust_title">इस गेटवे पर भरोसा करें?</string>
-<string name="gateway_trust_message">पहली बार टीएलएस कनेक्शन।\n\nभरोसा करने से पहले इस SHA-256 फिंगरप्रिंट आउट-ऑफ-बैंड को सत्यापित करें:\n%s</string>
+<string name="gateway_trust_message">पहली बार टीएलएस कनेक्शन।\n\nभरोसा करने से पहले इस SHA-256 फिंगरप्रिंट आउट-ऑफ-बैंड को सत्यापित करें:</string>
 <string name="gateway_trust_confirm">भरोसा करें और जुड़ें</string>
 <string name="gateway_fingerprint_label">SHA-256 फ़िंगरप्रिंट:</string>
 <string name="gateway_not_connected">गेटवे से कनेक्ट नहीं है</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -352,7 +352,7 @@
 <string name="status_operator_online_node_offline">オペレーター接続中（ノードオフライン）</string>
 <string name="status_node_online_operator_offline">ノード接続中（オペレーター未認証）</string>
 <string name="gateway_trust_title">このゲートウェイを信頼しますか？</string>
-<string name="gateway_trust_message">初回TLS接続です。\n\n接続を信頼する前に、以下のSHA-256フィンガープリントを他の手段で確認してください：\n%s</string>
+<string name="gateway_trust_message">初回TLS接続です。\n\n接続を信頼する前に、以下のSHA-256フィンガープリントを他の手段で確認してください：</string>
 <string name="gateway_trust_confirm">信頼して接続</string>
 <string name="gateway_fingerprint_label">SHA-256 フィンガープリント:</string>
 <string name="gateway_not_connected">ゲートウェイに接続されていません</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -350,7 +350,7 @@
 <string name="status_operator_online_node_offline">Оператор онлайн (узел не в сети)</string>
 <string name="status_node_online_operator_offline">Узел онлайн (оператор не в сети)</string>
 <string name="gateway_trust_title">Доверять этому шлюзу?</string>
-<string name="gateway_trust_message">Первое TLS-соединение.\n\nПроверьте этот отпечаток SHA-256 вне диапазона, прежде чем доверять:\n%s</string>
+<string name="gateway_trust_message">Первое TLS-соединение.\n\nПроверьте этот отпечаток SHA-256 вне диапазона, прежде чем доверять:</string>
 <string name="gateway_trust_confirm">Доверие и подключение</string>
 <string name="gateway_fingerprint_label">SHA-256 Отпечаток пальца:</string>
 <string name="gateway_not_connected">Не подключен к шлюзу</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -350,7 +350,7 @@
 <string name="status_operator_online_node_offline">操作员在线（节点离线）</string>
 <string name="status_node_online_operator_offline">节点在线（操作员离线）</string>
 <string name="gateway_trust_title">信任此网关吗？</string>
-<string name="gateway_trust_message">首次 TLS 连接。\n\n在信任之前在带外验证此 SHA-256 指纹：\n%s</string>
+<string name="gateway_trust_message">首次 TLS 连接。\n\n在信任之前在带外验证此 SHA-256 指纹：</string>
 <string name="gateway_trust_confirm">信任与连接</string>
 <string name="gateway_fingerprint_label">SHA-256 指纹：</string>
 <string name="gateway_not_connected">未连接到网关</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -349,7 +349,7 @@
 <string name="status_operator_online_node_offline">運營商在線（節點離線）</string>
 <string name="status_node_online_operator_offline">節點上線（營運商離線）</string>
 <string name="gateway_trust_title">信任這個網關嗎？</string>
-<string name="gateway_trust_message">首次 TLS 連線。 \n\n在信任之前在帶外驗證此 SHA-256 指紋：\n%s</string>
+<string name="gateway_trust_message">首次 TLS 連線。 \n\n在信任之前在帶外驗證此 SHA-256 指紋：</string>
 <string name="gateway_trust_confirm">信任與聯繫</string>
 <string name="gateway_fingerprint_label">SHA-256 指紋：</string>
 <string name="gateway_not_connected">未連接到網關</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -416,7 +416,7 @@
 
     <!-- Gateway Trust Dialog -->
     <string name="gateway_trust_title">Trust this Gateway?</string>
-    <string name="gateway_trust_message">First-time TLS connection.\n\nVerify this SHA-256 fingerprint out-of-band before trusting:\n%s</string>
+    <string name="gateway_trust_message">First-time TLS connection.\n\nVerify this SHA-256 fingerprint out-of-band before trusting:</string>
     <string name="gateway_trust_confirm">Trust &amp; Connect</string>
     <string name="gateway_fingerprint_label">SHA-256 Fingerprint:</string>
 


### PR DESCRIPTION
### 💡 What
Improved the readability of the TLS fingerprint shown in the `GatewayTrustDialog`. The SHA-256 string is now isolated into its own contained block with a `surfaceVariant` background and a monospaced font, rather than being appended as a dynamic argument to the main string resource. 

### 🎯 Why
During the first-time Gateway TLS connection, users are prompted to verify a long, dense SHA-256 fingerprint out-of-band. Displaying this fingerprint inline within a standard proportional font block made visual parsing and comparison difficult. Moving it into a distinct, monospaced visual container significantly improves clarity and reduces the cognitive load of verification without altering the product identity.

### 📸 Before/After
**Before:** The fingerprint text was squished at the end of the dialog's instructional paragraph in standard font.
**After:** The fingerprint sits in its own rounded `Surface` block below the main text, using `FontFamily.Monospace` with padding for high legibility.

### ♿ Accessibility
The layout refactor separates the instruction from the raw data. Screen readers will now traverse the primary instruction text node independently of the long hash string, potentially making navigation smoother. (No explicit `contentDescription` changes were required as standard `Text` composition handles it gracefully).

---
*PR created automatically by Jules for task [720083799408679909](https://jules.google.com/task/720083799408679909) started by @yuga-hashimoto*