### PR TITLE
🛡️ Sentinel: Fix insecure temp file creation

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
@@ -111,7 +111,7 @@ class CameraCaptureManager(private val context: Context) {
       provider.unbindAll()
       provider.bindToLifecycle(owner, selector, capture)
 
-      val (bytes, orientation) = capture.takeJpegWithExif(context.mainExecutor())
+      val (bytes, orientation) = capture.takeJpegWithExif(context, context.mainExecutor())
       val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
         ?: throw IllegalStateException("UNAVAILABLE: failed to decode captured image")
       val rotated = rotateBitmapByExif(decoded, orientation)
@@ -213,7 +213,7 @@ class CameraCaptureManager(private val context: Context) {
       android.util.Log.w("CameraCaptureManager", "clip: warming up camera 1.5s...")
       kotlinx.coroutines.delay(1_500)
 
-      val file = File.createTempFile("openclaw-clip-", ".mp4")
+      val file = File.createTempFile("openclaw-clip-", ".mp4", context.cacheDir)
       val outputOptions = FileOutputOptions.Builder(file).build()
 
       val finalized = kotlinx.coroutines.CompletableDeferred<VideoRecordEvent.Finalize>()
@@ -356,9 +356,9 @@ private suspend fun Context.cameraProvider(): ProcessCameraProvider =
   }
 
 /** Returns (jpegBytes, exifOrientation) so caller can rotate the decoded bitmap. */
-private suspend fun ImageCapture.takeJpegWithExif(executor: Executor): Pair<ByteArray, Int> =
+private suspend fun ImageCapture.takeJpegWithExif(context: Context, executor: Executor): Pair<ByteArray, Int> =
   suspendCancellableCoroutine { cont ->
-    val file = File.createTempFile("openclaw-snap-", ".jpg")
+    val file = File.createTempFile("openclaw-snap-", ".jpg", context.cacheDir)
     val options = ImageCapture.OutputFileOptions.Builder(file).build()
     takePicture(
       options,

--- a/app/src/main/java/com/openclaw/assistant/node/ScreenRecordManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/ScreenRecordManager.kt
@@ -93,7 +93,7 @@ class ScreenRecordManager(private val context: Context) {
       val height = metrics.heightPixels
       val densityDpi = metrics.densityDpi
 
-      val file = File.createTempFile("openclaw-screen-", ".mp4")
+      val file = File.createTempFile("openclaw-screen-", ".mp4", context.cacheDir)
       if (includeAudio) ensureMicPermission()
 
       val recorder = createMediaRecorder()


### PR DESCRIPTION
**💡 What**
Explicitly passed `context.cacheDir` to `File.createTempFile()` when saving camera captures, screen recordings, and temporary media files.

**🎯 Why**
Previously, these files were created in the system default temporary directory. Using `context.cacheDir` is a security best practice that resolves CodeQL local temp-file disclosure findings by ensuring sensitive user media is stored securely within the application's private cache partition, preventing potential unauthorized access or symlink attacks.

**🛡️ Security Area**
- Prevented leaked secrets/sensitive data in shared paths
- Addressed insecure temp-file handling

---
*PR created automatically by Jules for task [1864966114638676003](https://jules.google.com/task/1864966114638676003) started by @yuga-hashimoto*