### PR TITLE
🎨 Polish: Improve connection status clarity

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/StatusIndicator.kt
@@ -88,10 +88,15 @@ fun StatusIndicator(
                 .background(dotColor, CircleShape)
         )
         if (label != null) {
+            val textColor = when (state) {
+                ConnectionState.Connected -> Color(0xFF4CAF50)
+                ConnectionState.Connecting -> MaterialTheme.colorScheme.onSurfaceVariant
+                ConnectionState.Disconnected -> MaterialTheme.colorScheme.error
+            }
             Text(
                 text = label,
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = textColor,
                 modifier = Modifier.clearAndSetSemantics {}
             )
         }


### PR DESCRIPTION
## 💡 What
Modified `StatusIndicator` text label to dynamically change color depending on the current `ConnectionState`.

## 🎯 Why
Previously, the `StatusIndicator` label text used a static text color (`MaterialTheme.colorScheme.onSurface`) regardless of the connection state, even though the pulsing dot changed color. Applying semantic colors (Green for Connected, surface variant for Connecting, and error red for Disconnected) directly to the label text provides more immediate, clearer visual feedback to the user regarding their connection status, especially when skimming the settings or status overlays.

## 📸 Before/After
**Before:** Text label was always `onSurface` (usually white or black).
**After:** Text label is `Color(0xFF4CAF50)` when connected, `onSurfaceVariant` when connecting, and `error` when disconnected.

## ♿ Accessibility
This improvement reinforces the visual state communicated by the pulsing dot, offering an additional vector of information (text color) for users navigating connection states, adhering closer to WCAG recommendations for avoiding reliance on single visual cues (like just a colored dot) by combining it with semantically colored text.

---
*PR created automatically by Jules for task [4762078492531532447](https://jules.google.com/task/4762078492531532447) started by @yuga-hashimoto*