### PR TITLE
🔄 Upstream Parity: Keep camera temp files private

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
@@ -111,7 +111,7 @@ class CameraCaptureManager(private val context: Context) {
       provider.unbindAll()
       provider.bindToLifecycle(owner, selector, capture)
 
-      val (bytes, orientation) = capture.takeJpegWithExif(context.mainExecutor())
+      val (bytes, orientation) = capture.takeJpegWithExif(context.mainExecutor(), context.cacheDir)
       val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
         ?: throw IllegalStateException("UNAVAILABLE: failed to decode captured image")
       val rotated = rotateBitmapByExif(decoded, orientation)
@@ -213,7 +213,7 @@ class CameraCaptureManager(private val context: Context) {
       android.util.Log.w("CameraCaptureManager", "clip: warming up camera 1.5s...")
       kotlinx.coroutines.delay(1_500)
 
-      val file = File.createTempFile("openclaw-clip-", ".mp4")
+      val file = File.createTempFile("openclaw-clip-", ".mp4", context.cacheDir)
       val outputOptions = FileOutputOptions.Builder(file).build()
 
       val finalized = kotlinx.coroutines.CompletableDeferred<VideoRecordEvent.Finalize>()
@@ -356,9 +356,9 @@ private suspend fun Context.cameraProvider(): ProcessCameraProvider =
   }
 
 /** Returns (jpegBytes, exifOrientation) so caller can rotate the decoded bitmap. */
-private suspend fun ImageCapture.takeJpegWithExif(executor: Executor): Pair<ByteArray, Int> =
+private suspend fun ImageCapture.takeJpegWithExif(executor: Executor, tempDir: File): Pair<ByteArray, Int> =
   suspendCancellableCoroutine { cont ->
-    val file = File.createTempFile("openclaw-snap-", ".jpg")
+    val file = File.createTempFile("openclaw-snap-", ".jpg", tempDir)
     val options = ImageCapture.OutputFileOptions.Builder(file).build()
     takePicture(
       options,


### PR DESCRIPTION
- **Source:** Upstream commit `d525d6486d` (fix(android): keep camera temp files private).
- **Why:** Resolves a CodeQL local temp-file disclosure finding. Using the default `File.createTempFile` writes to the system's shared temp directory (`java.io.tmpdir`). Passing `context.cacheDir` ensures that the temporary files created during camera capture (.mp4 and .jpg) remain strictly within the app's isolated private cache storage, improving security and preventing potential `IOException` crashes on certain OEM setups.
- **Adaptation:** Directly applied the upstream changes to `app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt` by passing `context.cacheDir` in `File.createTempFile` for both `.mp4` and `.jpg` creation flows, and updated the `takeJpegWithExif` helper signature.
- **Excluded behavior:** None, exactly matched the upstream logic for this localized fix.
- **Verification:** Verified compilation and ran `./gradlew app:testStandardDebugUnitTest`, which succeeded. Code Review assessed the fix as #Correct#.

---
*PR created automatically by Jules for task [17626170818675022355](https://jules.google.com/task/17626170818675022355) started by @yuga-hashimoto*