### PR TITLE
🎨 Palette: Improve accessibility of pairing card

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
+++ b/app/src/main/java/com/openclaw/assistant/ui/components/PairingRequiredCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -55,7 +56,10 @@ fun PairingRequiredCard(deviceId: String, displayName: String = "") {
         shape = RoundedCornerShape(12.dp)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.semantics(mergeDescendants = true) {}
+            ) {
                 Icon(Icons.Default.Devices, contentDescription = null, tint = MaterialTheme.colorScheme.error)
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,15 +1,11 @@
-**Source**
-Upstream openclaw/openclaw commit `8790c54635`
+💡 What
+Added `Modifier.semantics(mergeDescendants = true)` to the `Row` holding the title and the `Devices` icon in `PairingRequiredCard.kt`.
 
-**Why**
-Gateway setup URLs or explicit manual endpoint inputs shouldn't enforce default ports blindly when displaying the connection UI or verifying connection security, particularly ensuring custom or cleartext implicit ports accurately reflect their configuration.
+🎯 Why
+To prevent screen readers like TalkBack from redundantly announcing both the decorative icon and the title separately. Encapsulating them into a single focus bounds ensures a cohesive reading.
 
-**Adaptation**
-Ported the modified `displayUrl` string building logic from `GatewayConfigResolver.kt` (upstream) to `GatewayConfigUtils.kt` (this repo). Added tests covering various edge cases (bare domains vs default ports).
-Modified test parameters in `GatewayConfigUtilsTest` to use local `192.168.1.100` instead of `gateway.example` for cleartext, as `NetworkUtils.isUrlSecure` in this repo explicitly forbids public domains for WS/HTTP connections.
+📸 Before/After
+No visual changes.
 
-**Excluded upstream behavior**
-N/A. This was a direct logic porting.
-
-**Verification**
-Locally verified by running `./gradlew app:testStandardDebugUnitTest app:lintStandardDebug` ensuring all updated assertions succeed and no memory or regressions are flagged.
+♿ Accessibility
+Improves screen reader behavior by eliminating redundant and fragmented navigation announcements for the pairing required card header.


### PR DESCRIPTION
💡 What
Added `Modifier.semantics(mergeDescendants = true)` to the `Row` holding the title and the `Devices` icon in `PairingRequiredCard.kt`.

🎯 Why
To prevent screen readers like TalkBack from redundantly announcing both the decorative icon and the title separately. Encapsulating them into a single focus bounds ensures a cohesive reading.

📸 Before/After
No visual changes.

♿ Accessibility
Improves screen reader behavior by eliminating redundant and fragmented navigation announcements for the pairing required card header.

---
*PR created automatically by Jules for task [2257461732623023490](https://jules.google.com/task/2257461732623023490) started by @yuga-hashimoto*