### PR TITLE
🧪 Regression Guard: Fix service cleanup crashes

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,18 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (e2: Exception) {
+                    Log.e(TAG, "Failed to stopService in IllegalStateException handler", e2)
+                }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (e2: Exception) {
+                    Log.e(TAG, "Failed to stopService in SecurityException handler", e2)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,18 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try {
+            context.stopService(intent)
+        } catch (stopEx: Exception) {
+            android.util.Log.e(TAG, "Failed to stopService in IllegalStateException handler", stopEx)
+        }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try {
+            context.stopService(intent)
+        } catch (stopEx: Exception) {
+            android.util.Log.e(TAG, "Failed to stopService in SecurityException handler", stopEx)
+        }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,18 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (e2: Exception) {
+                    Log.e(TAG, "Failed to stopService in IllegalStateException handler", e2)
+                }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (e2: Exception) {
+                    Log.e(TAG, "Failed to stopService in SecurityException handler", e2)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
**Fix service cleanup crashes by wrapping fallback stopService calls in try-catch**

**Issue:**
When Android 8+ background execution limits or security constraints prevent a service from starting via `startService` or `startForegroundService`, the existing error handlers attempted to gracefully fall back to `stopService(intent)`. However, `stopService` itself can occasionally throw exceptions (such as `SecurityException` for component/permission issues or `IllegalStateException`), leading to secondary application crashes when these fallbacks fail.

**Changes:**
- Modified `HotwordService.kt`, `NodeForegroundService.kt`, and `SessionForegroundService.kt`.
- Wrapped fallback `context.stopService(intent)` calls inside nested `try-catch (e: Exception)` blocks within the existing `IllegalStateException` and `SecurityException` catch handlers.
- Safely consume and log any exceptions thrown during the stop attempt, preventing cascading application crashes.

**Testing:**
- Created a dummy `app/google-services.json` to allow local compilation.
- Executed `./gradlew app:testStandardDebugUnitTest` successfully.
- Code review flagged minor test artifacts (`.kotlin/errors`), which were cleaned up before submission.

---
*PR created automatically by Jules for task [10318138282547861280](https://jules.google.com/task/10318138282547861280) started by @yuga-hashimoto*