### PR TITLE
🛡️ Sentinel: Secure temporary file creation

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/CameraCaptureManager.kt
@@ -111,7 +111,7 @@ class CameraCaptureManager(private val context: Context) {
       provider.unbindAll()
       provider.bindToLifecycle(owner, selector, capture)
 
-      val (bytes, orientation) = capture.takeJpegWithExif(context.mainExecutor())
+      val (bytes, orientation) = capture.takeJpegWithExif(context.mainExecutor(), context.cacheDir)
       val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
         ?: throw IllegalStateException("UNAVAILABLE: failed to decode captured image")
       val rotated = rotateBitmapByExif(decoded, orientation)
@@ -213,7 +213,7 @@ class CameraCaptureManager(private val context: Context) {
       android.util.Log.w("CameraCaptureManager", "clip: warming up camera 1.5s...")
       kotlinx.coroutines.delay(1_500)
 
-      val file = File.createTempFile("openclaw-clip-", ".mp4")
+      val file = File.createTempFile("openclaw-clip-", ".mp4", context.cacheDir)
       val outputOptions = FileOutputOptions.Builder(file).build()
 
       val finalized = kotlinx.coroutines.CompletableDeferred<VideoRecordEvent.Finalize>()
@@ -356,9 +356,9 @@ private suspend fun Context.cameraProvider(): ProcessCameraProvider =
   }
 
 /** Returns (jpegBytes, exifOrientation) so caller can rotate the decoded bitmap. */
-private suspend fun ImageCapture.takeJpegWithExif(executor: Executor): Pair<ByteArray, Int> =
+private suspend fun ImageCapture.takeJpegWithExif(executor: Executor, cacheDir: java.io.File): Pair<ByteArray, Int> =
   suspendCancellableCoroutine { cont ->
-    val file = File.createTempFile("openclaw-snap-", ".jpg")
+    val file = File.createTempFile("openclaw-snap-", ".jpg", cacheDir)
     val options = ImageCapture.OutputFileOptions.Builder(file).build()
     takePicture(
       options,

--- a/app/src/main/java/com/openclaw/assistant/node/ScreenRecordManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/node/ScreenRecordManager.kt
@@ -93,7 +93,7 @@ class ScreenRecordManager(private val context: Context) {
       val height = metrics.heightPixels
       val densityDpi = metrics.densityDpi
 
-      val file = File.createTempFile("openclaw-screen-", ".mp4")
+      val file = File.createTempFile("openclaw-screen-", ".mp4", context.cacheDir)
       if (includeAudio) ensureMicPermission()
 
       val recorder = createMediaRecorder()


### PR DESCRIPTION
🛡️ Sentinel: Secure temporary file creation

**What:**
Updated temporary file creation calls in `ScreenRecordManager` and `CameraCaptureManager` to explicitly use the application's secure cache directory (`context.cacheDir`) instead of the system default temporary directory.

**Why:**
Relying on the system default temporary directory for sensitive temporary files (like camera frames, screen recordings, or audio recordings) can expose the data to local file disclosure vulnerabilities. Explicitly writing these temporary files to the app's internal cache directory ensures they are properly sandboxed and protected by standard application filesystem permissions.

**Security Impact:**
- Fixes potential local temp file disclosure.
- Increases data isolation for sensitive capture media.

**Verification:**
- Ran `./gradlew app:assembleStandardDebug` to confirm no build breakages.
- Ran `./gradlew app:testStandardDebugUnitTest` to ensure tests continue to pass.

---
*PR created automatically by Jules for task [8423327602111708361](https://jules.google.com/task/8423327602111708361) started by @yuga-hashimoto*