### PR TITLE
🧪 Regression Guard: Fix cascading crashes on service stop

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/HotwordService.kt
@@ -55,10 +55,18 @@ class HotwordService : Service(), VoskRecognitionListener {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (ex: Exception) {
+                    android.util.Log.e(TAG, "Failed to stopService: ${ex.message}", ex)
+                }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting HotwordService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (ex: Exception) {
+                    android.util.Log.e(TAG, "Failed to stopService: ${ex.message}", ex)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start HotwordService: ${e.message}", e)
             }

--- a/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/NodeForegroundService.kt
@@ -285,10 +285,18 @@ class NodeForegroundService : Service() {
         context.startService(intent)
       } catch (e: IllegalStateException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try {
+            context.stopService(intent)
+        } catch (ex: Exception) {
+            android.util.Log.e(TAG, "Failed to stopService: ${ex.message}", ex)
+        }
       } catch (e: SecurityException) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
-        context.stopService(intent)
+        try {
+            context.stopService(intent)
+        } catch (ex: Exception) {
+            android.util.Log.e(TAG, "Failed to stopService: ${ex.message}", ex)
+        }
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed to send ACTION_STOP via startService, falling back to stopService", e)
         try {

--- a/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
+++ b/app/src/main/java/com/openclaw/assistant/service/SessionForegroundService.kt
@@ -40,10 +40,18 @@ class SessionForegroundService : Service() {
                 }
             } catch (e: IllegalStateException) {
                 Log.e(TAG, "Background execution limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (ex: Exception) {
+                    android.util.Log.e(TAG, "Failed to stopService: ${ex.message}", ex)
+                }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Security limits prevented starting SessionForegroundService: ${e.message}", e)
-                context.stopService(intent)
+                try {
+                    context.stopService(intent)
+                } catch (ex: Exception) {
+                    android.util.Log.e(TAG, "Failed to stopService: ${ex.message}", ex)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start SessionForegroundService: ${e.message}", e)
             }


### PR DESCRIPTION
**Description:**
This PR introduces a defensive fix to prevent cascading service cleanup crashes.

**Context:**
Android imposes strict background execution limits. When a foreground service or standard service fails to start due to these limits (throwing an `IllegalStateException` or `SecurityException`), the app's current error-handling logic catches the exception and attempts a fallback cleanup by calling `context.stopService(intent)`.

**The Bug:**
Depending on the Android version and the exact state of the app/intent, `context.stopService(intent)` itself can throw an exception (e.g., another `SecurityException` or `IllegalArgumentException`). When this happens inside the `catch` block of the original startup exception, the unhandled secondary exception causes the entire app to crash, turning a graceful failure into a hard crash.

**The Fix:**
Wrapped the `context.stopService(intent)` fallback calls inside nested `try-catch (e: Exception)` blocks in `HotwordService`, `NodeForegroundService`, and `SessionForegroundService`. This ensures that if the cleanup call fails, the exception is safely caught and logged, preventing a fatal crash and allowing the app to degrade gracefully.

**Verification:**
* Verified the nested `try-catch` blocks are syntactically correct and use the standard `android.util.Log.e` for logging.
* Ran local builds and unit tests via `./gradlew build` and `./gradlew testStandardDebugUnitTest`, confirming no compilation regressions.

---
*PR created automatically by Jules for task [16455628158932526732](https://jules.google.com/task/16455628158932526732) started by @yuga-hashimoto*