### PR TITLE
🎨 Palette: Improve accessibility of pairing and permission summaries

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2025-10-24 - Dropdown Trigger Accessibility
 **Learning:** Using `Modifier.clickable` without a specific role and label for a row that opens a dropdown causes screen readers to misidentify its function.
 **Action:** When a clickable element opens a dropdown menu, always use `Modifier.clickable(onClickLabel = "...", role = Role.DropdownList)` to ensure proper screen reader announcement.
+
+## 2024-05-08 - Merge Descendants in Jetpack Compose
+**Learning:** In Jetpack Compose, when standard views like `Row` or `Column` group icons and texts, applying `Modifier.semantics(mergeDescendants = true)` correctly coalesces these into a single focusable accessibility element for TalkBack, avoiding disjointed reading. Setting `contentDescription = null` on the decorative icon removes redundant reading.
+**Action:** Always apply `mergeDescendants = true` on the parent container (like `Row` or `Button`) and `contentDescription = null` on the purely decorative internal icon (when accompanying a text label) to prevent redundant or split screen-reader announcements.

--- a/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/SetupGuideScreen.kt
@@ -1087,6 +1087,7 @@ private fun FinalCheckStep(
                 .fillMaxWidth()
                 .background(OnboardingGradientMid.copy(alpha = 0.1f), RoundedCornerShape(8.dp))
                 .border(1.dp, OnboardingGradientMid.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
+                .semantics(mergeDescendants = true) {}
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -1238,6 +1239,7 @@ private fun CommandBlock(command: String) {
         modifier = Modifier
             .fillMaxWidth()
             .background(Color(0xFF0D1117), RoundedCornerShape(8.dp))
+            .semantics(mergeDescendants = true) {}
             .clickable(
                 onClickLabel = stringResource(R.string.pairing_copy_command),
                 role = Role.Button
@@ -1258,7 +1260,7 @@ private fun CommandBlock(command: String) {
         Spacer(modifier = Modifier.width(8.dp))
         Icon(
             imageVector = Icons.Default.ContentCopy,
-            contentDescription = stringResource(R.string.pairing_copy_command),
+            contentDescription = null,
             tint = Color(0xFF58A6FF),
             modifier = Modifier.size(16.dp)
         )


### PR DESCRIPTION
### 💡 What
Improved the accessibility semantics of the `CommandBlock` and `Permission Summary` sections in `SetupGuideScreen.kt` by merging descendants and nullifying decorative icon descriptions. Recorded the learnings in `.jules/palette.md`.

### 🎯 Why
When standard views like `Row` group icons and texts, screen readers like TalkBack often read them disjointedly or redundantly (e.g., announcing the copy action twice). Applying `Modifier.semantics(mergeDescendants = true)` cohesively groups them into a single focusable accessibility element.

### 📸 Before/After
**Before:** Screen reader announces "openclaw devices list", then "Copy command".
**After:** Screen reader announces "openclaw devices list, Copy command" as a single cohesive element, and the redundant icon description is ignored.

### ♿ Accessibility
-   Added `Modifier.semantics(mergeDescendants = true)` to parent containers.
-   Set `contentDescription = null` on the purely decorative internal copy icon (as the parent already provides the `onClickLabel`).

---
*PR created automatically by Jules for task [4660032512049083758](https://jules.google.com/task/4660032512049083758) started by @yuga-hashimoto*