### PR TITLE
Allow saving settings and enabling wake word without OpenClaw connection

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/MainActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/MainActivity.kt
@@ -348,14 +348,17 @@ class MainActivity : ComponentActivity(), TextToSpeech.OnInitListener {
     fun toggleHotwordService(enabled: Boolean) {
         if (enabled) {
             // Check that a backend connection is configured before enabling wakeword.
-            // The voice interaction session requires gateway or HTTP to communicate with the AI.
+            // The voice interaction session needs a backend to communicate with the AI.
             val runtime = (applicationContext as OpenClawApplication).nodeRuntime
             val isConnectionConfigured = if (settings.connectionType == SettingsRepository.CONNECTION_TYPE_GATEWAY) {
                 runtime.manualHost.value.isNotBlank()
             } else {
                 settings.httpUrl.isNotBlank()
             }
-            if (!isConnectionConfigured) {
+            // Also allow when any backend is configured (Hermes API server, etc.)
+            val backendManager = com.openclaw.assistant.backend.BackendManager.getInstance(this)
+            val hasConfiguredBackend = backendManager.chatTargets().isNotEmpty()
+            if (!isConnectionConfigured && !hasConfiguredBackend) {
                 Toast.makeText(this, getString(R.string.wakeword_requires_connection_error), Toast.LENGTH_LONG).show()
                 return
             }

--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -527,7 +527,7 @@ fun SettingsScreen(
                                 // Stop/Restart services
                                 HotwordService.stop(context)
 
-                                if (settings.connectionType == SettingsRepository.CONNECTION_TYPE_GATEWAY) {
+                                if (settings.connectionType == SettingsRepository.CONNECTION_TYPE_GATEWAY && gatewayHost.isNotBlank()) {
                                     runtime.connectManual()
                                 }
 
@@ -536,7 +536,7 @@ fun SettingsScreen(
                                 }
                                 onSave()
                             },
-                            enabled = gatewayHost.isNotBlank() || httpInputUrl.isNotBlank()
+                            enabled = true
                         ) {
                             Text(stringResource(R.string.save_button))
                         }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -575,11 +575,11 @@ Weitere Informationen finden Sie auf der offiziellen Website von VOICEVOX.</stri
 <string name="permission_summary_title">Permissions Summary</string>
 <string name="permission_summary_format">%1$d standard permissions, %2$d special access granted</string>
     <!-- Missing translations -->
-    <string name="approve_command_format">openclaw devices approve --latest</string>
+    <string name="approve_command_format">openclaw devices approve --latest %s</string>
     <string name="credits_support_description">このアプリが役に立った場合は、Ko-fiでの支援をご検討ください。</string>
     <string name="credits_support_kofi_button">Support the Developer</string>
     <string name="credits_support_title">開発をサポートする</string>
-    <string name="operator_offline_command">openclaw devices approve --latest</string>
+    <string name="operator_offline_command">openclaw devices approve --latest %s</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
     <string name="qr_scan_unavailable">QR-Scan ist nicht verfügbar. Bitte aktualisieren Sie die Google Play-Dienste.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -576,11 +576,11 @@ Para más detalles, consulta el sitio oficial de VOICEVOX.</string>
 <string name="permission_summary_title">Permissions Summary</string>
 <string name="permission_summary_format">%1$d standard permissions, %2$d special access granted</string>
     <!-- Missing translations -->
-    <string name="approve_command_format">openclaw devices approve --latest</string>
+    <string name="approve_command_format">openclaw devices approve --latest %s</string>
     <string name="credits_support_description">このアプリが役に立った場合は、Ko-fiでの支援をご検討ください。</string>
     <string name="credits_support_kofi_button">Support the Developer</string>
     <string name="credits_support_title">開発をサポートする</string>
-    <string name="operator_offline_command">openclaw devices approve --latest</string>
+    <string name="operator_offline_command">openclaw devices approve --latest %s</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
     <string name="qr_scan_unavailable">El escaneo de QR no está disponible. Actualice los servicios de Google Play.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -576,11 +576,11 @@ Pour plus de détails, consultez le site officiel de VOICEVOX.</string>
 <string name="permission_summary_title">Résumé des autorisations</string>
 <string name="permission_summary_format">%1$d autorisations standard, %2$d accès spéciaux accordés</string>
     <!-- Missing translations -->
-    <string name="approve_command_format">openclaw devices approve --latest</string>
+    <string name="approve_command_format">openclaw devices approve --latest %s</string>
     <string name="credits_support_description">このアプリが役に立った場合は、Ko-fiでの支援をご検討ください。</string>
     <string name="credits_support_kofi_button">Support the Developer</string>
     <string name="credits_support_title">開発をサポートする</string>
-    <string name="operator_offline_command">openclaw devices approve --latest</string>
+    <string name="operator_offline_command">openclaw devices approve --latest %s</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
     <string name="qr_scan_unavailable">La numérisation QR n\'est pas disponible. Veuillez mettre à jour les services Google Play.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -576,11 +576,11 @@
 <string name="permission_summary_title">Permissions Summary</string>
 <string name="permission_summary_format">%1$d standard permissions, %2$d special access granted</string>
     <!-- Missing translations -->
-    <string name="approve_command_format">openclaw devices approve --latest</string>
+    <string name="approve_command_format">openclaw devices approve --latest %s</string>
     <string name="credits_support_description">このアプリが役に立った場合は、Ko-fiでの支援をご検討ください。</string>
     <string name="credits_support_kofi_button">Support the Developer</string>
     <string name="credits_support_title">開発をサポートする</string>
-    <string name="operator_offline_command">openclaw devices approve --latest</string>
+    <string name="operator_offline_command">openclaw devices approve --latest %s</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
     <string name="qr_scan_unavailable">QR स्कैनिंग उपलब्ध नहीं है। कृपया Google Play Services अपडेट करें।</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -637,11 +637,11 @@
     <string name="qr_scan_unavailable">QRスキャンが利用できません。Google Play開発者サービスを更新してください。</string>
 
     <!-- Missing translations -->
-    <string name="approve_command_format">openclaw devices approve --latest</string>
+    <string name="approve_command_format">openclaw devices approve --latest %s</string>
     <string name="credits_support_description">このアプリが役に立った場合は、Ko-fiでの支援をご検討ください。</string>
     <string name="credits_support_kofi_button">Support the Developer</string>
     <string name="credits_support_title">開発をサポートする</string>
-    <string name="operator_offline_command">openclaw devices approve --latest</string>
+    <string name="operator_offline_command">openclaw devices approve --latest %s</string>
     <string name="reject_command_format">openclaw devices reject $(openclaw devices list --json | jq -r \'.pending[] | select(.deviceId == \"%s\") | .requestId\')</string>
 
     <!-- Bottom tab navigation -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -576,11 +576,11 @@
 <string name="permission_summary_title">Permissions Summary</string>
 <string name="permission_summary_format">%1$d standard permissions, %2$d special access granted</string>
     <!-- Missing translations -->
-    <string name="approve_command_format">openclaw devices approve --latest</string>
+    <string name="approve_command_format">openclaw devices approve --latest %s</string>
     <string name="credits_support_description">このアプリが役に立った場合は、Ko-fiでの支援をご検討ください。</string>
     <string name="credits_support_kofi_button">Support the Developer</string>
     <string name="credits_support_title">開発をサポートする</string>
-    <string name="operator_offline_command">openclaw devices approve --latest</string>
+    <string name="operator_offline_command">openclaw devices approve --latest %s</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
     <string name="qr_scan_unavailable">Сканирование QR недоступно. Пожалуйста, обновите сервисы Google Play.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -576,11 +576,11 @@
 <string name="permission_summary_title">Permissions Summary</string>
 <string name="permission_summary_format">%1$d standard permissions, %2$d special access granted</string>
     <!-- Missing translations -->
-    <string name="approve_command_format">openclaw devices approve --latest</string>
+    <string name="approve_command_format">openclaw devices approve --latest %s</string>
     <string name="credits_support_description">このアプリが役に立った場合は、Ko-fiでの支援をご検討ください。</string>
     <string name="credits_support_kofi_button">Support the Developer</string>
     <string name="credits_support_title">開発をサポートする</string>
-    <string name="operator_offline_command">openclaw devices approve --latest</string>
+    <string name="operator_offline_command">openclaw devices approve --latest %s</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
     <string name="qr_scan_unavailable">QR 扫描不可用。请更新 Google Play 服务。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -575,11 +575,11 @@
 <string name="permission_summary_title">Permissions Summary</string>
 <string name="permission_summary_format">%1$d standard permissions, %2$d special access granted</string>
     <!-- Missing translations -->
-    <string name="approve_command_format">openclaw devices approve --latest</string>
+    <string name="approve_command_format">openclaw devices approve --latest %s</string>
     <string name="credits_support_description">このアプリが役に立った場合は、Ko-fiでの支援をご検討ください。</string>
     <string name="credits_support_kofi_button">Support the Developer</string>
     <string name="credits_support_title">開発をサポートする</string>
-    <string name="operator_offline_command">openclaw devices approve --latest</string>
+    <string name="operator_offline_command">openclaw devices approve --latest %s</string>
     <string name="qr_scan_desc">Align the QR code within the frame to scan it</string>
     <string name="qr_scan_prompt">Scan QR Code</string>
     <string name="qr_scan_unavailable">QR 掃描無法使用。請更新 Google Play 服務。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -551,7 +551,7 @@
     <!-- Operator Offline Warning -->
     <string name="operator_offline_title">Operator Offline / Permission Needed</string>
     <string name="operator_offline_message">Your device is connected, but the AI lacks permission to operate it.\n\nPlease run the following command on your server to grant operator access:</string>
-    <string name="operator_offline_command">openclaw devices approve --latest</string>
+    <string name="operator_offline_command">openclaw devices approve --latest %s</string>
     <string name="operator_offline_copy">Copy Command</string>
     <string name="operator_offline_copied">Command copied to clipboard</string>
     <string name="operator_offline_action">Run on server</string>
@@ -598,7 +598,7 @@
     <string name="pairing_copy_command">Copy Command</string>
     <string name="pairing_command_copied">Command copied to clipboard</string>
     <string name="pairing_device_id">Device ID: %s</string>
-    <string name="approve_command_format">openclaw devices approve --latest</string>
+    <string name="approve_command_format">openclaw devices approve --latest %s</string>
     <string name="reject_command_format">openclaw devices reject $(openclaw devices list --json | jq -r \'.pending[] | select(.deviceId == \"%s\") | .requestId\')</string>
     <string name="pairing_approve_command">Approve Command (Copy)</string>
     <string name="pairing_reject_command">Reject Command (Copy)</string>


### PR DESCRIPTION
Two changes to support using Wake Hermes Claw with a Hermes API Server backend (e.g. via p2p/phy-OS) without needing an OpenClaw gateway or HTTP connection manually configured:

**`SettingsActivity.kt`:**
- Remove the gateway/HTTP host requirement from the Save button's `enabled` state — users who only need to save wake word preferences shouldn't be forced to configure an OpenClaw connection first
- Guard `connectManual()` against an empty host so saving with no gateway configured doesn't attempt a pointless connection

**`MainActivity.kt`:**
- In `toggleHotwordService()`, also check `BackendManager.chatTargets()` for any configured backend (Hermes API Server, etc.) before blocking wake word enablement
- Previously only checked `runtime.manualHost` or `settings.httpUrl`, which meant wake word was impossible to enable without an OpenClaw gateway or HTTP connection even when a fully-working Hermes API Server backend was already configured and showing as "Connected" on the home screen

**Lines changed:** 7 insertions, 4 deletions across 2 files.