### PR TITLE
🎨 Palette: Improve accessibility of DiagnosticItem

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2025-10-24 - Dropdown Trigger Accessibility
 **Learning:** Using `Modifier.clickable` without a specific role and label for a row that opens a dropdown causes screen readers to misidentify its function.
 **Action:** When a clickable element opens a dropdown menu, always use `Modifier.clickable(onClickLabel = "...", role = Role.DropdownList)` to ensure proper screen reader announcement.
+
+## 2024-05-07 - Accessibility Fix in DiagnosticItem
+**Learning:** In Jetpack Compose, when using `semantics(mergeDescendants = true)` on a parent container to group content for screen readers, you MUST provide an explicit `contentDescription` on the parent block. Furthermore, you must apply `Modifier.clearAndSetSemantics {}` to child `Text` elements to prevent them from being wiped completely from the accessibility tree or announced redundantly. Also, do not forget to import `androidx.compose.ui.semantics.contentDescription` and `androidx.compose.ui.semantics.clearAndSetSemantics`.
+**Action:** Always verify that parent containers with `mergeDescendants` have a clear, combined `contentDescription`, explicitly suppress child text with `clearAndSetSemantics`, set `contentDescription = null` on decorative/inner icons, and verify the correct extension imports are present.

--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -52,6 +52,8 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
@@ -1259,10 +1261,12 @@ fun PermissionDiagnosticsPanel(allPermissionsStatus: List<PermissionStatusInfo>,
 fun DiagnosticItem(label: String, status: DiagnosticStatus, modifier: Modifier = Modifier) {
     val color = when (status) { DiagnosticStatus.READY -> Color(0xFF4CAF50); DiagnosticStatus.WARNING -> Color(0xFFFFC107); DiagnosticStatus.ERROR -> Color(0xFFF44336) }
     val icon = when (status) { DiagnosticStatus.READY -> Icons.Default.Check; DiagnosticStatus.WARNING -> Icons.Default.Info; DiagnosticStatus.ERROR -> Icons.Default.Error }
-    Row(modifier = modifier.semantics(mergeDescendants = true) {}, verticalAlignment = Alignment.CenterVertically) {
-        Icon(icon, contentDescription = status.name, tint = color, modifier = Modifier.size(16.dp))
+    Row(modifier = modifier.semantics(mergeDescendants = true) {
+        contentDescription = "$label: ${status.name}"
+    }, verticalAlignment = Alignment.CenterVertically) {
+        Icon(icon, contentDescription = null, tint = color, modifier = Modifier.size(16.dp))
         Spacer(modifier = Modifier.width(4.dp))
-        Text(label, fontSize = 11.sp, fontWeight = FontWeight.Medium)
+        Text(label, fontSize = 11.sp, fontWeight = FontWeight.Medium, modifier = Modifier.clearAndSetSemantics {})
     }
 }
 


### PR DESCRIPTION
**💡 What**
Improved the accessibility of the `DiagnosticItem` composable by correctly applying Jetpack Compose semantics for screen readers. Added a computed `contentDescription` to the parent `Row`'s `semantics` block, set the inner `Icon`'s `contentDescription` to `null`, and applied `clearAndSetSemantics {}` to the inner `Text`. Necessary extension imports were also added.

**🎯 Why**
Previously, `DiagnosticItem` used `semantics(mergeDescendants = true)` but left its inner `Icon` with a `contentDescription` and its child `Text` with standard semantics. This could result in screen readers reading elements out of context, duplicating announcements, or dropping the text entirely. Consolidating the description at the parent level ensures a seamless, single announcement (e.g., "Label: READY") for visually impaired users.

**📸 Before/After**
*Before:* `Icon` had `contentDescription`, `Text` had standard semantics, parent `Row` merged descendants but lacked an explicit description.
*After:* Parent `Row` explicitly defines `contentDescription = "$label: ${status.name}"`. Inner `Icon` has `contentDescription = null`. Inner `Text` has `Modifier.clearAndSetSemantics {}`.

**♿ Accessibility**
Directly improves TalkBack and general screen reader support by ensuring the diagnostic status is announced as a single, cohesive focusable unit rather than disjointed, potentially duplicate pieces of text and icon descriptions.

---
*PR created automatically by Jules for task [7701322718224610787](https://jules.google.com/task/7701322718224610787) started by @yuga-hashimoto*