### PR TITLE
🧪 Regression Guard: Fix stopService crash on start failure

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,18 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    Log.e(TAG, "Failed to stopService as well", stopEx)
+                }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    Log.e(TAG, "Failed to stopService as well", stopEx)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,18 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try {
+            context.stopService(intent)
+        } catch (stopEx: Exception) {
+            android.util.Log.e(TAG, "Failed to stopService as well", stopEx)
+        }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try {
+            context.stopService(intent)
+        } catch (stopEx: Exception) {
+            android.util.Log.e(TAG, "Failed to stopService as well", stopEx)
+        }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,18 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    Log.e(TAG, "Failed to stopService as well", stopEx)
+                }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (stopEx: Exception) {
+                    Log.e(TAG, "Failed to stopService as well", stopEx)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
### 💡 What
Wraps fallback `context.stopService(intent)` calls inside `try-catch` blocks in `HotwordService.kt`, `NodeForegroundService.kt`, and `SessionForegroundService.kt`.

### 🎯 Why
When `startService()` or `startForegroundService()` fail due to Android background execution limits (`IllegalStateException`) or permission constraints (`SecurityException`), the system jumps to the catch block. If the subsequent fallback attempt to stop the service (`context.stopService(intent)`) also throws an exception (which is common under the same constraints), it causes an unhandled cascading crash. Catching the exception ensures the app remains stable during error-recovery paths.

### 🧪 Verification
- Unit tests (`./gradlew app:testStandardDebugUnitTest`) pass successfully.
- Modifications were verified manually to correctly encapsulate the `stopService()` calls.

---
*PR created automatically by Jules for task [3103120127939956807](https://jules.google.com/task/3103120127939956807) started by @yuga-hashimoto*