### PR TITLE
🎨 Palette: Fix IconButton touch targets

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/ChatActivity.kt
@@ -781,7 +781,7 @@ fun SpeakingIndicator(onStop: () -> Unit) {
                 fontWeight = androidx.compose.ui.text.font.FontWeight.Medium
             )
             Spacer(modifier = Modifier.width(8.dp))
-            IconButton(onClick = onStop, modifier = Modifier.size(24.dp)) {
+            IconButton(onClick = onStop) {
                 Icon(Icons.Default.Stop, contentDescription = stringResource(R.string.stop_description), tint = MaterialTheme.colorScheme.onErrorContainer)
             }
         }

--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -1082,7 +1082,7 @@ fun SystemStatusCard(
                     color = contentColor.copy(alpha = 0.8f),
                     modifier = Modifier.weight(1f)
                 )
-                IconButton(onClick = onOpenSettings, modifier = Modifier.size(24.dp)) {
+                IconButton(onClick = onOpenSettings) {
                     Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.settings_title), tint = contentColor.copy(alpha = 0.6f))
                 }
             }
@@ -1204,7 +1204,7 @@ fun DiagnosticPanel(diagnostic: VoiceDiagnostic, onRefresh: () -> Unit) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                 Text(stringResource(R.string.diagnostic_engines), fontWeight = FontWeight.Medium, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                IconButton(onClick = onRefresh, modifier = Modifier.size(24.dp)) { Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.action_refresh), modifier = Modifier.size(16.dp)) }
+                IconButton(onClick = onRefresh) { Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.action_refresh), modifier = Modifier.size(16.dp)) }
             }
             Spacer(modifier = Modifier.height(8.dp))
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -1229,7 +1229,7 @@ fun PermissionDiagnosticsPanel(allPermissionsStatus: List<PermissionStatusInfo>,
         Column(modifier = Modifier.padding(16.dp)) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                 Text(stringResource(R.string.diagnostic_app_permissions), fontWeight = FontWeight.Medium, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                IconButton(onClick = onRefresh, modifier = Modifier.size(24.dp)) { Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.action_refresh), modifier = Modifier.size(16.dp)) }
+                IconButton(onClick = onRefresh) { Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.action_refresh), modifier = Modifier.size(16.dp)) }
             }
             Spacer(modifier = Modifier.height(8.dp))
             allPermissionsStatus.forEach { perm ->


### PR DESCRIPTION
**💡 What**
Removed `Modifier.size(24.dp)` from several `IconButton` components across `MainActivity.kt` and `ChatActivity.kt`.

**🎯 Why**
Android and Material Design guidelines stipulate a minimum touch target size of 48x48dp for interactive elements to ensure accessibility for users with varying dexterity levels. Explicitly constraining the size of an `IconButton` (which internally provides padding to meet this target) to 24dp overrides this behavior, making the buttons harder to tap.

**♿ Accessibility**
By removing the explicit size constraint, the `IconButton` components naturally expand to provide the standard, accessible 48x48dp minimum touch target area without altering the visual size of the inner `Icon` (which remains appropriately scaled). This significantly improves the UX for all users, particularly those relying on accessible touch targets.

---
*PR created automatically by Jules for task [3506056329231000616](https://jules.google.com/task/3506056329231000616) started by @yuga-hashimoto*