### PR TITLE
🧪 Regression Guard: Fix background service stop exceptions

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,10 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (se: Exception) { Log.e(TAG, "Failed to stop service", se) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (se: Exception) { Log.e(TAG, "Failed to stop service", se) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,10 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (se: Exception) { android.util.Log.e(TAG, "Failed to stop service", se) }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try { context.stopService(intent) } catch (se: Exception) { android.util.Log.e(TAG, "Failed to stop service", se) }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,10 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (se: Exception) { Log.e(TAG, "Failed to stop service", se) }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try { context.stopService(intent) } catch (se: Exception) { Log.e(TAG, "Failed to stop service", se) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
**Fix background service stop exceptions**

This change addresses a stability issue where calling `context.stopService(intent)` inside exception handlers in Android services could crash the app if the stop service call itself fails. By wrapping the `stopService` calls in a `try-catch` block, we prevent cascading crashes when recovering from failed background service execution limits or security limits.

**Changes made:**
- Wrapped `context.stopService(intent)` calls with `try-catch` inside error handling blocks in:
  - `HotwordService.kt`
  - `NodeForegroundService.kt`
  - `SessionForegroundService.kt`

**Testing:**
- Ran `app:lintStandardDebug` successfully.
- Executed `app:testStandardDebugUnitTest` successfully with dummy `google-services.json` file.

---
*PR created automatically by Jules for task [926834075013692405](https://jules.google.com/task/926834075013692405) started by @yuga-hashimoto*