### PR TITLE
🎨 Polish: Improve connection loading state UX

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1076,6 +1076,14 @@ fun SystemStatusCard(
                     fontWeight = FontWeight.Bold
                 )
                 Spacer(modifier = Modifier.width(8.dp))
+                if (isConnecting) {
+                    androidx.compose.material3.CircularProgressIndicator(
+                        modifier = Modifier.size(12.dp),
+                        color = contentColor,
+                        strokeWidth = 2.dp
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                }
                 Text(
                     text = statusText,
                     fontSize = 13.sp,


### PR DESCRIPTION
**💡 What:** Added an inline `CircularProgressIndicator` to the `SystemStatusCard` in `MainActivity.kt` that is visible exclusively when the gateway connection is in an active "Connecting" state.

**🎯 Why:** Previously, the connection status relied entirely on text ("Connecting...") and color changes, which lacked an active indication that a background process was ongoing. Adding a subtle spinner improves the loading/retry state feedback and connection status clarity without disrupting the existing design language.

**📸 Before/After:**
- Before: Text simply says "Connecting..." with a static dot.
- After: Text says "Connecting..." alongside an actively spinning loading indicator, providing clear visual reinforcement of the loading state.

---
*PR created automatically by Jules for task [5503882210065059956](https://jules.google.com/task/5503882210065059956) started by @yuga-hashimoto*