### PR TITLE
🔄 Upstream Parity: keep camera temp files private

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
@@ -111,7 +111,7 @@ class CameraCaptureManager(private val context: Context) {
       provider.unbindAll()
       provider.bindToLifecycle(owner, selector, capture)
 
-      val (bytes, orientation) = capture.takeJpegWithExif(context.mainExecutor())
+      val (bytes, orientation) = capture.takeJpegWithExif(context.mainExecutor(), context.cacheDir)
       val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
         ?: throw IllegalStateException("UNAVAILABLE: failed to decode captured image")
       val rotated = rotateBitmapByExif(decoded, orientation)
@@ -213,7 +213,7 @@ class CameraCaptureManager(private val context: Context) {
       android.util.Log.w("CameraCaptureManager", "clip: warming up camera 1.5s...")
       kotlinx.coroutines.delay(1_500)
 
-      val file = File.createTempFile("openclaw-clip-", ".mp4")
+      val file = File.createTempFile("openclaw-clip-", ".mp4", context.cacheDir)
       val outputOptions = FileOutputOptions.Builder(file).build()
 
       val finalized = kotlinx.coroutines.CompletableDeferred<VideoRecordEvent.Finalize>()
@@ -356,9 +356,9 @@ private suspend fun Context.cameraProvider(): ProcessCameraProvider =
   }
 
 /** Returns (jpegBytes, exifOrientation) so caller can rotate the decoded bitmap. */
-private suspend fun ImageCapture.takeJpegWithExif(executor: Executor): Pair<ByteArray, Int> =
+private suspend fun ImageCapture.takeJpegWithExif(executor: Executor, tempDir: File): Pair<ByteArray, Int> =
   suspendCancellableCoroutine { cont ->
-    val file = File.createTempFile("openclaw-snap-", ".jpg")
+    val file = File.createTempFile("openclaw-snap-", ".jpg", tempDir)
     val options = ImageCapture.OutputFileOptions.Builder(file).build()
     takePicture(
       options,

--- a/app/src/main/java/com/openclaw/assistant/node/ScreenRecordManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/ScreenRecordManager.kt
@@ -93,7 +93,7 @@ class ScreenRecordManager(private val context: Context) {
       val height = metrics.heightPixels
       val densityDpi = metrics.densityDpi
 
-      val file = File.createTempFile("openclaw-screen-", ".mp4")
+      val file = File.createTempFile("openclaw-screen-", ".mp4", context.cacheDir)
       if (includeAudio) ensureMicPermission()
 
       val recorder = createMediaRecorder()


### PR DESCRIPTION
- **Source**: Upstream commit `d525d6486d305482906b974136b8d25395211709`
- **Why**: Fixes Android CodeQL local temp-file disclosure findings. By default, `File.createTempFile` relies on the system default temp directory, which can sometimes lead to permissions issues or inadvertent temp-file disclosure. Explicitly using `context.cacheDir` resolves this security and stability issue.
- **Adaptation**: The exact implementation from upstream was ported directly to `CameraCaptureManager.kt` and `ScreenRecordManager.kt` in this repo using `context.cacheDir`.
- **Excluded upstream behavior**: N/A, exact port.
- **Verification**: Unit tests (`app:testStandardDebugUnitTest`) and lint checks (`app:lintStandardDebug`) pass successfully.

---
*PR created automatically by Jules for task [15479791943929717256](https://jules.google.com/task/15479791943929717256) started by @yuga-hashimoto*