### PR TITLE
🛡️ Sentinel: Disable cleartext traffic globally

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,7 +89,7 @@
         android:name="com.openclaw.assistant.OpenClawApplication"
         android:allowBackup="false"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>


### PR DESCRIPTION
This PR addresses the 'insecure transport / cleartext traffic' security priority by globally disabling cleartext (HTTP) network requests and enforcing HTTPS.

**Changes:**
1. Removed `android:usesCleartextTraffic="true"` from `app/src/main/AndroidManifest.xml`.
2. Explicitly set `cleartextTrafficPermitted="false"` in the base configuration of `app/src/main/res/xml/network_security_config.xml`.

**Note:** This security hardening step may impact local hardware connectivity that currently relies on cleartext HTTP/WS. If specific local endpoints require cleartext, they should be explicitly whitelisted in the network security configuration rather than allowing cleartext globally.

---
*PR created automatically by Jules for task [4378834790096375071](https://jules.google.com/task/4378834790096375071) started by @yuga-hashimoto*