### PR TITLE
🎨 Polish: Improve button feedback and touch targets

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -781,7 +781,7 @@ fun SpeakingIndicator(onStop: () -> Unit) {
                 fontWeight = androidx.compose.ui.text.font.FontWeight.Medium
             )
             Spacer(modifier = Modifier.width(8.dp))
-            IconButton(onClick = onStop, modifier = Modifier.size(24.dp)) {
+            IconButton(onClick = onStop) {
                 Icon(Icons.Default.Stop, contentDescription = stringResource(R.string.stop_description), tint = MaterialTheme.colorScheme.onErrorContainer)
             }
         }

--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1082,7 +1082,7 @@ fun SystemStatusCard(
                     color = contentColor.copy(alpha = 0.8f),
                     modifier = Modifier.weight(1f)
                 )
-                IconButton(onClick = onOpenSettings, modifier = Modifier.size(24.dp)) {
+                IconButton(onClick = onOpenSettings) {
                     Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.settings_title), tint = contentColor.copy(alpha = 0.6f))
                 }
             }
@@ -1113,6 +1113,12 @@ fun SystemStatusCard(
                         )
                     ) {
                         if (isConnecting) {
+                            androidx.compose.material3.CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                color = Color.White,
+                                strokeWidth = 2.dp
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
                             Text(stringResource(R.string.gateway_connecting))
                         } else {
                             Text(stringResource(R.string.connect))
@@ -1204,7 +1210,7 @@ fun DiagnosticPanel(diagnostic: VoiceDiagnostic, onRefresh: () -> Unit) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                 Text(stringResource(R.string.diagnostic_engines), fontWeight = FontWeight.Medium, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                IconButton(onClick = onRefresh, modifier = Modifier.size(24.dp)) { Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.action_refresh), modifier = Modifier.size(16.dp)) }
+                IconButton(onClick = onRefresh) { Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.action_refresh), modifier = Modifier.size(16.dp)) }
             }
             Spacer(modifier = Modifier.height(8.dp))
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -1229,7 +1235,7 @@ fun PermissionDiagnosticsPanel(allPermissionsStatus: List<PermissionStatusInfo>,
         Column(modifier = Modifier.padding(16.dp)) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                 Text(stringResource(R.string.diagnostic_app_permissions), fontWeight = FontWeight.Medium, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                IconButton(onClick = onRefresh, modifier = Modifier.size(24.dp)) { Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.action_refresh), modifier = Modifier.size(16.dp)) }
+                IconButton(onClick = onRefresh) { Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.action_refresh), modifier = Modifier.size(16.dp)) }
             }
             Spacer(modifier = Modifier.height(8.dp))
             allPermissionsStatus.forEach { perm ->


### PR DESCRIPTION
## 🎨 Polish: Improve button feedback and touch targets

### 💡 What
This PR makes two highly targeted UX improvements:
1.  **Loading State Feedback:** Added a `CircularProgressIndicator` alongside the "Connecting..." text in the main connection button.
2.  **Accessibility Compliance:** Removed hardcoded `Modifier.size(24.dp)` restrictions on several `IconButton` components across `MainActivity` and `ChatActivity`.

### 🎯 Why
*   **Loading State:** Previously, the connection button only changed its text to "Connecting...", which lacked clear, active visual feedback that an operation was in progress. The spinner makes the loading state much more explicit.
*   **Accessibility:** Android accessibility guidelines strongly recommend a minimum touch target size of 48x48dp for interactive elements. By explicitly sizing the `IconButton` to 24dp, the application was violating this guideline, making the buttons harder to reliably tap, especially for users with motor impairments. Removing the modifier allows the `IconButton` to size itself appropriately to meet these standards.

### 📸 Before/After
*   **Before:** Connection button just said "Connecting...". Several icon buttons were exactly 24x24dp.
*   **After:** Connection button shows a white spinner + "Connecting...". Icon buttons now have standard accessible padding while keeping the inner icon at an appropriate visual size.

### ♿ Accessibility
This change directly resolves multiple accessibility touch target violations by allowing standard Compose `IconButton` behavior to enforce the 48dp minimum touch boundary.

### 🔬 Verification
- Tested locally by modifying `MainActivity.kt` and `ChatActivity.kt`.
- Compiled successfully with `./gradlew app:assembleStandardDebug` and ran full unit test suite `app:testStandardDebugUnitTest` with no regressions.
- Code review passed.

---
*PR created automatically by Jules for task [11883682284153437201](https://jules.google.com/task/11883682284153437201) started by @yuga-hashimoto*