### PR TITLE
🎨 Palette: Improve empty state UI in SessionListActivity

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2025-10-24 - Dropdown Trigger Accessibility
 **Learning:** Using `Modifier.clickable` without a specific role and label for a row that opens a dropdown causes screen readers to misidentify its function.
 **Action:** When a clickable element opens a dropdown menu, always use `Modifier.clickable(onClickLabel = "...", role = Role.DropdownList)` to ensure proper screen reader announcement.
+
+## 2024-05-10 - Improved Empty State UI in SessionListActivity
+**Learning:** Adding visual elements (like an appropriately themed icon and better spacing/typography) to empty states significantly improves the perceived quality and user-friendliness of an application, making the interface feel more thoughtful and less stark.
+**Action:** Always look for plain text empty states and consider wrapping them in a `Column` with a descriptive, decorative icon (with `contentDescription = null` for accessibility if accompanied by text) and better alignment.

--- a/app/src/main/java/com/openclaw/assistant/SessionListActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SessionListActivity.kt
@@ -28,6 +28,8 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenu
@@ -206,11 +208,24 @@ fun SessionListScreen(
                     .padding(paddingValues),
                 contentAlignment = Alignment.Center
             ) {
-                Text(
-                    text = stringResource(R.string.no_sessions),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    modifier = Modifier.padding(32.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.Chat,
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp),
+                        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
+                    )
+                    Text(
+                        text = stringResource(R.string.no_sessions),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center
+                    )
+                }
             }
         } else {
             LazyColumn(


### PR DESCRIPTION
💡 **What:** Replaced the plain text empty state in `SessionListActivity` with a more visually appealing `Column` containing a chat icon, centered text, and better spacing.
🎯 **Why:** To make the screen look more polished and provide a friendlier user experience when a user has no active sessions, instead of a stark, unstyled text block.
📸 **Before/After:** Before: Plain text "No conversations yet." After: A semi-transparent primary-colored chat icon with slightly larger, centered text below it.
♿ **Accessibility:** The added decorative icon explicitly sets `contentDescription = null` to prevent redundant screen reader announcements, since the accompanying text already conveys the "no sessions" message.

---
*PR created automatically by Jules for task [11573610812375713412](https://jules.google.com/task/11573610812375713412) started by @yuga-hashimoto*