### PR TITLE
🧪 Regression Guard: Fix cascading service shutdown crashes

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,10 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService as well", stopEx) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService as well", stopEx) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,10 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (stopEx: Exception) { android.util.Log.e(TAG, "Failed to stopService as well", stopEx) }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (stopEx: Exception) { android.util.Log.e(TAG, "Failed to stopService as well", stopEx) }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,10 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService as well", stopEx) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService as well", stopEx) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
## 💡 What
Wrapped the fallback `context.stopService(intent)` calls inside `try-catch` blocks within the `startForegroundService` exception handlers of `HotwordService`, `NodeForegroundService`, and `SessionForegroundService`.

## 🎯 Why
When starting a foreground service fails due to Android 14+ background execution limits (`IllegalStateException`) or security constraints (`SecurityException`), the services attempt to gracefully clean up by calling `context.stopService(intent)`. However, if `stopService` itself throws an exception under those same aggressive background restrictions, the app crashes entirely. Wrapping it prevents cascading crashes.

## 🔬 Verification
Run standard assembly, unit tests, and linting to ensure no regressions were introduced.

- [x] `./gradlew app:assembleStandardDebug` 
- [x] `./gradlew app:testStandardDebugUnitTest`
- [x] `./gradlew app:lintStandardDebug`

---
*PR created automatically by Jules for task [8988651738832577573](https://jules.google.com/task/8988651738832577573) started by @yuga-hashimoto*