### PR TITLE
🧪 Regression Guard: Fix cascading crashes during service cleanup

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,10 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService as well", stopEx) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService as well", stopEx) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,10 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (stopEx: Exception) { android.util.Log.e(TAG, "Failed to stopService as well", stopEx) }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (stopEx: Exception) { android.util.Log.e(TAG, "Failed to stopService as well", stopEx) }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,10 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService as well", stopEx) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (stopEx: Exception) { Log.e(TAG, "Failed to stopService as well", stopEx) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
**🧪 Regression Guard: Fix cascading crashes during service cleanup**

**What**
Wrapped fallback `context.stopService(intent)` calls inside `try-catch` blocks within the exception handlers of `HotwordService.kt`, `SessionForegroundService.kt`, and `NodeForegroundService.kt`.

**Why**
In recent Android versions, interacting with services from the background can be strict. The app attempted to recover from failed `startForegroundService` (or `startService`) calls by sending a `stopService` request. However, if the OS also rejects the background stop request, it throws another exception, leading to a cascading crash. By catching these secondary exceptions, we prevent the app from unexpectedly terminating while still logging the failure.

**Verification**
- Executed full test suite (`./gradlew app:testStandardDebugUnitTest`), which passed successfully.

---
*PR created automatically by Jules for task [4102847720372877507](https://jules.google.com/task/4102847720372877507) started by @yuga-hashimoto*