### PR TITLE
🔄 Upstream Parity: use absolute logcat path

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/DebugHandler.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/DebugHandler.kt
@@ -6,6 +6,8 @@ import com.openclaw.assistant.gateway.DeviceIdentityStore
 import com.openclaw.assistant.gateway.GatewaySession
 import kotlinx.serialization.json.JsonPrimitive
 
+private const val LOGCAT_PATH = "/system/bin/logcat"
+
 class DebugHandler(
   private val appContext: Context,
   private val identityStore: DeviceIdentityStore,
@@ -78,7 +80,7 @@ class DebugHandler(
     val logResult = try {
       val tmpFile = java.io.File(appContext.cacheDir, "debug_logs.txt")
       if (tmpFile.exists()) tmpFile.delete()
-      val pb = ProcessBuilder("logcat", "-d", "-t", "200", "--pid=$pid")
+      val pb = ProcessBuilder(LOGCAT_PATH, "-d", "-t", "200", "--pid=$pid")
       pb.redirectOutput(tmpFile)
       pb.redirectErrorStream(true)
       val proc = pb.start()


### PR DESCRIPTION
- Source: Upstream commit `29a34e0a4d` (fix(android): use absolute logcat path)
- Why: Fixes an Android CodeQL relative path command finding in debug log collection. Relying strictly on the absolute path for system binaries avoids execution failures on certain Android OS forks/versions where the PATH environment variable might not be predictably populated.
- Adaptation: Applied the `LOGCAT_PATH` constant and updated the `ProcessBuilder` call in `DebugHandler.kt` to match the upstream logic.
- Excluded upstream behavior: None, this was a straightforward, 1:1 port.
- Verification: Read file to verify changes, ran `./gradlew app:testStandardDebugUnitTest`.

---
*PR created automatically by Jules for task [10197611382316800920](https://jules.google.com/task/10197611382316800920) started by @yuga-hashimoto*