### PR TITLE
🧪 Regression Guard: Fix cascaded stopService crashes

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,18 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
+                try {
                 context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    android.util.Log.e(TAG, "Failed to stopService during fallback", stopEx)
+                }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
+                try {
                 context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    android.util.Log.e(TAG, "Failed to stopService during fallback", stopEx)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,18 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
+        try {
         context.stopService(intent)
+        } catch (stopEx: Exception) {
+            android.util.Log.e(TAG, "Failed to stopService during fallback", stopEx)
+        }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
+        try {
         context.stopService(intent)
+        } catch (stopEx: Exception) {
+            android.util.Log.e(TAG, "Failed to stopService during fallback", stopEx)
+        }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,18 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
+                try {
                 context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    android.util.Log.e(TAG, "Failed to stopService during fallback", stopEx)
+                }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
+                try {
                 context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    android.util.Log.e(TAG, "Failed to stopService during fallback", stopEx)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
🧪 Regression Guard: Fix cascaded stopService crashes

**What**
Wraps fallback `context.stopService(intent)` calls inside secondary `try-catch` blocks across three foreground services (`HotwordService`, `NodeForegroundService`, `SessionForegroundService`).

**Why**
In Android, when `startService` or `startForegroundService` fails due to background execution limits (`IllegalStateException`) or permission denials (`SecurityException`), directly calling `stopService` in the `catch` block can sometimes trigger another exception (e.g., if the service intent is malformed or the context is in a strict state). Catching these secondary exceptions prevents the application from hard-crashing during an already-failing lifecycle state.

**Validation**
- Built successfully using standard standardDebug variants.
- Ran `./gradlew app:lintStandardDebug` and `./gradlew app:testStandardDebugUnitTest` successfully.

---
*PR created automatically by Jules for task [6816961749189627693](https://jules.google.com/task/6816961749189627693) started by @yuga-hashimoto*